### PR TITLE
feat(server): logic correctness and hot-path perf fixes

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -43,9 +43,9 @@
 | # | Issue | File | Detail |
 |---|-------|------|--------|
 | L4 ✅ | **Products have stock constraints but no decrement on order** | `schema.ts` (stock check constraint) vs `order.service.ts` | The schema enforces `stock >= 0` but `insertOrderProducts` never decrements stock. |
-| L5 | **Public tracking fetches full data before validating phone** | `routes/public/orders.ts:28-103` | Unauthenticated users can probe order existence. Phone check should be in the DB query. |
-| L6 | **`buildWhereClause` and `buildRelationalWhere` can diverge** | `order.repository.ts:52-238` | Two parallel filter implementations that must stay in sync. Search already uses slightly different patterns. |
-| L7 | **Default sort order is oldest-first** | `order.schema.ts:33-34` | `sort_by: "id"`, `sort_order: "asc"` — most admin UIs expect newest-first. |
+| L5 ✅ | **Public tracking fetches full data before validating phone** | `routes/public/orders.ts:28-103` | Unauthenticated users can probe order existence. Phone check should be in the DB query. |
+| L6 ✅ | **`buildWhereClause` and `buildRelationalWhere` can diverge** | `order.repository.ts:52-238` | Two parallel filter implementations that must stay in sync. Search already uses slightly different patterns. |
+| L7 ✅ | **Default sort order is oldest-first** | `order.schema.ts:33-34` | `sort_by: "id"`, `sort_order: "asc"` — most admin UIs expect newest-first. |
 
 ---
 
@@ -55,10 +55,10 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| P1 | **`getOrderServiceByItemCode` / `getOrderServiceById` not prepared** | `order-admin.service.ts:261-317` | Hot-path queue queries. The adjacent `getOrderServicePrepared` is correctly prepared. |
-| P2 | **`getS3Client()` creates a new client per request** | `utils/s3.ts:21-33` | Should be a module-level singleton. |
-| P3 | **`listProducts()` / `listServices()` have no pagination** | `product.repository.ts`, `service.repository.ts` | Unbounded table scans with no limit. |
-| P4 | **`DATABASE_URL_DEV` hardcoded in runtime** | `db/index.ts:5` | Production would silently use the dev database. |
+| P1 ✅ | **`getOrderServiceByItemCode` / `getOrderServiceById` not prepared** | `order-admin.service.ts:261-317` | Hot-path queue queries. The adjacent `getOrderServicePrepared` is correctly prepared. |
+| P2 ✅ | **`getS3Client()` creates a new client per request** | `utils/s3.ts:21-33` | Should be a module-level singleton. |
+| P3 ✅ | **`listProducts()` / `listServices()` have no pagination** | `product.repository.ts`, `service.repository.ts` | Unbounded table scans with no limit. |
+| P4 ✅ | **`DATABASE_URL_DEV` hardcoded in runtime** | `db/index.ts:5` | Production would silently use the dev database. |
 
 ---
 

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -2,5 +2,18 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { relations } from "@/db/relations";
 
-const sql = neon(process.env.DATABASE_URL_DEV);
+const isProduction = process.env.NODE_ENV === "production";
+const databaseUrl = isProduction
+  ? process.env.DATABASE_URL_PROD
+  : process.env.DATABASE_URL_DEV;
+
+if (!databaseUrl) {
+  throw new Error(
+    `Missing database connection string: ${
+      isProduction ? "DATABASE_URL_PROD" : "DATABASE_URL_DEV"
+    } is required`
+  );
+}
+
+const sql = neon(databaseUrl);
 export const db = drizzle({ client: sql, relations });

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -260,62 +260,50 @@ async function getOrderLineRefundCaps(orderId: number) {
   });
 }
 
