### PR TITLE
feat(web): dashboard counts, 401 interceptor, form provider

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -68,7 +68,7 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| W1 | **Dashboard fetches ALL entity records just to count them** | `lib/api.ts:910-944` | 9 concurrent full-table fetches, discarded after `.length`. Need a server-side counts endpoint. |
+| W1 ✅ | **Dashboard fetches ALL entity records just to count them** | `lib/api.ts:910-944` | 9 concurrent full-table fetches, discarded after `.length`. Need a server-side counts endpoint. |
 
 ### HIGH
 
@@ -76,7 +76,7 @@
 |---|-------|------|--------|
 | W2 ✅ | **`ordersQueryOptions` and `ordersPageQueryOptions` share the same queryKey** | `query-options.ts:93-103` | Different response shapes with same cache key — whichever runs first poisons the cache. |
 | W3 ✅ | **8 individual `useWatch` calls** in `TransactionsCheckout` | `transactions-checkout.tsx:87-125` | Consolidate into one `useWatch({ name: [...] })` to reduce re-renders. |
-| W4 | **Infinite scroll observer torn down on every fetch** | `worker.index.tsx:198-221` | Observer recreated on `isFetchingNextPage` change. Should be stable. |
+| W4 ✅ | **Infinite scroll observer torn down on every fetch** | `worker.index.tsx:198-221` | Observer recreated on `isFetchingNextPage` change. Should be stable. |
 | W5 ✅ | **`submit` handler recreated every render, re-binds controller** | `use-transactions-page.ts:276-319` | Needs `useCallback`. |
 | W6 ✅ | **No `staleTime` on any query** | `query-options.ts` (all entries) | Reference data (stores, categories, services) refetched on every mount. |
 
@@ -89,17 +89,17 @@
 | # | Issue | File | Detail |
 |---|-------|------|--------|
 | U1 ✅ | **Loading/error states are bare `<p>` text** | `orders.$orderId.tsx:458-469`, `queue-service-detail.tsx:308-324` | No skeleton, no layout wrapper. `<Skeleton>` component exists but isn't used. |
-| U2 | **Hooks called before early returns in `AdminOrderDetailPage`** | `orders.$orderId.tsx:324-453` | All mutations registered with `id = NaN` before guard checks. |
+| U2 ✅ | **Hooks called before early returns in `AdminOrderDetailPage`** | `orders.$orderId.tsx:324-453` | All mutations registered with `id = NaN` before guard checks. |
 | U3 ✅ | **`PickupRadar` uses hardcoded `slate-*` colors** | `pickup-radar.tsx` (entire file) | Won't respond to dark mode. Rest of app uses semantic tokens. |
 | U4 ✅ | **User edit form pre-fills password with `"placeholder1"`** | `users.tsx:165-166` | Security smell and misleading UX. Server will receive this string if user doesn't change it. |
-| U5 | **No 401 interceptor — expired/invalid tokens aren't cleared** | `lib/auth.ts`, `auth-store.ts` | User with stale token passes `requireAuth` then every API call silently fails. |
+| U5 ✅ | **No 401 interceptor — expired/invalid tokens aren't cleared** | `lib/auth.ts`, `auth-store.ts` | User with stale token passes `requireAuth` then every API call silently fails. |
 
 ### MEDIUM
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
 | U6 ✅ | **`ORDER_STATUS_TRANSITIONS` duplicated in two files** | `orders.$orderId.tsx:82-106`, `queue-service-detail.tsx:51-67` | Must be changed in two places. Should import from server package or shared constant. |
-| U7 | **No empty state explaining missing store assignment** | `orders.index.tsx:169-172` | Non-admin with no store sees "No data found" with no explanation. |
+| U7 ✅ | **No empty state explaining missing store assignment** | `orders.index.tsx:169-172` | Non-admin with no store sees "No data found" with no explanation. |
 | U8 ✅ | **`campaigns.tsx` columns not in `useMemo`** | `campaigns.tsx:262-331` | Recreated on every render, triggering full table reconciliation. |
 
 ---
@@ -119,7 +119,7 @@
 | # | Issue | File | Detail |
 |---|-------|------|--------|
 | SM4 | **`useSheet`/`useDialog` stores `ReactNode`, content can't re-render** | `dialog-store.ts:8`, `sheet-store.ts:7` | Data fetched after open won't update the sheet content. |
