### PR TITLE
fix(web): harden caches, cut re-renders, use semantic UI states

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -74,11 +74,11 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| W2 | **`ordersQueryOptions` and `ordersPageQueryOptions` share the same queryKey** | `query-options.ts:93-103` | Different response shapes with same cache key — whichever runs first poisons the cache. |
-| W3 | **8 individual `useWatch` calls** in `TransactionsCheckout` | `transactions-checkout.tsx:87-125` | Consolidate into one `useWatch({ name: [...] })` to reduce re-renders. |
+| W2 ✅ | **`ordersQueryOptions` and `ordersPageQueryOptions` share the same queryKey** | `query-options.ts:93-103` | Different response shapes with same cache key — whichever runs first poisons the cache. |
+| W3 ✅ | **8 individual `useWatch` calls** in `TransactionsCheckout` | `transactions-checkout.tsx:87-125` | Consolidate into one `useWatch({ name: [...] })` to reduce re-renders. |
 | W4 | **Infinite scroll observer torn down on every fetch** | `worker.index.tsx:198-221` | Observer recreated on `isFetchingNextPage` change. Should be stable. |
-| W5 | **`submit` handler recreated every render, re-binds controller** | `use-transactions-page.ts:276-319` | Needs `useCallback`. |
-| W6 | **No `staleTime` on any query** | `query-options.ts` (all entries) | Reference data (stores, categories, services) refetched on every mount. |
+| W5 ✅ | **`submit` handler recreated every render, re-binds controller** | `use-transactions-page.ts:276-319` | Needs `useCallback`. |
+| W6 ✅ | **No `staleTime` on any query** | `query-options.ts` (all entries) | Reference data (stores, categories, services) refetched on every mount. |
 
 ---
 
@@ -88,19 +88,19 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| U1 | **Loading/error states are bare `<p>` text** | `orders.$orderId.tsx:458-469`, `queue-service-detail.tsx:308-324` | No skeleton, no layout wrapper. `<Skeleton>` component exists but isn't used. |
+| U1 ✅ | **Loading/error states are bare `<p>` text** | `orders.$orderId.tsx:458-469`, `queue-service-detail.tsx:308-324` | No skeleton, no layout wrapper. `<Skeleton>` component exists but isn't used. |
 | U2 | **Hooks called before early returns in `AdminOrderDetailPage`** | `orders.$orderId.tsx:324-453` | All mutations registered with `id = NaN` before guard checks. |
-| U3 | **`PickupRadar` uses hardcoded `slate-*` colors** | `pickup-radar.tsx` (entire file) | Won't respond to dark mode. Rest of app uses semantic tokens. |
-| U4 | **User edit form pre-fills password with `"placeholder1"`** | `users.tsx:165-166` | Security smell and misleading UX. Server will receive this string if user doesn't change it. |
+| U3 ✅ | **`PickupRadar` uses hardcoded `slate-*` colors** | `pickup-radar.tsx` (entire file) | Won't respond to dark mode. Rest of app uses semantic tokens. |
+| U4 ✅ | **User edit form pre-fills password with `"placeholder1"`** | `users.tsx:165-166` | Security smell and misleading UX. Server will receive this string if user doesn't change it. |
 | U5 | **No 401 interceptor — expired/invalid tokens aren't cleared** | `lib/auth.ts`, `auth-store.ts` | User with stale token passes `requireAuth` then every API call silently fails. |
 
 ### MEDIUM
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| U6 | **`ORDER_STATUS_TRANSITIONS` duplicated in two files** | `orders.$orderId.tsx:82-106`, `queue-service-detail.tsx:51-67` | Must be changed in two places. Should import from server package or shared constant. |
+| U6 ✅ | **`ORDER_STATUS_TRANSITIONS` duplicated in two files** | `orders.$orderId.tsx:82-106`, `queue-service-detail.tsx:51-67` | Must be changed in two places. Should import from server package or shared constant. |
 | U7 | **No empty state explaining missing store assignment** | `orders.index.tsx:169-172` | Non-admin with no store sees "No data found" with no explanation. |
-| U8 | **`campaigns.tsx` columns not in `useMemo`** | `campaigns.tsx:262-331` | Recreated on every render, triggering full table reconciliation. |
+| U8 ✅ | **`campaigns.tsx` columns not in `useMemo`** | `campaigns.tsx:262-331` | Recreated on every render, triggering full table reconciliation. |
 
 ---
 
@@ -112,7 +112,7 @@
 |---|-------|------|--------|
 | SM1 | **`transactionsPageController` is a module-level mutable singleton** | `transactions-store.ts:89-107` | Not React-owned. Breaks on Strict Mode double-mount, fast refresh, or multiple instances. |
 | SM2 | **Server-fetched data duplicated into Zustand via effects** | `transactions-store.ts:48-66`, `use-transactions-page.ts:321-352` | TanStack Query manages cache, but Zustand holds a derived snapshot. Components should read from Query directly. |
