### PR TITLE
fix(orders): close status races, guard repayment, decrement stock

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -34,15 +34,15 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| L1 | **TOCTOU race on service status transitions** | `order-admin.service.ts` (lines 650-698, 764-818) | Status is checked outside the transaction, then written inside. Two workers can claim the same item simultaneously. Fix: `UPDATE ... WHERE status = 'queued' RETURNING *`. |
-| L2 | **Re-paying a paid order is allowed** | `order-admin.service.ts:592-638` | `updateOrderPayment` doesn't guard against double-pay or paying a cancelled order. |
-| L3 | **All-cancelled orders become "completed"** | `order-admin.service.ts:156-200` | `recalculateOrderStatus` treats all-terminal as "completed" even when every service was cancelled. The `cancelled` order status is never set. |
+| L1 ✅ | **TOCTOU race on service status transitions** | `order-admin.service.ts` (lines 650-698, 764-818) | Status is checked outside the transaction, then written inside. Two workers can claim the same item simultaneously. Fix: `UPDATE ... WHERE status = 'queued' RETURNING *`. |
+| L2 ✅ | **Re-paying a paid order is allowed** | `order-admin.service.ts:592-638` | `updateOrderPayment` doesn't guard against double-pay or paying a cancelled order. |
+| L3 ✅ | **All-cancelled orders become "completed"** | `order-admin.service.ts:156-200` | `recalculateOrderStatus` treats all-terminal as "completed" even when every service was cancelled. The `cancelled` order status is never set. |
 
 ### MEDIUM
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| L4 | **Products have stock constraints but no decrement on order** | `schema.ts` (stock check constraint) vs `order.service.ts` | The schema enforces `stock >= 0` but `insertOrderProducts` never decrements stock. |
+| L4 ✅ | **Products have stock constraints but no decrement on order** | `schema.ts` (stock check constraint) vs `order.service.ts` | The schema enforces `stock >= 0` but `insertOrderProducts` never decrements stock. |
 | L5 | **Public tracking fetches full data before validating phone** | `routes/public/orders.ts:28-103` | Unauthenticated users can probe order existence. Phone check should be in the DB query. |
 | L6 | **`buildWhereClause` and `buildRelationalWhere` can diverge** | `order.repository.ts:52-238` | Two parallel filter implementations that must stay in sync. Search already uses slightly different patterns. |
 | L7 | **Default sort order is oldest-first** | `order.schema.ts:33-34` | `sort_by: "id"`, `sort_order: "asc"` — most admin UIs expect newest-first. |

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -178,7 +178,9 @@ async function recalculateOrderStatus(
   } else if (
     services.every((item) => isTerminalOrderServiceStatus(item.status))
   ) {
-    nextStatus = "completed";
+    nextStatus = services.every((item) => item.status === "cancelled")
+      ? "cancelled"
+      : "completed";
   } else if (
     services
       .filter((item) => !isTerminalOrderServiceStatus(item.status))
@@ -607,11 +609,23 @@ export async function updateOrderPayment({
       total: true,
       discount: true,
       refunded_amount: true,
+      payment_status: true,
+      status: true,
     },
   });
 
   if (!order) {
     return null;
+  }
+
+  if (order.payment_status === "paid") {
+    throw new BadRequestException("Order has already been paid");
+  }
+
+  if (order.status === "cancelled") {
+    throw new BadRequestException(
+      "Cannot collect payment on a cancelled order"
+    );
   }
 
   const netDue =