-export function getOrderServiceByItemCode(item_code: string) {
-  return db.query.ordersServicesTable.findFirst({
-    where: { item_code },
-    with: {
-      order: {
-        columns: {
-          id: true,
-          code: true,
-          store_id: true,
-          status: true,
-        },
-      },
-      service: {
-        columns: {
-          id: true,
-          code: true,
-          name: true,
-        },
-      },
-      handler: {
-        columns: {
-          id: true,
-          name: true,
-        },
-      },
+const queueRelationColumns = {
+  order: {
+    columns: {
+      id: true,
+      code: true,
+      store_id: true,
+      status: true,
     },
-  });
+  },
+  service: {
+    columns: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  handler: {
+    columns: {
+      id: true,
+      name: true,
+    },
+  },
+} as const;
+
+const getOrderServiceByItemCodePrepared = db.query.ordersServicesTable
+  .findFirst({
+    where: { item_code: { eq: sql.placeholder("item_code") } },
+    with: queueRelationColumns,
+  })
+  .prepare("get_order_service_by_item_code");
+
+const getOrderServiceByIdPrepared = db.query.ordersServicesTable
+  .findFirst({
+    where: { id: { eq: sql.placeholder("id") } },
+    with: queueRelationColumns,
+  })
+  .prepare("get_order_service_by_id");
+
+export function getOrderServiceByItemCode(item_code: string) {
+  return getOrderServiceByItemCodePrepared.execute({ item_code });
 }
 
 export function getOrderServiceById(serviceId: number) {
-  return db.query.ordersServicesTable.findFirst({
-    where: { id: serviceId },
-    with: {
-      order: {
-        columns: {
-          id: true,
-          code: true,
-          store_id: true,
-          status: true,
-        },
-      },
-      service: {
-        columns: {
-          id: true,
-          code: true,
-          name: true,
-        },
-      },
-      handler: {
-        columns: {
-          id: true,
-          name: true,
-        },
-      },
-    },
-  });
+  return getOrderServiceByIdPrepared.execute({ id: serviceId });
 }
 
 export async function getMyOrderServices(

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -1,9 +1,8 @@
 import dayjs from "dayjs";
 import type { InferInsertModel } from "drizzle-orm";
-import { and, eq, gte, inArray, lte, or, type SQL, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
-  customersTable,
   orderCountersTable,
   ordersProductsTable,
   ordersServicesTable,
@@ -49,109 +48,7 @@ interface FindOrdersResult {
 
 const numericSearchRegex = /^\d+$/;
 
-function buildWhereClause(
-  filters: NormalizedOrderListQuery,
-  scopedStoreIds?: number[]
-): SQL | undefined {
-  const conditions: SQL[] = [];
-
-  if (scopedStoreIds !== undefined) {
-    if (scopedStoreIds.length === 0) {
-      conditions.push(eq(ordersTable.id, -1));
-    } else {
-      conditions.push(inArray(ordersTable.store_id, scopedStoreIds));
-    }
-  }
-
-  if (filters.status) {
-    conditions.push(eq(ordersTable.status, filters.status));
-  }
-
-  if (filters.payment_status) {
-    conditions.push(eq(ordersTable.payment_status, filters.payment_status));
-  }
-
-  if (filters.store_id) {
-    conditions.push(eq(ordersTable.store_id, filters.store_id));
-  }
-
-  if (filters.customer_id) {
-    conditions.push(eq(ordersTable.customer_id, filters.customer_id));
-  }
-
-  if (filters.created_by) {
-    conditions.push(eq(ordersTable.created_by, filters.created_by));
-  }
-
-  if (filters.payment_method_id) {
-    conditions.push(
-      eq(ordersTable.payment_method_id, filters.payment_method_id)
-    );
-  }
-
-  if (filters.date_from) {
-    conditions.push(
-      gte(
-        ordersTable.created_at,
-        dayjs(filters.date_from).startOf("day").toDate()
-      )
-    );
-  }
-
-  if (filters.date_to) {
-    conditions.push(
-      lte(ordersTable.created_at, dayjs(filters.date_to).endOf("day").toDate())
-    );
-  }
-
-  if (filters.search) {
-    const search = filters.search.trim();
-    const loweredSearch = search.toLowerCase();
-    const searchPrefix = `${search}%`;
-    const loweredSearchPrefix = `${loweredSearch}%`;
-
-    const customerMatchesSearch = sql`
-      EXISTS (
-        SELECT 1
-        FROM ${customersTable}
-        WHERE ${customersTable.id} = ${ordersTable.customer_id}
-          AND (
-            LOWER(${customersTable.name}) LIKE ${loweredSearchPrefix}
-            OR ${customersTable.phone_number} LIKE ${searchPrefix}
-          )
-      )
-    `;
-
-    const searchConditions: SQL[] = [
-      sql`LOWER(${ordersTable.code}) LIKE ${loweredSearchPrefix}`,
-      customerMatchesSearch,
-    ];
-
-    if (numericSearchRegex.test(search)) {
-      const numericSearch = Number(search);
-
-      searchConditions.push(eq(ordersTable.id, numericSearch));
-      searchConditions.push(sql`
-        EXISTS (
-          SELECT 1
-          FROM ${ordersServicesTable}
-          WHERE ${ordersServicesTable.order_id} = ${ordersTable.id}
-            AND ${ordersServicesTable.id} = ${numericSearch}
-        )
-      `);
-    }
-
-    conditions.push(or(...searchConditions) as SQL);
-  }
-
-  if (conditions.length === 0) {
-    return undefined;
-  }
-
-  return and(...conditions);
-}
-
-function buildRelationalWhere(
+function buildOrderWhere(
   filters: NormalizedOrderListQuery,
   scopedStoreIds?: number[]
 ) {
@@ -279,15 +176,23 @@ export async function findOrders(
           },
         },
       },
-      where: buildRelationalWhere(filters, scopedStoreIds),
-      orderBy: {
-        [filters.sort_by ?? "id"]: filters.sort_order ?? "desc",
-        id: "asc",
-      },
+      where: buildOrderWhere(filters, scopedStoreIds),
+      orderBy:
+        filters.sort_by === "id"
+          ? { id: filters.sort_order }
+          : {
+              [filters.sort_by]: filters.sort_order,
+              id: filters.sort_order,
+            },
       limit: filters.limit,
       offset: filters.offset,
     }),
-    db.$count(ordersTable, buildWhereClause(filters, scopedStoreIds)),
+    db.query.ordersTable
+      .findMany({
+        where: buildOrderWhere(filters, scopedStoreIds),
+        columns: { id: true },
+      })
+      .then((rows) => rows.length),
   ]);
 
   const orderIds = rows.map((row) => row.id);

--- a/packages/server/src/modules/orders/order.schema.ts
+++ b/packages/server/src/modules/orders/order.schema.ts
@@ -31,7 +31,7 @@ export const GETOrdersQuerySchema = z
       .optional(),
 
     sort_by: z.enum(["created_at", "code", "id", "total"]).default("id"),
-    sort_order: z.enum(["asc", "desc"]).default("asc"),
+    sort_order: z.enum(["asc", "desc"]).default("desc"),
   })
   .refine(
     (query) =>
@@ -83,6 +83,6 @@ export function normalizeOrderListQuery(
     date_from: query?.date_from,
     date_to: query?.date_to,
     sort_by: query?.sort_by ?? "id",
-    sort_order: query?.sort_order ?? "asc",
+    sort_order: query?.sort_order ?? "desc",
   };
 }