-| SM5 | **`UsersPage` prop-drills form internals** | `users.tsx:73-76, 161-188` | Violates the `FormProvider`/`useFormContext` pattern documented in AGENTS.md. |
+| SM5 ✅ | **`UsersPage` prop-drills form internals** | `users.tsx:73-76, 161-188` | Violates the `FormProvider`/`useFormContext` pattern documented in AGENTS.md. |
 
 ---
 

--- a/packages/server/src/modules/dashboard/dashboard.repository.ts
+++ b/packages/server/src/modules/dashboard/dashboard.repository.ts
@@ -1,0 +1,44 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+
+export async function getEntityCounts() {
+  const result = await db.execute<{
+    customers: number;
+    users: number;
+    stores: number;
+    categories: number;
+    services: number;
+    products: number;
+    payment_methods: number;
+    orders: number;
+    campaigns: number;
+  }>(sql`
+    SELECT
+      (SELECT COUNT(*)::int FROM customers) AS customers,
+      (SELECT COUNT(*)::int FROM users) AS users,
+      (SELECT COUNT(*)::int FROM stores) AS stores,
+      (SELECT COUNT(*)::int FROM categories) AS categories,
+      (SELECT COUNT(*)::int FROM services) AS services,
+      (SELECT COUNT(*)::int FROM products) AS products,
+      (SELECT COUNT(*)::int FROM payment_methods) AS payment_methods,
+      (SELECT COUNT(*)::int FROM orders) AS orders,
+      (SELECT COUNT(*)::int FROM campaigns) AS campaigns
+  `);
+
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error("Failed to fetch dashboard counts");
+  }
+
+  return {
+    customers: Number(row.customers),
+    users: Number(row.users),
+    stores: Number(row.stores),
+    categories: Number(row.categories),
+    services: Number(row.services),
+    products: Number(row.products),
+    paymentMethods: Number(row.payment_methods),
+    orders: Number(row.orders),
+    campaigns: Number(row.campaigns),
+  };
+}

--- a/packages/server/src/modules/dashboard/dashboard.service.ts
+++ b/packages/server/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,5 @@
+import { getEntityCounts } from "@/modules/dashboard/dashboard.repository";
+
+export function getDashboardCounts() {
+  return getEntityCounts();
+}

--- a/packages/server/src/routes/admin/dashboard.ts
+++ b/packages/server/src/routes/admin/dashboard.ts
@@ -1,0 +1,11 @@
+import { Hono } from "hono";
+import { getDashboardCounts } from "@/modules/dashboard/dashboard.service";
+import { success } from "@/utils/http";
+
+const app = new Hono().get("/counts", async (c) => {
+  const counts = await getDashboardCounts();
+
+  return c.json(success(counts));
+});
+
+export default app;

--- a/packages/server/src/routes/admin/index.ts
+++ b/packages/server/src/routes/admin/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import campaignsRoutes from "@/routes/admin/campaigns";
 import categoriesRoutes from "@/routes/admin/categories";
 import customerRoutes from "@/routes/admin/customer";
+import dashboardRoutes from "@/routes/admin/dashboard";
 import orderServiceImagesRoutes from "@/routes/admin/order-service-images";
 import ordersRoutes from "@/routes/admin/orders";
 import paymentMethodsRoutes from "@/routes/admin/payment-methods";
@@ -20,6 +21,7 @@ const app = new Hono()
   .route("/campaigns", campaignsRoutes)
   .route("/payment-methods", paymentMethodsRoutes)
   .route("/orders", ordersRoutes)
-  .route("/order-service-images", orderServiceImagesRoutes);
+  .route("/order-service-images", orderServiceImagesRoutes)
+  .route("/dashboard", dashboardRoutes);
 
 export default app;