@@ -647,26 +661,39 @@ export async function startOrderServiceWork({
   serviceId: number;
   user: JWTPayload;
 }) {
-  const orderService = await getOrderServiceOrThrow(orderId, serviceId);
+  const orderService = await db.transaction(async (tx) => {
+    const [locked] = await tx
+      .select()
+      .from(ordersServicesTable)
+      .where(
+        and(
+          eq(ordersServicesTable.id, serviceId),
+          eq(ordersServicesTable.order_id, orderId)
+        )
+      )
+      .for("update");
 
-  if (orderService.status !== "queued") {
-    throw new BadRequestException(
-      `Service ${serviceId} cannot be started from status ${orderService.status}`
-    );
-  }
+    if (!locked) {
+      throw new BadRequestException("Order service not found for this order");
+    }
 
-  if (
-    orderService.handler_id !== null &&
-    orderService.handler_id !== undefined &&
-    orderService.handler_id !== user.id
-  ) {
-    throw new ForbiddenException(
-      "This item is already assigned to another worker"
-    );
-  }
+    if (locked.status !== "queued") {
+      throw new BadRequestException(
+        `Service ${serviceId} cannot be started from status ${locked.status}`
+      );
+    }
 
-  await db.transaction(async (tx) => {
-    if (orderService.handler_id !== user.id) {
+    if (
+      locked.handler_id !== null &&
+      locked.handler_id !== undefined &&
+      locked.handler_id !== user.id
+    ) {
+      throw new ForbiddenException(
+        "This item is already assigned to another worker"
+      );
+    }
+
+    if (locked.handler_id !== user.id) {
       await tx
         .update(ordersServicesTable)
         .set({ handler_id: user.id, status: "processing" })
@@ -674,7 +701,7 @@ export async function startOrderServiceWork({
 
       await tx.insert(orderServiceHandlerLogsTable).values({
         order_service_id: serviceId,
-        from_handler_id: orderService.handler_id,
+        from_handler_id: locked.handler_id,
         to_handler_id: user.id,
         changed_by: user.id,
         note: "Started from queue",
@@ -688,13 +715,15 @@ export async function startOrderServiceWork({
 
     await tx.insert(orderServiceStatusLogsTable).values({
       order_service_id: serviceId,
-      from_status: orderService.status,
+      from_status: locked.status,
       to_status: "processing",
       changed_by: user.id,
       note: "Started from queue",
     });
 
     await recalculateOrderStatus(tx, orderId, user.id);
+
+    return locked;
   });
 
   return {
@@ -761,25 +790,38 @@ export async function updateOrderServiceStatus({
     );
   }
 
-  const orderService = await getOrderServiceOrThrow(orderId, serviceId);
-
-  const allowedStatuses = ORDER_STATUS_TRANSITIONS[orderService.status];
-  if (!allowedStatuses.includes(body.status)) {
-    throw new BadRequestException(
-      `Invalid status transition from ${orderService.status} to ${body.status}`
-    );
-  }
-
   if (body.status === "picked_up") {
     await ensurePickupPhotoExists(serviceId);
   }
 
-  const isClaimTransition =
-    orderService.status === "queued" && body.status === "processing";
-  const needsHandlerAssign =
-    isClaimTransition && orderService.handler_id !== user.id;
+  const fromStatus = await db.transaction(async (tx) => {
+    const [locked] = await tx
+      .select()
+      .from(ordersServicesTable)
+      .where(
+        and(
+          eq(ordersServicesTable.id, serviceId),
+          eq(ordersServicesTable.order_id, orderId)
+        )
+      )
+      .for("update");
 
-  await db.transaction(async (tx) => {
+    if (!locked) {
+      throw new BadRequestException("Order service not found for this order");
+    }
+
+    const allowedStatuses = ORDER_STATUS_TRANSITIONS[locked.status];
+    if (!allowedStatuses.includes(body.status)) {
+      throw new BadRequestException(
+        `Invalid status transition from ${locked.status} to ${body.status}`
+      );
+    }
+
+    const isClaimTransition =
+      locked.status === "queued" && body.status === "processing";
+    const needsHandlerAssign =
+      isClaimTransition && locked.handler_id !== user.id;
+
     if (needsHandlerAssign) {
       await tx
         .update(ordersServicesTable)
@@ -788,7 +830,7 @@ export async function updateOrderServiceStatus({
 
       await tx.insert(orderServiceHandlerLogsTable).values({
         order_service_id: serviceId,
-        from_handler_id: orderService.handler_id,
+        from_handler_id: locked.handler_id,
         to_handler_id: user.id,
         changed_by: user.id,
         note: "Auto-assigned on status update",
@@ -802,17 +844,19 @@ export async function updateOrderServiceStatus({
 
     await tx.insert(orderServiceStatusLogsTable).values({
       order_service_id: serviceId,
-      from_status: orderService.status,
+      from_status: locked.status,
       to_status: body.status,
       changed_by: user.id,
       note: body.note,
     });
 
     await recalculateOrderStatus(tx, orderId, user.id);
+
+    return locked.status;
   });
 
   return {
-    from_status: orderService.status,
+    from_status: fromStatus,
     order_service_id: serviceId,
     to_status: body.status,
   };

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -20,7 +20,10 @@ import {
   type GetOrdersQuery,
   normalizeOrderListQuery,
 } from "@/modules/orders/order.schema";
-import { findProducts } from "@/modules/products/product.repository";
+import {
+  decrementProductStock,
+  findProducts,
+} from "@/modules/products/product.repository";
 import { findServices } from "@/modules/services/service.repository";
 import { findUserById } from "@/modules/users/user.repository";
 import type { POSTOrderSchema } from "@/schema";
@@ -265,6 +268,16 @@ export async function createOrder(
       created_by: userId,
       updated_by: userId,
     });
+
+    for (const item of products) {
+      const [decremented] = await decrementProductStock(tx, item.id, item.qty);
+      if (!decremented) {
+        const product = productMap.get(item.id);
+        throw new BadRequestException(
+          `Insufficient stock for product ${product?.name ?? item.id}`
+        );
+      }
+    }
 
     const [serviceSubtotal, productSubtotal] = await Promise.all([
       insertOrderServices(

--- a/packages/server/src/modules/products/product.repository.ts
+++ b/packages/server/src/modules/products/product.repository.ts
@@ -1,7 +1,20 @@
 import type { InferInsertModel } from "drizzle-orm";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { productsTable } from "@/db/schema";
+import type { OrderTx } from "@/modules/orders/order.repository";
+
+export function decrementProductStock(
+  tx: OrderTx,
+  productId: number,
+  qty: number
+) {
+  return tx
+    .update(productsTable)
+    .set({ stock: sql`${productsTable.stock} - ${qty}` })
+    .where(and(eq(productsTable.id, productId), gte(productsTable.stock, qty)))
+    .returning({ id: productsTable.id });
+}
 
 export function findProducts(ids: number[]) {
   return db.query.productsTable.findMany({


### PR DESCRIPTION
## Summary

PR2 of the audit follow-up — logic correctness fixes from `AUDIT.md`.

- **L1 — TOCTOU races on service status transitions.** `startOrderServiceWork` and `updateOrderServiceStatus` now lock the `orders_services` row with `SELECT ... FOR UPDATE` inside the transaction before validating and writing. Two workers can no longer claim the same queued item concurrently.
- **L2 — Re-paying or paying a cancelled order.** `updateOrderPayment` now rejects orders whose `payment_status` is already `paid` or whose `status` is `cancelled`.
- **L3 — All-cancelled orders wrongly marked completed.** `recalculateOrderStatus` now sets the order to `cancelled` when every service line is cancelled; mixed terminal states still resolve to `completed`.
- **L4 — Product stock never decremented.** `createOrder` now calls a new `decrementProductStock` repository helper inside the same transaction that creates the order. The update is conditional on `stock >= qty`, so insufficient stock throws `BadRequestException` and rolls back the whole order.

## Test plan

- [ ] Two concurrent `startOrderServiceWork` calls against the same queued service — only one succeeds.
- [ ] Concurrent `updateOrderServiceStatus` transitions on the same row — only one wins, the other surfaces the invalid-transition error.
- [ ] `updateOrderPayment` on a paid order returns 400.
- [ ] `updateOrderPayment` on a cancelled order returns 400.
- [ ] Cancel every service on an order → order status flips to `cancelled`, `completed_at` stays null.
- [ ] Create an order with `qty > stock` → entire transaction rolls back, stock unchanged, no order row persisted.
- [ ] Create an order with sufficient stock → `products.stock` decremented by the correct amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)