-| SM3 | **`updateUserStores` called outside `useMutation`** | `users.tsx:129-132, 148-151` | Errors silently swallowed. No toast on failure. Cache invalidated even on error. |
+| SM3 ✅ | **`updateUserStores` called outside `useMutation`** | `users.tsx:129-132, 148-151` | Errors silently swallowed. No toast on failure. Cache invalidated even on error. |
 
 ### MEDIUM
 

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -3,6 +3,11 @@ import parsePhoneNumberFromString, {
 } from "libphonenumber-js";
 import z from "zod";
 import { orderPaymentStatusEnum } from "@/db/schema";
+
+import { ORDER_STATUS_TRANSITIONS as _ORDER_STATUS_TRANSITIONS } from "@/modules/orders/order-admin.schema";
+
+export const ORDER_STATUS_TRANSITIONS = _ORDER_STATUS_TRANSITIONS;
+
 import {
   currencySchema,
   isActiveSchema,

--- a/packages/web/src/features/orders/components/pickup-radar.tsx
+++ b/packages/web/src/features/orders/components/pickup-radar.tsx
@@ -16,7 +16,7 @@ export function PickupRadar({ orders }: PickupRadarProps) {
 
 	if (readyOrders.length === 0) {
 		return (
-			<p className="py-12 text-center text-sm text-slate-400">
+			<p className="py-12 text-center text-sm text-muted-foreground">
 				No pickups right now.
 			</p>
 		);
@@ -44,11 +44,11 @@ function RadarSection({
 }) {
 	return (
 		<div className="grid gap-2">
-			<div className="flex items-center gap-2 border-b border-slate-200 pb-2">
-				<p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-slate-400">
+			<div className="flex items-center gap-2 border-b border-border pb-2">
+				<p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-muted-foreground">
 					{label}
 				</p>
-				<span className="inline-flex h-4 min-w-4 items-center justify-center bg-slate-900 px-1 text-[10px] font-semibold tabular-nums text-white">
+				<span className="inline-flex h-4 min-w-4 items-center justify-center bg-foreground px-1 text-[10px] font-semibold tabular-nums text-background">
 					{count}
 				</span>
 			</div>
@@ -66,28 +66,28 @@ function RadarRow({ order }: { order: Order }) {
 		<Link
 			to="/orders/$orderId"
 			params={{ orderId: String(order.id) }}
-			className="group grid grid-cols-[1fr_auto] items-center gap-3 border border-transparent px-2 py-2.5 transition-colors hover:border-slate-200 hover:bg-slate-50"
+			className="group grid grid-cols-[1fr_auto] items-center gap-3 border border-transparent px-2 py-2.5 transition-colors hover:border-border hover:bg-muted/50"
 		>
 			<div className="grid gap-1 overflow-hidden">
 				<div className="flex items-center gap-2">
-					<p className="truncate font-mono text-sm font-medium text-slate-950">
+					<p className="truncate font-mono text-sm font-medium text-foreground">
 						{order.code}
 					</p>
 					<Badge variant={getOrderStatusBadgeVariant(order.status)}>
 						{formatOrderStatus(order.status)}
 					</Badge>
 				</div>
-				<div className="flex items-center gap-3 text-xs text-slate-500">
+				<div className="flex items-center gap-3 text-xs text-muted-foreground">
 					<span>{order.customer_name}</span>
-					<span className="text-slate-300">/</span>
+					<span className="text-border">/</span>
 					<span>{order.store_name}</span>
 				</div>
 			</div>
 			<div className="flex items-center gap-3">
-				<p className="font-mono text-xs text-slate-600">
+				<p className="font-mono text-xs text-muted-foreground">
 					{formatIDRCurrency(String(order.total ?? 0))}
 				</p>
-				<ArrowRightIcon className="size-3.5 text-slate-300 transition-colors group-hover:text-slate-700" />
+				<ArrowRightIcon className="size-3.5 text-muted-foreground transition-colors group-hover:text-foreground" />
 			</div>
 		</Link>
 	);

--- a/packages/web/src/features/orders/components/queue-service-detail.tsx
+++ b/packages/web/src/features/orders/components/queue-service-detail.tsx
@@ -1,3 +1,4 @@
+import { ORDER_STATUS_TRANSITIONS } from "@fresclean/api/schema";
 import {
 	ArrowLeftIcon,
 	CameraIcon,
@@ -25,6 +26,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { HoldToConfirmButton } from "@/features/orders/components/hold-to-confirm-button";
 import { OrderPhotoGallery } from "@/features/orders/components/order-photo-gallery";
@@ -48,22 +50,48 @@ import {
 import { cn } from "@/lib/utils";
 import { getCurrentUser } from "@/stores/auth-store";
 
-const ORDER_STATUS_TRANSITIONS: Record<
-	UpdateOrderServiceStatusPayload["status"],
-	UpdateOrderServiceStatusPayload["status"][]
-> = {
-	queued: ["processing", "cancelled"],
-	processing: ["quality_check", "cancelled"],
-	quality_check: ["processing", "ready_for_pickup", "cancelled"],
-	ready_for_pickup: ["picked_up", "refunded", "cancelled"],
-	picked_up: [],
-	refunded: [],
-	cancelled: [],
-};
-
 const WORKER_BLOCKED_QUEUE_STATUSES = new Set<
 	UpdateOrderServiceStatusPayload["status"]
 >(["cancelled", "refunded"]);
+
+function QueueServiceDetailSkeleton() {
+	return (
+		<div className="grid gap-5">
+			<div className="flex items-center gap-3">
+				<Skeleton className="size-9" />
+				<Skeleton className="h-8 w-48" />
+			</div>
+			<Skeleton className="h-12 w-full" />
+			<div className="grid gap-3">
+				<Skeleton className="h-5 w-40" />
+				<Skeleton className="h-24 w-full" />
+				<Skeleton className="h-24 w-full" />
+			</div>
+		</div>
+	);
+}
+
+function QueueServiceDetailMessage({
+	description,
+	title,
+	tone,
+}: {
+	description: string;
+	title: string;
+	tone: "error" | "muted";
+}) {
+	return (
+		<div
+			className={cn(
+				"grid gap-1 border border-border/70 bg-muted/30 p-6 text-sm",
+				tone === "error" && "border-destructive/40 bg-destructive/5",
+			)}
+		>
+			<p className="font-medium">{title}</p>
+			<p className="text-muted-foreground">{description}</p>
+		</div>
+	);
+}
 
 type QueueServiceDetailProps = {
 	orderId: number;
@@ -306,21 +334,31 @@ export function QueueServiceDetail({
 	});
 
 	if (detailQuery.isPending) {
-		return <p>Loading queue item...</p>;
+		return <QueueServiceDetailSkeleton />;
 	}
 
 	if (detailQuery.isError) {
 		return (
-			<p>
-				{detailQuery.error instanceof Error
-					? detailQuery.error.message
-					: "Failed to load queue item."}
-			</p>
+			<QueueServiceDetailMessage
+				tone="error"
+				title="Failed to load queue item"
+				description={
+					detailQuery.error instanceof Error
+						? detailQuery.error.message
+						: "Please try again in a moment."
+				}
+			/>
 		);
 	}
 
 	if (!(detail && selectedService)) {
-		return <p>Queue item not found.</p>;
+		return (
+			<QueueServiceDetailMessage
+				tone="muted"
+				title="Queue item not found"
+				description="It may have been removed or reassigned."
+			/>
+		);
 	}
 
 	const isHandledByCurrentUser = selectedService.handler_id === currentUser?.id;

--- a/packages/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/packages/web/src/features/transactions/components/transactions-checkout.tsx
@@ -83,46 +83,28 @@ export function TransactionsCheckout() {
 	} = useTransactionsPageStore();
 
 	const form = useFormContext<TransactionDraftValues>();
-	const selectedCustomerId =
-		useWatch({
-			control: form.control,
-			name: "selectedCustomerId",
-		}) ?? "";
-	const selectedCampaignId =
-		useWatch({
-			control: form.control,
-			name: "selectedCampaignId",
-		}) ?? "";
-	const selectedPaymentMethodId =
-		useWatch({
-			control: form.control,
-			name: "selectedPaymentMethodId",
-		}) ?? "";
-	const paymentStatus =
-		useWatch({
-			control: form.control,
-			name: "paymentStatus",
-		}) ?? "unpaid";
-	const manualDiscount =
-		useWatch({
-			control: form.control,
-			name: "manualDiscount",
-		}) ?? "";
-	const selectedStoreId =
-		useWatch({
-			control: form.control,
-			name: "selectedStoreId",
-		}) ?? "";
-	const productCart =
-		useWatch({
-			control: form.control,
-			name: "productCart",
-		}) ?? [];
-	const serviceCart =
-		useWatch({
-			control: form.control,
-			name: "serviceCart",
-		}) ?? [];
+	const [
+		selectedCustomerId = "",
+		selectedCampaignId = "",
+		selectedPaymentMethodId = "",
+		paymentStatus = "unpaid",
+		manualDiscount = "",
+		selectedStoreId = "",
+		productCart = [],
+		serviceCart = [],
+	] = useWatch({
+		control: form.control,
+		name: [
+			"selectedCustomerId",
+			"selectedCampaignId",
+			"selectedPaymentMethodId",
+			"paymentStatus",
+			"manualDiscount",
+			"selectedStoreId",
+			"productCart",
+			"serviceCart",
+		],
+	});
 
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),

--- a/packages/web/src/features/transactions/hooks/use-transactions-page.ts
+++ b/packages/web/src/features/transactions/hooks/use-transactions-page.ts
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -263,7 +263,7 @@ export function useTransactionsPageBootstrap() {
 		mutationFn: createOrder,
 	});
 
-	const resetCart = () => {
+	const resetCart = useCallback(() => {
 		const selectedStore = form.getValues("selectedStoreId");
 
 		useTransactionsPageStore.getState().setSubmitError("");
@@ -271,40 +271,50 @@ export function useTransactionsPageBootstrap() {
 			...defaultDraftValues,
 			selectedStoreId: selectedStore,
 		});
-	};
+	}, [form]);
 
-	const submit = form.handleSubmit(async (values) => {
-		useTransactionsPageStore.getState().setSubmitError("");
+	const onValidSubmit = useCallback(
+		async (values: TransactionDraftValues) => {
+			useTransactionsPageStore.getState().setSubmitError("");
 
-		try {
-			const created = await createMutation.mutateAsync(
-				toTransactionPayload(values),
-			);
+			try {
+				const created = await createMutation.mutateAsync(
+					toTransactionPayload(values),
+				);
 
-			await handleCreatedOrderSuccess({
-				created,
-				queryClient,
-				onFallbackNavigate: () => {
-					resetCart();
-					void navigate({ to: "/orders", search: { page: 1 } });
-				},
-				onOrderDetailNavigate: (orderId) => {
-					resetCart();
-					void navigate({
-						to: "/orders/$orderId",
-						params: { orderId: String(orderId) },
-					});
-				},
-			});
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : "Failed to create transaction";
-			useTransactionsPageStore.getState().setSubmitError(message);
-			toast.error("Unable to create transaction", {
-				description: message,
-			});
-		}
-	});
+				await handleCreatedOrderSuccess({
+					created,
+					queryClient,
+					onFallbackNavigate: () => {
+						resetCart();
+						void navigate({ to: "/orders", search: { page: 1 } });
+					},
+					onOrderDetailNavigate: (orderId) => {
+						resetCart();
+						void navigate({
+							to: "/orders/$orderId",
+							params: { orderId: String(orderId) },
+						});
+					},
+				});
+			} catch (error) {
+				const message =
+					error instanceof Error
+						? error.message
+						: "Failed to create transaction";
+				useTransactionsPageStore.getState().setSubmitError(message);
+				toast.error("Unable to create transaction", {
+					description: message,
+				});
+			}
+		},
+		[createMutation, navigate, queryClient, resetCart],
+	);
+
+	const submit = useMemo(
+		() => form.handleSubmit(onValidSubmit),
+		[form, onValidSubmit],
+	);
 
 	useEffect(() => {
 		bindTransactionsPageController({

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -280,6 +280,8 @@ export const queryKeys = {
 	orderDetail: (id: number) => ["order-detail", id] as const,
 	campaigns: (query?: FetchCampaignsQuery) =>
 		["campaigns", query ?? {}] as const,
+	campaignsList: (query?: FetchCampaignsQuery) =>
+		["campaigns-list", query ?? {}] as const,
 	campaignDetail: (id: number) => ["campaign-detail", id] as const,
 	orderServiceLookup: (itemCode: string) =>
 		["order-service-lookup", itemCode] as const,

--- a/packages/web/src/lib/query-options.ts
+++ b/packages/web/src/lib/query-options.ts
@@ -8,21 +8,20 @@ import {
 	fetchCampaignsPage,
 	fetchCategories,
 	fetchCurrentUserDetail,
-	fetchCustomers,
 	fetchCustomersPage,
 	fetchDashboardCounts,
 	fetchMyOrderServices,
 	fetchOrderDetail,
-	fetchOrders,
 	fetchOrdersPage,
 	fetchPaymentMethods,
 	fetchProducts,
 	fetchServices,
 	fetchStores,
-	fetchUsers,
 	fetchUsersPage,
 	queryKeys,
 } from "@/lib/api";
+
+const REFERENCE_DATA_STALE_TIME = 5 * 60 * 1000;
 
 export const dashboardQueryOptions = () =>
 	queryOptions({
@@ -30,22 +29,10 @@ export const dashboardQueryOptions = () =>
 		queryFn: fetchDashboardCounts,
 	});
 
-export const customersQueryOptions = () =>
-	queryOptions({
-		queryKey: queryKeys.customers(),
-		queryFn: fetchCustomers,
-	});
-
 export const customersPageQueryOptions = (query?: FetchCustomersQuery) =>
 	queryOptions({
 		queryKey: queryKeys.customers(query),
 		queryFn: () => fetchCustomersPage(query),
-	});
-
-export const usersQueryOptions = () =>
-	queryOptions({
-		queryKey: queryKeys.users(),
-		queryFn: fetchUsers,
 	});
 
 export const usersPageQueryOptions = (query?: FetchUsersQuery) =>
@@ -64,36 +51,35 @@ export const storesQueryOptions = () =>
 	queryOptions({
 		queryKey: queryKeys.stores,
 		queryFn: fetchStores,
+		staleTime: REFERENCE_DATA_STALE_TIME,
 	});
 
 export const categoriesQueryOptions = () =>
 	queryOptions({
 		queryKey: queryKeys.categories,
 		queryFn: fetchCategories,
+		staleTime: REFERENCE_DATA_STALE_TIME,
 	});
 
 export const servicesQueryOptions = () =>
 	queryOptions({
 		queryKey: queryKeys.services,
 		queryFn: fetchServices,
+		staleTime: REFERENCE_DATA_STALE_TIME,
 	});
 
 export const productsQueryOptions = () =>
 	queryOptions({
 		queryKey: queryKeys.products,
 		queryFn: fetchProducts,
+		staleTime: REFERENCE_DATA_STALE_TIME,
 	});
 
 export const paymentMethodsQueryOptions = () =>
 	queryOptions({
 		queryKey: queryKeys.paymentMethods,
 		queryFn: fetchPaymentMethods,
-	});
-
-export const ordersQueryOptions = (query?: FetchOrdersQuery) =>
-	queryOptions({
-		queryKey: queryKeys.orders(query),
-		queryFn: () => fetchOrders(query),
+		staleTime: REFERENCE_DATA_STALE_TIME,
 	});
 
 export const ordersPageQueryOptions = (query?: FetchOrdersQuery) =>
@@ -110,7 +96,7 @@ export const orderDetailQueryOptions = (id: number) =>
 
 export const campaignsQueryOptions = (query?: FetchCampaignsQuery) =>
 	queryOptions({
-		queryKey: queryKeys.campaigns(query),
+		queryKey: queryKeys.campaignsList(query),
 		queryFn: () => fetchCampaigns(query),
 	});
 

--- a/packages/web/src/routes/_admin/campaigns.tsx
+++ b/packages/web/src/routes/_admin/campaigns.tsx
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
 import { z } from "zod";
 import { DataTable } from "@/components/data-table";
 import { PageHeader } from "@/components/page-header";
@@ -226,109 +227,115 @@ function CampaignsPage() {
 		});
 	};
 
-	const handleOpenEditSheet = (campaign: Campaign) => {
-		openSheet({
-			title: "Edit Campaign",
-			content: (
-				<CampaignForm
-					defaultValues={{
-						code: campaign.code,
-						name: campaign.name,
-						discount_type: campaign.discount_type,
-						discount_value: String(campaign.discount_value),
-						min_order_total: String(campaign.min_order_total),
-						max_discount: campaign.max_discount
-							? String(campaign.max_discount)
-							: "",
-						starts_at: toDateTimeLocal(campaign.starts_at),
-						ends_at: toDateTimeLocal(campaign.ends_at),
-						is_active: campaign.is_active,
-						store_ids: campaign.stores.map((item) => item.store_id),
-					}}
-					isEditing
-					onReset={closeSheet}
-					stores={stores}
-					handleOnSubmit={async (payload) => {
-						await updateMutation.mutateAsync({
-							id: campaign.id,
-							payload,
-						});
-					}}
-				/>
-			),
-		});
-	};
-
-	const columns: ColumnDef<Campaign>[] = [
-		{ accessorKey: "code", header: "Code" },
-		{ accessorKey: "name", header: "Name" },
-		{
-			id: "discount",
-			header: "Discount",
-			cell: ({ row }) => formatCampaignDiscount(row.original),
-		},
-		{
-			accessorKey: "min_order_total",
-			header: "Min Order",
-			cell: ({ row }) =>
-				formatIDRCurrency(String(row.original.min_order_total)),
-		},
-		{
-			accessorKey: "max_discount",
-			header: "Max Discount",
-			cell: ({ row }) =>
-				row.original.max_discount
-					? formatIDRCurrency(String(row.original.max_discount))
-					: "-",
-		},
-		{
-			id: "stores",
-			header: "Stores",
-			cell: ({ row }) => {
-				if (row.original.stores.length === 0) {
-					return "All Stores";
-				}
-
-				return row.original.stores
-					.map((item) => item.store?.code ?? String(item.store_id))
-					.join(", ");
-			},
-		},
-		{
-			id: "status",
-			header: "Status",
-			cell: ({ row }) => (
-				<Badge variant={row.original.is_active ? "success" : "danger"}>
-					{row.original.is_active ? "Active" : "Inactive"}
-				</Badge>
-			),
-		},
-		{
-			id: "actions",
-			header: "Actions",
-			cell: ({ row }) => (
-				<div className="flex gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={!isAdmin}
-						onClick={() => handleOpenEditSheet(row.original)}
-						icon={<PencilSimpleLineIcon className="size-4" />}
-					>
-						Edit
-					</Button>
-					<DeleteCampaignButton
-						campaign={row.original}
-						disabled={!isAdmin}
-						isPending={deleteMutation.isPending}
-						onConfirm={async (campaignId) => {
-							await deleteMutation.mutateAsync(campaignId);
+	const handleOpenEditSheet = useCallback(
+		(campaign: Campaign) => {
+			openSheet({
+				title: "Edit Campaign",
+				content: (
+					<CampaignForm
+						defaultValues={{
+							code: campaign.code,
+							name: campaign.name,
+							discount_type: campaign.discount_type,
+							discount_value: String(campaign.discount_value),
+							min_order_total: String(campaign.min_order_total),
+							max_discount: campaign.max_discount
+								? String(campaign.max_discount)
+								: "",
+							starts_at: toDateTimeLocal(campaign.starts_at),
+							ends_at: toDateTimeLocal(campaign.ends_at),
+							is_active: campaign.is_active,
+							store_ids: campaign.stores.map((item) => item.store_id),
+						}}
+						isEditing
+						onReset={closeSheet}
+						stores={stores}
+						handleOnSubmit={async (payload) => {
+							await updateMutation.mutateAsync({
+								id: campaign.id,
+								payload,
+							});
 						}}
 					/>
-				</div>
-			),
+				),
+			});
 		},
-	];
+		[closeSheet, openSheet, stores, updateMutation],
+	);
+
+	const columns = useMemo<ColumnDef<Campaign>[]>(
+		() => [
+			{ accessorKey: "code", header: "Code" },
+			{ accessorKey: "name", header: "Name" },
+			{
+				id: "discount",
+				header: "Discount",
+				cell: ({ row }) => formatCampaignDiscount(row.original),
+			},
+			{
+				accessorKey: "min_order_total",
+				header: "Min Order",
+				cell: ({ row }) =>
+					formatIDRCurrency(String(row.original.min_order_total)),
+			},
+			{
+				accessorKey: "max_discount",
+				header: "Max Discount",
+				cell: ({ row }) =>
+					row.original.max_discount
+						? formatIDRCurrency(String(row.original.max_discount))
+						: "-",
+			},
+			{
+				id: "stores",
+				header: "Stores",
+				cell: ({ row }) => {
+					if (row.original.stores.length === 0) {
+						return "All Stores";
+					}
+
+					return row.original.stores
+						.map((item) => item.store?.code ?? String(item.store_id))
+						.join(", ");
+				},
+			},
+			{
+				id: "status",
+				header: "Status",
+				cell: ({ row }) => (
+					<Badge variant={row.original.is_active ? "success" : "danger"}>
+						{row.original.is_active ? "Active" : "Inactive"}
+					</Badge>
+				),
+			},
+			{
+				id: "actions",
+				header: "Actions",
+				cell: ({ row }) => (
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={!isAdmin}
+							onClick={() => handleOpenEditSheet(row.original)}
+							icon={<PencilSimpleLineIcon className="size-4" />}
+						>
+							Edit
+						</Button>
+						<DeleteCampaignButton
+							campaign={row.original}
+							disabled={!isAdmin}
+							isPending={deleteMutation.isPending}
+							onConfirm={async (campaignId) => {
+								await deleteMutation.mutateAsync(campaignId);
+							}}
+						/>
+					</div>
+				),
+			},
+		],
+		[deleteMutation, handleOpenEditSheet, isAdmin],
+	);
 
 	return (
 		<>

--- a/packages/web/src/routes/_admin/orders.$orderId.tsx
+++ b/packages/web/src/routes/_admin/orders.$orderId.tsx
@@ -1,3 +1,4 @@
+import { ORDER_STATUS_TRANSITIONS } from "@fresclean/api/schema";
 import {
 	type UseMutationResult,
 	useMutation,
@@ -22,6 +23,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { OrderFulfillmentOverview } from "@/features/orders/components/order-fulfillment-overview";
 import { OrderIntakePhotoCard } from "@/features/orders/components/order-intake-photo-card";
@@ -79,19 +81,6 @@ export const Route = createFileRoute("/_admin/orders/$orderId")({
 	component: OrderDetailPage,
 });
 
-const ORDER_STATUS_TRANSITIONS: Record<
-	UpdateOrderServiceStatusPayload["status"],
-	UpdateOrderServiceStatusPayload["status"][]
-> = {
-	queued: ["processing", "cancelled"],
-	processing: ["quality_check", "cancelled"],
-	quality_check: ["processing", "ready_for_pickup", "cancelled"],
-	ready_for_pickup: ["picked_up", "refunded", "cancelled"],
-	picked_up: [],
-	refunded: [],
-	cancelled: [],
-};
-
 const STATUS_ACTION_LABELS: Record<
 	UpdateOrderServiceStatusPayload["status"],
 	string
@@ -106,6 +95,50 @@ const STATUS_ACTION_LABELS: Record<
 };
 
 const REFUND_REASONS = ["damaged", "cannot_process", "lost", "other"] as const;
+
+function OrderDetailSkeleton() {
+	return (
+		<div className="grid gap-6">
+			<div className="flex items-center justify-between gap-3">
+				<Skeleton className="h-8 w-64" />
+				<Skeleton className="h-9 w-32" />
+			</div>
+			<div className="grid gap-4 md:grid-cols-[2fr_1fr]">
+				<div className="grid gap-4">
+					<Skeleton className="h-40 w-full" />
+					<Skeleton className="h-64 w-full" />
+				</div>
+				<div className="grid gap-4">
+					<Skeleton className="h-32 w-full" />
+					<Skeleton className="h-48 w-full" />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function OrderDetailMessage({
+	description,
+	title,
+	tone,
+}: {
+	description: string;
+	title: string;
+	tone: "error" | "muted";
+}) {
+	return (
+		<div
+			className={
+				tone === "error"
+					? "grid gap-1 border border-destructive/40 bg-destructive/5 p-6 text-sm"
+					: "grid gap-1 border border-border/70 bg-muted/30 p-6 text-sm"
+			}
+		>
+			<p className="font-medium">{title}</p>
+			<p className="text-muted-foreground">{description}</p>
+		</div>
+	);
+}
 
 function ServiceStatusUpdateButton({
 	orderId,
@@ -452,25 +485,41 @@ function AdminOrderDetailPage() {
 	});
 
 	if (!isValidOrderId) {
-		return <p>Invalid order ID.</p>;
+		return (
+			<OrderDetailMessage
+				tone="error"
+				title="Invalid order ID"
+				description="The URL does not point to a valid order."
+			/>
+		);
 	}
 
 	if (detailQuery.isPending) {
-		return <p>Loading order…</p>;
+		return <OrderDetailSkeleton />;
 	}
 
 	if (detailQuery.isError) {
 		return (
-			<p>
-				{detailQuery.error instanceof Error
-					? detailQuery.error.message
-					: "Failed to load order."}
-			</p>
+			<OrderDetailMessage
+				tone="error"
+				title="Failed to load order"
+				description={
+					detailQuery.error instanceof Error
+						? detailQuery.error.message
+						: "Please try again in a moment."
+				}
+			/>
 		);
 	}
 
 	if (!detailQuery.data) {
-		return <p>Order not found.</p>;
+		return (
+			<OrderDetailMessage
+				tone="muted"
+				title="Order not found"
+				description="It may have been deleted or you may not have access."
+			/>
+		);
 	}
 
 	const detail = detailQuery.data;

--- a/packages/web/src/routes/_admin/users.tsx
+++ b/packages/web/src/routes/_admin/users.tsx
@@ -1,4 +1,4 @@
-import { POSTUserSchema } from "@fresclean/api/schema";
+import { PUTUserSchema } from "@fresclean/api/schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PencilSimpleLineIcon, PlusIcon } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -49,8 +49,25 @@ export const Route = createFileRoute("/_admin/users")({
 	component: UsersPage,
 });
 
-const userFormSchema = POSTUserSchema.extend({
+const userFormSchema = PUTUserSchema.extend({
+	password: z.string().trim(),
+	confirm_password: z.string().trim(),
 	store_ids: z.array(z.number().int()),
+}).superRefine((data, ctx) => {
+	if (data.password.length > 0 && data.password.length < 8) {
+		ctx.addIssue({
+			code: "custom",
+			message: "Minimum 8 characters",
+			path: ["password"],
+		});
+	}
+	if (data.password !== data.confirm_password) {
+		ctx.addIssue({
+			code: "custom",
+			message: "Password does not match",
+			path: ["confirm_password"],
+		});
+	}
 });
 
 const defaultForm: UserFormState = {
@@ -111,7 +128,16 @@ function UsersPage() {
 		}) => updateUser(id, payload),
 	});
 
-	const isSubmitting = createMutation.isPending || updateMutation.isPending;
+	const updateStoresMutation = useMutation({
+		mutationKey: ["update-user-stores"],
+		mutationFn: ({ id, store_ids }: { id: number; store_ids: number[] }) =>
+			updateUserStores(id, { store_ids }),
+	});
+
+	const isSubmitting =
+		createMutation.isPending ||
+		updateMutation.isPending ||
+		updateStoresMutation.isPending;
 
 	const handleSubmit: SubmitHandler<UserFormState> = useCallback(
 		async (values) => {
@@ -126,11 +152,17 @@ function UsersPage() {
 					id: editingUser.id,
 					payload,
 				});
-				await updateUserStores(editingUser.id, {
+				await updateStoresMutation.mutateAsync({
+					id: editingUser.id,
 					store_ids: values.store_ids,
 				});
 				await queryClient.invalidateQueries({ queryKey: ["users"] });
 				resetForm();
+				return;
+			}
+
+			if (values.password.length < 8) {
+				form.setError("password", { message: "Minimum 8 characters" });
 				return;
 			}
 
@@ -147,7 +179,8 @@ function UsersPage() {
 			const createdUserId = (createdUser as { data?: { id?: number } }).data
 				?.id;
 			if (createdUserId && values.store_ids.length > 0) {
-				await updateUserStores(createdUserId, {
+				await updateStoresMutation.mutateAsync({
+					id: createdUserId,
 					store_ids: values.store_ids,
 				});
 			}
@@ -155,7 +188,15 @@ function UsersPage() {
 			await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
 			resetForm();
 		},
-		[createMutation, editingUser, queryClient, resetForm, updateMutation],
+		[
+			createMutation,
+			editingUser,
+			form,
+			queryClient,
+			resetForm,
+			updateMutation,
+			updateStoresMutation,
+		],
 	);
 
 	const handleEdit = useCallback(
@@ -164,8 +205,8 @@ function UsersPage() {
 			form.reset({
 				username: user.username,
 				name: user.name,
-				password: "placeholder1",
-				confirm_password: "placeholder1",
+				password: "",
+				confirm_password: "",
 				role: user.role,
 				is_active: user.is_active,
 				store_ids: user.userStores.map((item) => item.store_id),


### PR DESCRIPTION
## Summary

Merged PR3 (web perf/state) and PR4 (UX cleanup) follow-up to `AUDIT.md`.

### Performance / state
- **W2 — cache key collision.** Added a separate `campaignsList` key for `campaignsQueryOptions` so the list fetcher no longer collides with `campaignsPageQueryOptions`. Removed the unused `customersQueryOptions`/`usersQueryOptions`/`ordersQueryOptions` that had the same issue.
- **W6 — no `staleTime` on reference data.** Added a 5-minute `staleTime` to stores/categories/services/products/paymentMethods so they stop refetching on every mount.
- **W3 — 8 `useWatch` calls in `TransactionsCheckout`.** Consolidated into a single tuple-style watch.
- **W5 — submit handler recreated every render.** Memoized via `useCallback` + `useMemo(form.handleSubmit, ...)` so the transactions controller no longer rebinds every render.
- **SM3 — `updateUserStores` called outside `useMutation`.** Wrapped in a dedicated `useMutation` so errors surface via the global toast handler and `isSubmitting` reflects it.

### UX
- **U1 — bare `<p>Loading...</p>` / error text.** Replaced loading and error branches in `OrderDetailPage` and `QueueServiceDetail` with `Skeleton`-based layouts and message panels.
- **U3 — PickupRadar hardcoded slate colors.** Swapped for semantic tokens (`muted-foreground`, `border`, `foreground`) so the component responds to dark mode.
- **U4 — edit-user form pre-filled with `"placeholder1"`.** Form schema now allows empty passwords in edit mode; create mode still enforces min length via a manual check. The placeholder is gone.
- **U6 — `ORDER_STATUS_TRANSITIONS` duplicated.** Re-exported from `@fresclean/api/schema` and imported from both `orders.\$orderId.tsx` and `queue-service-detail.tsx`.
- **U8 — campaigns table columns not memoized.** Wrapped in `useMemo`, stabilized `handleOpenEditSheet` with `useCallback`.

## Test plan

- [ ] Navigate to `/campaigns` then `/transactions`, confirm campaigns list on transactions still loads correctly (separate cache key).
- [ ] Open `/transactions`, type into cart fields — re-renders only fire once per change.
- [ ] Create an order from `/transactions`, confirm success flow still navigates correctly.
- [ ] On `/users`, edit an existing user without touching password, confirm save works and no placeholder is submitted.
- [ ] On `/users`, create a user with a short password, confirm client-side validation triggers.
- [ ] Open an order detail page while slow, confirm skeleton shows instead of bare text.
- [ ] Toggle dark mode while viewing `PickupRadar`, confirm colors adapt.
- [ ] Assign/unassign stores to a user, confirm toasts fire on both success and failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)