--- a/packages/web/src/features/users/components/user-form.tsx
+++ b/packages/web/src/features/users/components/user-form.tsx
@@ -1,9 +1,8 @@
 import { PlusIcon } from "@phosphor-icons/react";
 import {
-	type Control,
 	Controller,
 	type SubmitHandler,
-	type UseFormHandleSubmit,
+	useFormContext,
 } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -39,24 +38,21 @@ export type UserFormState = {
 };
 
 type UserFormProps = {
-	control: Control<UserFormState>;
-	handleSubmit: UseFormHandleSubmit<UserFormState>;
 	onSubmit: SubmitHandler<UserFormState>;
-	isSubmitting: boolean;
 	isEditing: boolean;
 	stores: Array<{ id: number; code: string; name: string }>;
 	onReset: () => void;
 };
 
 export function UserForm({
-	control,
-	handleSubmit,
 	onSubmit,
-	isSubmitting,
 	isEditing,
 	stores,
 	onReset,
 }: UserFormProps) {
+	const { control, handleSubmit, formState } = useFormContext<UserFormState>();
+	const isSubmitting = formState.isSubmitting;
+
 	return (
 		<form onSubmit={handleSubmit(onSubmit)}>
 			<FieldGroup>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -57,6 +57,7 @@ const orderServiceByItemCodeRoute =
 	rpc.api.admin.orders.services["by-item-code"].$get;
 const orderServiceQueueRoute = rpc.api.admin.orders.services.queue.$get;
 const myOrderServicesRoute = rpc.api.admin.orders.services.me.$get;
+const dashboardCountsRoute = rpc.api.admin.dashboard.counts.$get;
 const publicTrackOrderRoute = rpc.api.public.orders.track.$post;
 
 type LoginSuccessResponse = Extract<
@@ -909,38 +910,12 @@ export async function trackPublicOrder(payload: TrackPublicOrderPayload) {
 	);
 }
 
-export async function fetchDashboardCounts() {
-	const [
-		customers,
-		users,
-		stores,
-		categories,
-		services,
-		products,
-		paymentMethods,
-		orders,
-		campaigns,
-	] = await Promise.all([
-		fetchCustomers(),
-		fetchUsers(),
-		fetchStores(),
-		fetchCategories(),
-		fetchServices(),
-		fetchProducts(),
-		fetchPaymentMethods(),
-		fetchOrders(),
-		fetchCampaigns(),
-	]);
+export type DashboardCounts = InferResponseType<
+	typeof dashboardCountsRoute
+>["data"];
 
-	return {
-		customers: customers.length,
-		users: users.length,
-		stores: stores.length,
-		categories: categories.length,
-		services: services.length,
-		products: products.length,
-		paymentMethods: paymentMethods.length,
-		orders: orders.length,
-		campaigns: campaigns.length,
-	};
+export async function fetchDashboardCounts() {
+	return parseSuccessData<DashboardCounts>(
+		rpcWithAuth().api.admin.dashboard.counts.$get(),
+	);
 }

--- a/packages/web/src/lib/rpc.ts
+++ b/packages/web/src/lib/rpc.ts
@@ -4,12 +4,32 @@ import { useAuthStore } from "@/stores/auth-store";
 const API_BASE_URL =
 	import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/";
 
-export const rpc = rpcFn(API_BASE_URL);
+const authFetch: typeof fetch = async (input, init) => {
+	const response = await fetch(input, init);
+
+	if (response.status === 401) {
+		const { token, clearToken } = useAuthStore.getState();
+		if (token) {
+			clearToken();
+			if (typeof window !== "undefined") {
+				const loginPath = "/auth/login";
+				if (window.location.pathname !== loginPath) {
+					window.location.assign(loginPath);
+				}
+			}
+		}
+	}
+
+	return response;
+};
+
+export const rpc = rpcFn(API_BASE_URL, { fetch: authFetch });
 
 export const rpcWithAuth = () => {
 	const token = useAuthStore.getState().token;
 
 	return rpcFn(API_BASE_URL, {
 		headers: token ? { Authorization: `Bearer ${token}` } : {},
+		fetch: authFetch,
 	});
 };

--- a/packages/web/src/routes/_admin/orders.$orderId.tsx
+++ b/packages/web/src/routes/_admin/orders.$orderId.tsx
@@ -330,6 +330,17 @@ function OrderDetailPage() {
 	const search = Route.useSearch();
 	const { orderId } = Route.useParams();
 	const parsedOrderId = Number(orderId);
+	const isValidOrderId = Number.isInteger(parsedOrderId) && parsedOrderId > 0;
+
+	if (!isValidOrderId) {
+		return (
+			<OrderDetailMessage
+				tone="error"
+				title="Invalid order ID"
+				description="The URL does not point to a valid order."
+			/>
+		);
+	}
 
 	if (search.workerServiceId) {
 		return (
@@ -341,17 +352,14 @@ function OrderDetailPage() {
 		);
 	}
 
-	return <AdminOrderDetailPage />;
+	return <AdminOrderDetailPage orderId={parsedOrderId} />;
 }
 
-function AdminOrderDetailPage() {
+function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 	const user = getCurrentUser();
 	const isPaymentAllowed = user?.role === "admin" || user?.role === "cashier";
 	const isRefundAllowed = isPaymentAllowed;
 
-	const { orderId } = Route.useParams();
-	const id = Number(orderId);
-	const isValidOrderId = Number.isInteger(id) && id > 0;
 	const queryClient = useQueryClient();
 
 	const [photoTypeByServiceId, setPhotoTypeByServiceId] = useState<
@@ -371,10 +379,7 @@ function AdminOrderDetailPage() {
 	>({});
 	const [refundNote, setRefundNote] = useState("");
 
-	const detailQuery = useQuery({
-		...orderDetailQueryOptions(id),
-		enabled: isValidOrderId,
-	});
+	const detailQuery = useQuery(orderDetailQueryOptions(id));
 
 	const paymentMethodsQuery = useQuery(paymentMethodsQueryOptions());
 
@@ -483,16 +488,6 @@ function AdminOrderDetailPage() {
 			await refreshOrderData();
 		},
 	});
-
-	if (!isValidOrderId) {
-		return (
-			<OrderDetailMessage
-				tone="error"
-				title="Invalid order ID"
-				description="The URL does not point to a valid order."
-			/>
-		);
-	}
 
 	if (detailQuery.isPending) {
 		return <OrderDetailSkeleton />;

--- a/packages/web/src/routes/_admin/orders.index.tsx
+++ b/packages/web/src/routes/_admin/orders.index.tsx
@@ -171,6 +171,11 @@ function OrdersPage() {
 		enabled: currentUser?.role === "admin" ? true : parsedStoreId !== undefined,
 	});
 
+	const hasNoStoreAssignment =
+		currentUser?.role !== "admin" &&
+		currentUserDetailQuery.isSuccess &&
+		userStoreIds.length === 0;
+
 	const openSheet = useSheet((state) => state.openSheet);
 
 	const orders = ordersQuery.data?.items ?? [];
@@ -395,25 +400,36 @@ function OrdersPage() {
 								}}
 							/>
 						</div>
-						<div className="grid gap-4">
-							<DataTable
-								columns={columns}
-								data={orders}
-								isLoading={ordersQuery.isPending || storesQuery.isPending}
-							/>
-							<TablePagination
-								meta={ordersQuery.data?.meta}
-								isLoading={ordersQuery.isPending}
-								onPageChange={(page) => {
-									void navigate({
-										search: (prev) => ({
-											...prev,
-											page,
-										}),
-									});
-								}}
-							/>
-						</div>
+						{hasNoStoreAssignment ? (
+							<div className="rounded border border-dashed border-border bg-muted/30 p-8 text-center">
+								<p className="font-medium text-foreground text-sm">
+									No store assigned
+								</p>
+								<p className="mt-1 text-muted-foreground text-sm">
+									Ask an admin to assign you to a store before viewing orders.
+								</p>
+							</div>
+						) : (
+							<div className="grid gap-4">
+								<DataTable
+									columns={columns}
+									data={orders}
+									isLoading={ordersQuery.isPending || storesQuery.isPending}
+								/>
+								<TablePagination
+									meta={ordersQuery.data?.meta}
+									isLoading={ordersQuery.isPending}
+									onPageChange={(page) => {
+										void navigate({
+											search: (prev) => ({
+												...prev,
+												page,
+											}),
+										});
+									}}
+								/>
+							</div>
+						)}
 					</CardContent>
 				</Card>
 			</div>

--- a/packages/web/src/routes/_admin/users.tsx
+++ b/packages/web/src/routes/_admin/users.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
-import { type SubmitHandler, useForm } from "react-hook-form";
+import { FormProvider, type SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { DataTable } from "@/components/data-table";
 import { PageHeader } from "@/components/page-header";
@@ -134,11 +134,6 @@ function UsersPage() {
 			updateUserStores(id, { store_ids }),
 	});
 
-	const isSubmitting =
-		createMutation.isPending ||
-		updateMutation.isPending ||
-		updateStoresMutation.isPending;
-
 	const handleSubmit: SubmitHandler<UserFormState> = useCallback(
 		async (values) => {
 			if (editingUser) {
@@ -214,19 +209,18 @@ function UsersPage() {
 			openSheet({
 				title: "Edit User",
 				content: (
-					<UserForm
-						control={form.control}
-						handleSubmit={form.handleSubmit}
-						onSubmit={handleSubmit}
-						isSubmitting={isSubmitting}
-						isEditing={true}
-						stores={storesQuery.data ?? []}
-						onReset={resetForm}
-					/>
+					<FormProvider {...form}>
+						<UserForm
+							onSubmit={handleSubmit}
+							isEditing={true}
+							stores={storesQuery.data ?? []}
+							onReset={resetForm}
+						/>
+					</FormProvider>
 				),
 			});
 		},
-		[form, openSheet, isSubmitting, storesQuery.data, resetForm, handleSubmit],
+		[form, openSheet, storesQuery.data, resetForm, handleSubmit],
 	);
 
 	const handleCreate = useCallback(() => {
@@ -235,25 +229,17 @@ function UsersPage() {
 		openSheet({
 			title: "Add User",
 			content: (
-				<UserForm
-					control={form.control}
-					handleSubmit={form.handleSubmit}
-					onSubmit={handleSubmit}
-					isSubmitting={isSubmitting}
-					isEditing={false}
-					stores={storesQuery.data ?? []}
-					onReset={resetForm}
-				/>
+				<FormProvider {...form}>
+					<UserForm
+						onSubmit={handleSubmit}
+						isEditing={false}
+						stores={storesQuery.data ?? []}
+						onReset={resetForm}
+					/>
+				</FormProvider>
 			),
 		});
-	}, [
-		form,
-		openSheet,
-		isSubmitting,
-		storesQuery.data,
-		resetForm,
-		handleSubmit,
-	]);
+	}, [form, openSheet, storesQuery.data, resetForm, handleSubmit]);
 
 	const columns = useMemo<ColumnDef<User>[]>(
 		() => [

--- a/packages/web/src/routes/_admin/worker.index.tsx
+++ b/packages/web/src/routes/_admin/worker.index.tsx
@@ -195,17 +195,24 @@ function WorkerQueuePage() {
 		enabled: parsedStoreId !== undefined,
 	});
 
+	const queueQueryRef = useRef(queueQuery);
+	queueQueryRef.current = queueQuery;
+
 	useEffect(() => {
 		const node = loadMoreRef.current;
-		if (!node || !queueQuery.hasNextPage || queueQuery.isFetchingNextPage) {
+		if (!node) {
 			return;
 		}
 
 		const observer = new IntersectionObserver(
 			(entries) => {
 				const [entry] = entries;
-				if (entry?.isIntersecting) {
-					void queueQuery.fetchNextPage();
+				if (!entry?.isIntersecting) {
+					return;
+				}
+				const current = queueQueryRef.current;
+				if (current.hasNextPage && !current.isFetchingNextPage) {
+					void current.fetchNextPage();
 				}
 			},
 			{ rootMargin: "240px 0px" },
@@ -214,11 +221,7 @@ function WorkerQueuePage() {
 		observer.observe(node);
 
 		return () => observer.disconnect();
-	}, [
-		queueQuery.fetchNextPage,
-		queueQuery.hasNextPage,
-		queueQuery.isFetchingNextPage,
-	]);
+	}, []);
 
 	const lookupMutation = useMutation({
 		mutationFn: async ({


### PR DESCRIPTION
## Summary

PR4 — web fixes from AUDIT.md.

- **W1** — New `/admin/dashboard/counts` endpoint runs a single SQL with 9 subqueries; replaces 9 concurrent full-table fetches on the dashboard.
- **W4** — Worker infinite scroll observer now uses a stable effect with a ref-backed query snapshot; no more teardown on every fetch.
- **U2** — `OrderDetailPage` validates `orderId` and early-returns before rendering `AdminOrderDetailPage`; mutations no longer get `NaN`.
- **U5** — `rpcWithAuth` and `rpc` share a custom fetch that clears the token and redirects to `/auth/login` on 401.
- **U7** — Non-admin users with no store assignment now see a clear empty state instead of a blank table.
- **SM5** — `UsersPage` wraps `UserForm` in `FormProvider`; the form reads `control`/`handleSubmit`/`formState` via `useFormContext`.

## Test plan

- [ ] Dashboard loads instantly with correct counts
- [ ] Worker queue fetches next page on scroll without observer flicker
- [ ] Invalid order ID URL shows the error card, no mutations registered
- [ ] Tamper JWT → next API call clears token and bounces to login
- [ ] Non-admin user without store assignment sees empty state on /orders
- [ ] Create + edit user flows still work via the sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)