--- a/packages/server/src/modules/products/product.repository.ts
+++ b/packages/server/src/modules/products/product.repository.ts
@@ -22,9 +22,12 @@ export function findProducts(ids: number[]) {
   });
 }
 
+export const LIST_PRODUCTS_MAX = 500;
+
 export function listProducts() {
   return db.query.productsTable.findMany({
     orderBy: { id: "asc" },
+    limit: LIST_PRODUCTS_MAX,
     with: {
       category: true,
     },

--- a/packages/server/src/modules/services/service.repository.ts
+++ b/packages/server/src/modules/services/service.repository.ts
@@ -9,9 +9,12 @@ export function findServices(ids: number[]) {
   });
 }
 
+export const LIST_SERVICES_MAX = 500;
+
 export function listServices() {
   return db.query.servicesTable.findMany({
     orderBy: { id: "asc" },
+    limit: LIST_SERVICES_MAX,
     with: {
       category: true,
     },

--- a/packages/server/src/routes/public/orders.ts
+++ b/packages/server/src/routes/public/orders.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
@@ -10,8 +11,10 @@ const POSTPublicTrackOrderSchema = z.object({
   phone_number: z.string().trim().min(6).max(20),
 });
 
+const nonDigitRegex = /\D/g;
+
 function normalizePhoneNumber(value: string) {
-  return value.replace(/\D/g, "");
+  return value.replace(nonDigitRegex, "");
 }
 
 function maskPhoneNumber(phone: string) {
@@ -24,9 +27,16 @@ const app = new Hono().post(
   zodValidator("json", POSTPublicTrackOrderSchema),
   async (c) => {
     const { code, phone_number } = c.req.valid("json");
+    const normalizedPhone = normalizePhoneNumber(phone_number);
 
     const order = await db.query.ordersTable.findFirst({
-      where: { code },
+      where: {
+        code,
+        customer: {
+          RAW: (customer) =>
+            sql`REGEXP_REPLACE(${customer.phone_number}, '\D', '', 'g') = ${normalizedPhone}`,
+        },
+      },
       columns: {
         id: true,
         code: true,
@@ -92,16 +102,9 @@ const app = new Hono().post(
     });
 
     if (!order) {
-      return c.json(failure("Order not found"), StatusCodes.NOT_FOUND);
-    }
-
-    const incomingPhone = normalizePhoneNumber(phone_number);
-    const customerPhone = normalizePhoneNumber(order.customer.phone_number);
-
-    if (incomingPhone !== customerPhone) {
       return c.json(
         failure("Order code or phone number is invalid"),
-        StatusCodes.UNAUTHORIZED
+        StatusCodes.NOT_FOUND
       );
     }
 

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -17,10 +17,16 @@ function getS3Config() {
   return { bucket, region };
 }
 
+let cachedClient: S3Client | null = null;
+
 function getS3Client() {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
   const { region } = getS3Config();
 
-  return new S3Client({
+  cachedClient = new S3Client({
     region,
     credentials:
       process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
@@ -30,6 +36,8 @@ function getS3Client() {
           }
         : undefined,
   });
+
+  return cachedClient;
 }
 
 export function buildS3ObjectUrl(key: string) {


### PR DESCRIPTION
## Summary

PR5 — server logic + perf batch from AUDIT.md.

### Logic
- **L5** — Public `/orders/track` pushes phone match into the DB via `REGEXP_REPLACE(phone, '\D', '', 'g')`; a wrong code and a wrong phone now return the same 404.
- **L6** — Dropped the SQL \`buildWhereClause\`; list and count share a single \`buildOrderWhere\` relational filter. Count uses \`findMany\` with an id-only projection to avoid divergence.
- **L7** — Default order listing sort is now \`id desc\` (newest first). Dropped the redundant id tiebreaker when \`sort_by\` is already id.

### Perf
- **P1** — \`getOrderServiceByItemCode\` and \`getOrderServiceById\` are now prepared statements using \`sql.placeholder\`.
- **P2** — \`S3Client\` is cached at module level; no more fresh client per presigned URL.
- **P3** — \`listProducts\` and \`listServices\` now cap at 500 rows to prevent unbounded scans.
- **P4** — \`db/index.ts\` switches between \`DATABASE_URL_PROD\` and \`DATABASE_URL_DEV\` by \`NODE_ENV\` with a startup guard if the expected URL is missing.

## Test plan

- [ ] Public tracking: correct code + phone still returns the order
- [ ] Public tracking: wrong phone on a real code returns 404 (not 401)
- [ ] Admin /orders list returns newest first by default and pagination count matches
- [ ] Worker queue scan (by-id, by-item-code) still resolves under load
- [ ] Upload flow still produces valid presigned URLs
- [ ] Production build boots against \`DATABASE_URL_PROD\`; missing env throws at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)