### PR TITLE
refactor(web): transactions state architecture + global sheet/dialog rerender

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -110,15 +110,15 @@
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| SM1 | **`transactionsPageController` is a module-level mutable singleton** | `transactions-store.ts:89-107` | Not React-owned. Breaks on Strict Mode double-mount, fast refresh, or multiple instances. |
-| SM2 | **Server-fetched data duplicated into Zustand via effects** | `transactions-store.ts:48-66`, `use-transactions-page.ts:321-352` | TanStack Query manages cache, but Zustand holds a derived snapshot. Components should read from Query directly. |
+| SM1 ✅ | **`transactionsPageController` is a module-level mutable singleton** | `transactions-store.ts:89-107` | Not React-owned. Breaks on Strict Mode double-mount, fast refresh, or multiple instances. |
+| SM2 ✅ | **Server-fetched data duplicated into Zustand via effects** | `transactions-store.ts:48-66`, `use-transactions-page.ts:321-352` | TanStack Query manages cache, but Zustand holds a derived snapshot. Components should read from Query directly. |
 | SM3 ✅ | **`updateUserStores` called outside `useMutation`** | `users.tsx:129-132, 148-151` | Errors silently swallowed. No toast on failure. Cache invalidated even on error. |
 
 ### MEDIUM
 
 | # | Issue | File | Detail |
 |---|-------|------|--------|
-| SM4 | **`useSheet`/`useDialog` stores `ReactNode`, content can't re-render** | `dialog-store.ts:8`, `sheet-store.ts:7` | Data fetched after open won't update the sheet content. |
+| SM4 ✅ | **`useSheet`/`useDialog` stores `ReactNode`, content can't re-render** | `dialog-store.ts:8`, `sheet-store.ts:7` | Data fetched after open won't update the sheet content. |
 | SM5 ✅ | **`UsersPage` prop-drills form internals** | `users.tsx:73-76, 161-188` | Violates the `FormProvider`/`useFormContext` pattern documented in AGENTS.md. |
 
 ---

--- a/packages/web/src/components/ui/global-dialog.tsx
+++ b/packages/web/src/components/ui/global-dialog.tsx
@@ -37,8 +37,8 @@ export function GlobalDialog() {
 						</DialogDescription>
 					</DialogHeader>
 				) : null}
-				{content ? <div className="py-4">{content}</div> : null}
-				{footer ? <DialogFooter>{footer}</DialogFooter> : null}
+				{content ? <div className="py-4">{content()}</div> : null}
+				{footer ? <DialogFooter>{footer()}</DialogFooter> : null}
 			</DialogContent>
 		</Dialog>
 	);

--- a/packages/web/src/components/ui/global-sheet.tsx
+++ b/packages/web/src/components/ui/global-sheet.tsx
@@ -36,7 +36,7 @@ export function GlobalSheet() {
 						</SheetDescription>
 					</SheetHeader>
 				) : null}
-				<div className="p-4">{content}</div>
+				<div className="p-4">{content ? content() : null}</div>
 			</SheetContent>
 		</Sheet>
 	);

--- a/packages/web/src/features/orders/components/customer-autocomplete.tsx
+++ b/packages/web/src/features/orders/components/customer-autocomplete.tsx
@@ -50,7 +50,7 @@ export function CustomerAutocomplete({
 		openSheet({
 			title: "Add Customer",
 			description: "Create a new customer record",
-			content: (
+			content: () => (
 				<CustomerSheetContent
 					onSuccess={(newCustomer) => {
 						onValueChange(String(newCustomer.id));

--- a/packages/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/packages/web/src/features/transactions/components/transactions-catalog.tsx
@@ -3,52 +3,63 @@ import {
 	PackageIcon,
 	ScissorsIcon,
 } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Card, CardContent } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { useTransactionsCart } from "@/features/transactions/hooks/use-transactions-cart";
 import {
 	getEntityCategoryName,
 	type TransactionDraftValues,
 } from "@/features/transactions/lib/transactions";
+import { useTransactionsPageContext } from "@/features/transactions/lib/transactions-context";
 import type { Product, Service } from "@/lib/api";
+import {
+	categoriesQueryOptions,
+	productsQueryOptions,
+	servicesQueryOptions,
+} from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { formatIDRCurrency } from "@/shared/utils";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 export function TransactionsCatalog() {
-	const {
-		activeProductCategory,
-		activeServiceCategory,
-		categories,
-		handleAddProduct,
-		handleAddService,
-		handleStoreChange,
-		isAdmin,
-		mode,
-		products,
-		searchTerm,
-		services,
-		setMode,
-		setSearchTerm,
-		visibleStores,
-	} = useTransactionsPageStore();
-	const onAddProduct = handleAddProduct;
-	const onAddService = handleAddService;
+	const { isAdmin, visibleStores, handleStoreChange } =
+		useTransactionsPageContext();
+	const { handleAddProduct, handleAddService } = useTransactionsCart();
+	const mode = useTransactionsPageStore((state) => state.mode);
+	const setMode = useTransactionsPageStore((state) => state.setMode);
+	const searchTerm = useTransactionsPageStore((state) => state.searchTerm);
+	const setSearchTerm = useTransactionsPageStore(
+		(state) => state.setSearchTerm,
+	);
+	const activeProductCategory = useTransactionsPageStore(
+		(state) => state.activeProductCategory,
+	);
+	const activeServiceCategory = useTransactionsPageStore(
+		(state) => state.activeServiceCategory,
+	);
 
-	const form = useFormContext<TransactionDraftValues>();
-	const selectedStoreId =
-		useWatch({
-			control: form.control,
-			name: "selectedStoreId",
-		}) ?? "";
-	const productCart =
-		useWatch({
-			control: form.control,
-			name: "productCart",
-		}) ?? [];
+	const categoriesQuery = useQuery(categoriesQueryOptions());
+	const productsQuery = useQuery(productsQueryOptions());
+	const servicesQuery = useQuery(servicesQueryOptions());
+
+	const categories = categoriesQuery.data ?? [];
+	const products = useMemo(
+		() => (productsQuery.data ?? []).filter((product) => product.is_active),
+		[productsQuery.data],
+	);
+	const services = useMemo(
+		() => (servicesQuery.data ?? []).filter((service) => service.is_active),
+		[servicesQuery.data],
+	);
+
+	const { control } = useFormContext<TransactionDraftValues>();
+	const selectedStoreId = useWatch({ control, name: "selectedStoreId" }) ?? "";
+	const productCart = useWatch({ control, name: "productCart" }) ?? [];
 
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),
@@ -105,8 +116,6 @@ export function TransactionsCatalog() {
 		[productCart],
 	);
 
-	const onSearchTermChange = setSearchTerm;
-	const onModeChange = setMode;
 	return (
 		<div className="grid gap-5 self-start xl:sticky xl:top-0">
 			<Card className="border-border/70 bg-linear-to-br from-background via-background to-card shadow-sm">
@@ -139,7 +148,7 @@ export function TransactionsCatalog() {
 										? "border-foreground bg-foreground text-background"
 										: "border-transparent text-foreground/70 hover:border-border/70 hover:bg-muted/40",
 								)}
-								onClick={() => onModeChange("services")}
+								onClick={() => setMode("services")}
 							>
 								<span className="flex items-center gap-2 text-sm font-medium">
 									<ScissorsIcon className="size-4" />
@@ -154,7 +163,7 @@ export function TransactionsCatalog() {
 										? "border-border bg-card text-foreground"
 										: "border-transparent text-foreground/55 hover:border-border/70 hover:bg-muted/40",
 								)}
-								onClick={() => onModeChange("products")}
+								onClick={() => setMode("products")}
 							>
 								<span className="flex items-center gap-2 text-sm font-medium">
 									<PackageIcon className="size-4" />
@@ -170,7 +179,7 @@ export function TransactionsCatalog() {
 								<Input
 									id="transaction-search"
 									value={searchTerm}
-									onChange={(event) => onSearchTermChange(event.target.value)}
+									onChange={(event) => setSearchTerm(event.target.value)}
 									placeholder="Search services or add-ons"
 									className="h-11 border-border/70 bg-background pl-9"
 								/>
@@ -203,14 +212,14 @@ export function TransactionsCatalog() {
 									className={cn(
 										"grid h-full w-full gap-4 p-4 text-left transition-colors",
 										isProduct ? "hover:bg-muted/30" : "hover:bg-background/80",
-										Boolean(isOutOfStock) && "cursor-not-allowed opacity-50",
+										isOutOfStock && "cursor-not-allowed opacity-50",
 									)}
 									onClick={() =>
 										isProduct
-											? onAddProduct(item as Product)
-											: onAddService(item as Service)
+											? handleAddProduct(item as Product)
+											: handleAddService(item as Service)
 									}
-									disabled={Boolean(isOutOfStock)}
+									disabled={isOutOfStock}
 									aria-label={`Add ${item.name}`}
 								>
 									<div className="grid gap-2">

--- a/packages/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/packages/web/src/features/transactions/components/transactions-checkout.tsx
@@ -6,7 +6,8 @@ import {
 	TrashIcon,
 	XIcon,
 } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { CurrencyInput } from "@/components/form/currency-input";
 import { Badge } from "@/components/ui/badge";
@@ -25,13 +26,23 @@ import {
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { CustomerAutocomplete } from "@/features/orders/components/customer-autocomplete";
+import { useTransactionsCart } from "@/features/transactions/hooks/use-transactions-cart";
 import {
 	getCampaignDiscount,
 	getEntityCategoryName,
+	isCampaignAvailable,
 	type ProductCartDisplayLine,
 	type ServiceCartDisplayLine,
 	type TransactionDraftValues,
 } from "@/features/transactions/lib/transactions";
+import { useTransactionsPageContext } from "@/features/transactions/lib/transactions-context";
+import {
+	campaignsQueryOptions,
+	categoriesQueryOptions,
+	paymentMethodsQueryOptions,
+	productsQueryOptions,
+	servicesQueryOptions,
+} from "@/lib/query-options";
 import { formatIDRCurrency } from "@/shared/utils";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
@@ -60,27 +71,15 @@ function OrderMetaBadge({
 
 export function TransactionsCheckout() {
 	const [paymentSheetOpen, setPaymentSheetOpen] = useState(false);
+	const { visibleStores, submit } = useTransactionsPageContext();
 	const {
-		campaigns,
-		campaignsLoading,
-		categories,
-		handleSubmit,
-		isSubmitting,
-		paymentMethods,
-		paymentMethodsLoading,
-		products,
 		resetCart,
-		services,
-		submitError,
-		visibleStores,
 		removeProductFromCart,
-		updateProductQty,
 		removeServiceFromCart,
-		updateServiceColor,
-		updateServiceBrand,
-		updateServiceModel,
-		updateServiceSize,
-	} = useTransactionsPageStore();
+		updateProductQty,
+		updateServiceField,
+	} = useTransactionsCart();
+	const submitError = useTransactionsPageStore((state) => state.submitError);
 
 	const form = useFormContext<TransactionDraftValues>();
 	const [
@@ -106,6 +105,52 @@ export function TransactionsCheckout() {
 		],
 	});
 
+	const selectedStoreNumber =
+		selectedStoreId && Number.isFinite(Number(selectedStoreId))
+			? Number(selectedStoreId)
+			: undefined;
+
+	const categoriesQuery = useQuery(categoriesQueryOptions());
+	const productsQuery = useQuery(productsQueryOptions());
+	const servicesQuery = useQuery(servicesQueryOptions());
+	const paymentMethodsQuery = useQuery(paymentMethodsQueryOptions());
+	const campaignsQuery = useQuery({
+		...campaignsQueryOptions({
+			store_id: selectedStoreNumber,
+			is_active: true,
+		}),
+		enabled: selectedStoreNumber !== undefined,
+	});
+
+	const categories = categoriesQuery.data ?? [];
+	const products = useMemo(
+		() => (productsQuery.data ?? []).filter((product) => product.is_active),
+		[productsQuery.data],
+	);
+	const services = useMemo(
+		() => (servicesQuery.data ?? []).filter((service) => service.is_active),
+		[servicesQuery.data],
+	);
+	const paymentMethods = paymentMethodsQuery.data ?? [];
+	const availableCampaigns = useMemo(() => {
+		const now = new Date();
+		return (campaignsQuery.data ?? []).filter((campaign) =>
+			isCampaignAvailable(campaign, now),
+		);
+	}, [campaignsQuery.data]);
+
+	useEffect(() => {
+		if (!selectedCampaignId) {
+			return;
+		}
+		const hasCampaign = availableCampaigns.some(
+			(campaign) => campaign.id === Number(selectedCampaignId),
+		);
+		if (!hasCampaign) {
+			form.setValue("selectedCampaignId", "", { shouldValidate: true });
+		}
+	}, [availableCampaigns, form, selectedCampaignId]);
+
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),
 		[categories],
@@ -122,12 +167,12 @@ export function TransactionsCheckout() {
 	const campaignOptions = useMemo<ComboboxOption[]>(
 		() => [
 			{ value: "none", label: "No campaign" },
-			...campaigns.map((campaign) => ({
+			...availableCampaigns.map((campaign) => ({
 				value: String(campaign.id),
 				label: `${campaign.code} - ${campaign.name}`,
 			})),
 		],
-		[campaigns],
+		[availableCampaigns],
 	);
 	const paymentMethodOptions = useMemo<ComboboxOption[]>(
 		() => [
@@ -140,10 +185,6 @@ export function TransactionsCheckout() {
 		[paymentMethods],
 	);
 
-	const selectedStoreNumber =
-		selectedStoreId && Number.isFinite(Number(selectedStoreId))
-			? Number(selectedStoreId)
-			: undefined;
 	const selectedStore = useMemo(
 		() =>
 			selectedStoreNumber
@@ -154,11 +195,11 @@ export function TransactionsCheckout() {
 	const selectedCampaign = useMemo(
 		() =>
 			selectedCampaignId
-				? campaigns.find(
+				? availableCampaigns.find(
 						(campaign) => campaign.id === Number(selectedCampaignId),
 					)
 				: undefined,
-		[campaigns, selectedCampaignId],
+		[availableCampaigns, selectedCampaignId],
 	);
 	const selectedPaymentMethodLabel = useMemo(
 		() =>
@@ -213,6 +254,8 @@ export function TransactionsCheckout() {
 	const total = Math.max(0, subtotal - totalDiscount);
 	const cartCount =
 		productCart.reduce((sum, item) => sum + item.qty, 0) + serviceCart.length;
+
+	const isSubmitting = form.formState.isSubmitting;
 
 	const orderMeta = useMemo(
 		() => [
@@ -384,7 +427,11 @@ export function TransactionsCheckout() {
 												id={`service-color-${line.line_id}`}
 												value={line.color}
 												onChange={(event) =>
-													updateServiceColor(line.line_id, event.target.value)
+													updateServiceField(
+														line.line_id,
+														"color",
+														event.target.value,
+													)
 												}
 												placeholder="e.g. Black"
 											/>
@@ -401,7 +448,11 @@ export function TransactionsCheckout() {
 												id={`service-brand-${line.line_id}`}
 												value={line.brand}
 												onChange={(event) =>
-													updateServiceBrand(line.line_id, event.target.value)
+													updateServiceField(
+														line.line_id,
+														"brand",
+														event.target.value,
+													)
 												}
 												placeholder="e.g. Adidas"
 											/>
@@ -423,7 +474,11 @@ export function TransactionsCheckout() {
 												id={`service-model-${line.line_id}`}
 												value={line.model}
 												onChange={(event) =>
-													updateServiceModel(line.line_id, event.target.value)
+													updateServiceField(
+														line.line_id,
+														"model",
+														event.target.value,
+													)
 												}
 												placeholder="e.g. Yeezy"
 											/>
@@ -445,7 +500,11 @@ export function TransactionsCheckout() {
 												id={`service-size-${line.line_id}`}
 												value={line.size}
 												onChange={(event) =>
-													updateServiceSize(line.line_id, event.target.value)
+													updateServiceField(
+														line.line_id,
+														"size",
+														event.target.value,
+													)
 												}
 												placeholder="e.g. 42"
 											/>
@@ -559,7 +618,7 @@ export function TransactionsCheckout() {
 										onValueChange={(value) =>
 											field.onChange(value === "none" ? "" : value)
 										}
-										loading={campaignsLoading}
+										loading={campaignsQuery.isFetching}
 										placeholder={
 											selectedStoreNumber
 												? "No campaign"
@@ -594,7 +653,7 @@ export function TransactionsCheckout() {
 										onValueChange={(value) =>
 											field.onChange(value === "none" ? "" : value)
 										}
-										loading={paymentMethodsLoading}
+										loading={paymentMethodsQuery.isFetching}
 										placeholder="No payment method"
 										searchPlaceholder="Search payment method..."
 										emptyText="No payment method found"
@@ -722,7 +781,7 @@ export function TransactionsCheckout() {
 						</Button>
 						<Button
 							type="button"
-							onClick={handleSubmit}
+							onClick={submit}
 							loading={isSubmitting}
 							loadingText="Creating order..."
 							disabled={cartCount === 0}

--- a/packages/web/src/features/transactions/hooks/use-transactions-cart.ts
+++ b/packages/web/src/features/transactions/hooks/use-transactions-cart.ts
@@ -1,0 +1,180 @@
+import { useCallback } from "react";
+import { useFormContext } from "react-hook-form";
+import type {
+	ProductCartLine,
+	ServiceCartLine,
+	TransactionDraftValues,
+} from "@/features/transactions/lib/transactions";
+import type { Product, Service } from "@/lib/api";
+import { useTransactionsPageStore } from "@/stores/transactions-store";
+
+function createServiceCartLineId() {
+	return (
+		globalThis.crypto?.randomUUID?.() ??
+		`service-${Date.now()}-${Math.random()}`
+	);
+}
+
+export function useTransactionsCart() {
+	const form = useFormContext<TransactionDraftValues>();
+	const setSubmitError = useTransactionsPageStore(
+		(state) => state.setSubmitError,
+	);
+
+	const setProductCart = useCallback(
+		(nextCart: ProductCartLine[]) => {
+			form.setValue("productCart", nextCart, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		},
+		[form],
+	);
+
+	const setServiceCart = useCallback(
+		(nextCart: ServiceCartLine[]) => {
+			form.setValue("serviceCart", nextCart, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		},
+		[form],
+	);
+
+	const resetCart = useCallback(() => {
+		const selectedStoreId = form.getValues("selectedStoreId");
+		setSubmitError("");
+		form.reset({
+			selectedStoreId,
+			selectedCustomerId: "",
+			selectedCampaignId: "",
+			selectedPaymentMethodId: "",
+			paymentStatus: "unpaid",
+			manualDiscount: "",
+			notes: "",
+			productCart: [],
+			serviceCart: [],
+		});
+	}, [form, setSubmitError]);
+
+	const removeProductFromCart = useCallback(
+		(productId: number) => {
+			setSubmitError("");
+			setProductCart(
+				form.getValues("productCart").filter((line) => line.id !== productId),
+			);
+		},
+		[form, setProductCart, setSubmitError],
+	);
+
+	const removeServiceFromCart = useCallback(
+		(lineId: string) => {
+			setSubmitError("");
+			setServiceCart(
+				form.getValues("serviceCart").filter((line) => line.line_id !== lineId),
+			);
+		},
+		[form, setServiceCart, setSubmitError],
+	);
+
+	const updateProductQty = useCallback(
+		(productId: number, nextQty: number, maxStock: number) => {
+			setSubmitError("");
+			setProductCart(
+				form.getValues("productCart").flatMap((line) => {
+					if (line.id !== productId) {
+						return [line];
+					}
+					if (nextQty <= 0) {
+						return [];
+					}
+					return [
+						{
+							...line,
+							qty: maxStock > 0 ? Math.min(nextQty, maxStock) : nextQty,
+						},
+					];
+				}),
+			);
+		},
+		[form, setProductCart, setSubmitError],
+	);
+
+	const updateServiceField = useCallback(
+		(
+			lineId: string,
+			field: "brand" | "color" | "model" | "size",
+			value: string,
+		) => {
+			setSubmitError("");
+			setServiceCart(
+				form
+					.getValues("serviceCart")
+					.map((line) =>
+						line.line_id === lineId ? { ...line, [field]: value } : line,
+					),
+			);
+		},
+		[form, setServiceCart, setSubmitError],
+	);
+
+	const handleAddProduct = useCallback(
+		(product: Product) => {
+			const currentCart = form.getValues("productCart");
+			const maxStock = Number(product.stock ?? 0);
+			const lineIndex = currentCart.findIndex((line) => line.id === product.id);
+
+			setSubmitError("");
+
+			if (lineIndex >= 0) {
+				const line = currentCart[lineIndex];
+				if (maxStock > 0 && line.qty >= maxStock) {
+					return;
+				}
+				const nextCart = [...currentCart];
+				nextCart[lineIndex] = { ...line, qty: line.qty + 1 };
+				setProductCart(nextCart);
+				return;
+			}
+
+			if (maxStock <= 0) {
+				return;
+			}
+
+			setProductCart([
+				...currentCart,
+				{ kind: "product", id: product.id, qty: 1 },
+			]);
+		},
+		[form, setProductCart, setSubmitError],
+	);
+
+	const handleAddService = useCallback(
+		(service: Service) => {
+			setSubmitError("");
+			setServiceCart([
+				...form.getValues("serviceCart"),
+				{
+					kind: "service",
+					line_id: createServiceCartLineId(),
+					id: service.id,
+					brand: "",
+					color: "",
+					model: "",
+					size: "",
+				},
+			]);
+		},
+		[form, setServiceCart, setSubmitError],
+	);
+
+	return {
+		resetCart,
+		removeProductFromCart,
+		removeServiceFromCart,
+		updateProductQty,
+		updateServiceField,
+		handleAddProduct,
+		handleAddService,
+	};
+}

--- a/packages/web/src/features/transactions/hooks/use-transactions-page.ts
+++ b/packages/web/src/features/transactions/hooks/use-transactions-page.ts
@@ -7,28 +7,18 @@ import { toast } from "sonner";
 import { z } from "zod";
 import { handleCreatedOrderSuccess } from "@/features/orders/lib/create-order-workflow";
 import {
-	isCampaignAvailable,
 	type TransactionDraftValues,
 	toTransactionPayload,
 } from "@/features/transactions/lib/transactions";
+import type { TransactionsPageContextValue } from "@/features/transactions/lib/transactions-context";
 import { createOrder } from "@/lib/api";
 import {
-	campaignsQueryOptions,
-	categoriesQueryOptions,
 	currentUserDetailQueryOptions,
-	paymentMethodsQueryOptions,
-	productsQueryOptions,
-	servicesQueryOptions,
 	storesQueryOptions,
 } from "@/lib/query-options";
 import { getCurrentUser } from "@/stores/auth-store";
 import { useTransactionPreferencesStore } from "@/stores/transaction-preferences-store";
-import {
-	bindTransactionsPageController,
-	clearTransactionsPageController,
-	transactionsPageDataInitialState,
-	useTransactionsPageStore,
-} from "@/stores/transactions-store";
+import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 const defaultDraftValues: TransactionDraftValues = {
 	selectedStoreId: "",
@@ -104,7 +94,13 @@ const transactionDraftSchema = z
 		}
 	});
 
-export function useTransactionsPageBootstrap() {
+export type TransactionsPageBootstrap = {
+	form: ReturnType<typeof useForm<TransactionDraftValues>>;
+	isBootstrapping: boolean;
+	pageContext: TransactionsPageContextValue;
+};
+
+export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const currentUser = getCurrentUser();
@@ -129,17 +125,7 @@ export function useTransactionsPageBootstrap() {
 			control: form.control,
 			name: "selectedStoreId",
 		}) ?? "";
-	const selectedCampaignId =
-		useWatch({
-			control: form.control,
-			name: "selectedCampaignId",
-		}) ?? "";
-
 	const storesQuery = useQuery(storesQueryOptions());
-	const categoriesQuery = useQuery(categoriesQueryOptions());
-	const productsQuery = useQuery(productsQueryOptions());
-	const servicesQuery = useQuery(servicesQueryOptions());
-	const paymentMethodsQuery = useQuery(paymentMethodsQueryOptions());
 	const currentUserDetailQuery = useQuery({
 		...currentUserDetailQueryOptions(currentUser?.id ?? -1),
 		enabled: !!currentUser,
@@ -148,20 +134,19 @@ export function useTransactionsPageBootstrap() {
 	const userStoreIds =
 		currentUserDetailQuery.data?.userStores?.map((item) => item.store_id) ?? [];
 
+	const isAdmin = currentUser?.role === "admin";
+
 	const visibleStores = useMemo(() => {
 		const stores = storesQuery.data ?? [];
-
-		if (currentUser?.role === "admin") {
+		if (isAdmin) {
 			return stores;
 		}
-
 		return stores.filter((store) => userStoreIds.includes(store.id));
-	}, [currentUser?.role, storesQuery.data, userStoreIds]);
+	}, [isAdmin, storesQuery.data, userStoreIds]);
 
 	useEffect(() => {
 		const canResolveStoreSelection =
-			storesQuery.isSuccess &&
-			(currentUser?.role === "admin" || currentUserDetailQuery.isSuccess);
+			storesQuery.isSuccess && (isAdmin || currentUserDetailQuery.isSuccess);
 
 		if (!canResolveStoreSelection || !currentUserKey) {
 			return;
@@ -172,8 +157,7 @@ export function useTransactionsPageBootstrap() {
 			visibleStores.some(
 				(store) => String(store.id) === persistedSelectedStoreId,
 			);
-		const fallbackStoreId =
-			currentUser?.role === "admin" ? "" : String(visibleStores[0]?.id ?? "");
+		const fallbackStoreId = isAdmin ? "" : String(visibleStores[0]?.id ?? "");
 		const nextStoreId = hasPersistedVisibleStore
 			? persistedSelectedStoreId
 			: fallbackStoreId;
@@ -196,10 +180,10 @@ export function useTransactionsPageBootstrap() {
 		}
 	}, [
 		clearPersistedSelectedStoreId,
-		currentUser?.role,
 		currentUserDetailQuery.isSuccess,
 		currentUserKey,
 		form,
+		isAdmin,
 		persistedSelectedStoreId,
 		selectedStoreId,
 		setPersistedSelectedStoreId,
@@ -207,56 +191,8 @@ export function useTransactionsPageBootstrap() {
 		visibleStores,
 	]);
 
-	const selectedStoreNumber =
-		selectedStoreId && Number.isFinite(Number(selectedStoreId))
-			? Number(selectedStoreId)
-			: undefined;
-
-	const campaignsQuery = useQuery({
-		...campaignsQueryOptions({
-			store_id: selectedStoreNumber,
-			is_active: true,
-		}),
-		enabled: selectedStoreNumber !== undefined,
-	});
-
-	const availableCampaigns = useMemo(() => {
-		const now = new Date();
-		return (campaignsQuery.data ?? []).filter((campaign) =>
-			isCampaignAvailable(campaign, now),
-		);
-	}, [campaignsQuery.data]);
-
-	useEffect(() => {
-		if (!selectedCampaignId) {
-			return;
-		}
-
-		const hasCampaign = availableCampaigns.some(
-			(campaign) => campaign.id === Number(selectedCampaignId),
-		);
-
-		if (!hasCampaign) {
-			form.setValue("selectedCampaignId", "", { shouldValidate: true });
-		}
-	}, [availableCampaigns, form, selectedCampaignId]);
-
 	const isBootstrapping =
-		storesQuery.isPending ||
-		categoriesQuery.isPending ||
-		productsQuery.isPending ||
-		servicesQuery.isPending ||
-		paymentMethodsQuery.isPending ||
-		currentUserDetailQuery.isPending;
-
-	const products = useMemo(
-		() => (productsQuery.data ?? []).filter((product) => product.is_active),
-		[productsQuery.data],
-	);
-	const services = useMemo(
-		() => (servicesQuery.data ?? []).filter((service) => service.is_active),
-		[servicesQuery.data],
-	);
+		storesQuery.isPending || currentUserDetailQuery.isPending;
 
 	const createMutation = useMutation({
 		mutationKey: ["create-pos-order"],
@@ -265,7 +201,6 @@ export function useTransactionsPageBootstrap() {
 
 	const resetCart = useCallback(() => {
 		const selectedStore = form.getValues("selectedStoreId");
-
 		useTransactionsPageStore.getState().setSubmitError("");
 		form.reset({
 			...defaultDraftValues,
@@ -316,60 +251,42 @@ export function useTransactionsPageBootstrap() {
 		[form, onValidSubmit],
 	);
 
-	useEffect(() => {
-		bindTransactionsPageController({
-			form,
-			currentUserKey,
-			submit,
-		});
-
-		return () => {
-			clearTransactionsPageController();
-		};
-	}, [currentUserKey, form, submit]);
-
-	const pageState = useMemo(
-		() => ({
-			isBootstrapping,
-			isAdmin: currentUser?.role === "admin",
-			visibleStores,
-			categories: categoriesQuery.data ?? [],
-			products,
-			services,
-			campaigns: availableCampaigns,
-			paymentMethods: paymentMethodsQuery.data ?? [],
-			campaignsLoading: campaignsQuery.isFetching,
-			paymentMethodsLoading: paymentMethodsQuery.isFetching,
-			isSubmitting: createMutation.isPending,
-		}),
-		[
-			availableCampaigns,
-			campaignsQuery.isFetching,
-			categoriesQuery.data,
-			createMutation.isPending,
-			currentUser?.role,
-			isBootstrapping,
-			paymentMethodsQuery.data,
-			paymentMethodsQuery.isFetching,
-			products,
-			services,
-			visibleStores,
-		],
+	const handleStoreChange = useCallback(
+		(value: string) => {
+			useTransactionsPageStore.getState().setSubmitError("");
+			form.setValue("selectedStoreId", value, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+			if (currentUserKey) {
+				useTransactionPreferencesStore
+					.getState()
+					.setSelectedStoreId(currentUserKey, value);
+			}
+			form.setValue("selectedCampaignId", "", {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		},
+		[currentUserKey, form],
 	);
-
-	useEffect(() => {
-		useTransactionsPageStore.setState(pageState);
-	}, [pageState]);
 
 	useEffect(
 		() => () => {
-			clearTransactionsPageController();
-			useTransactionsPageStore.setState(transactionsPageDataInitialState);
+			useTransactionsPageStore.getState().resetUi();
 		},
 		[],
 	);
 
-	return form;
-}
+	const pageContext = useMemo<TransactionsPageContextValue>(
+		() => ({
+			isAdmin,
+			visibleStores,
+			submit,
+			handleStoreChange,
+		}),
+		[handleStoreChange, isAdmin, submit, visibleStores],
+	);
 
-export const useTransactionsPage = useTransactionsPageBootstrap;
+	return { form, isBootstrapping, pageContext };
+}

--- a/packages/web/src/features/transactions/lib/transactions-context.tsx
+++ b/packages/web/src/features/transactions/lib/transactions-context.tsx
@@ -1,0 +1,34 @@
+import { createContext, type ReactNode, use } from "react";
+import type { Store } from "@/lib/api";
+
+export type TransactionsPageContextValue = {
+	isAdmin: boolean;
+	visibleStores: Store[];
+	submit: () => void;
+	handleStoreChange: (value: string) => void;
+};
+
+const TransactionsPageContext =
+	createContext<TransactionsPageContextValue | null>(null);
+
+export function TransactionsPageProvider({
+	value,
+	children,
+}: {
+	value: TransactionsPageContextValue;
+	children: ReactNode;
+}) {
+	return (
+		<TransactionsPageContext value={value}>{children}</TransactionsPageContext>
+	);
+}
+
+export function useTransactionsPageContext() {
+	const value = use(TransactionsPageContext);
+	if (!value) {
+		throw new Error(
+			"useTransactionsPageContext must be used within TransactionsPageProvider",
+		);
+	}
+	return value;
+}

--- a/packages/web/src/routes/_admin/campaigns.tsx
+++ b/packages/web/src/routes/_admin/campaigns.tsx
@@ -124,7 +124,7 @@ function DeleteCampaignButton({
 				openDialog({
 					title: "Delete campaign?",
 					description: `Delete ${campaign.code} (${campaign.name})? This cannot be undone.`,
-					footer: (
+					footer: () => (
 						<>
 							<Button variant="outline" onClick={closeDialog}>
 								Cancel
@@ -213,7 +213,7 @@ function CampaignsPage() {
 	const handleOpenCreateSheet = () => {
 		openSheet({
 			title: "Add Campaign",
-			content: (
+			content: () => (
 				<CampaignForm
 					defaultValues={defaultCampaignForm}
 					isEditing={false}
@@ -231,7 +231,7 @@ function CampaignsPage() {
 		(campaign: Campaign) => {
 			openSheet({
 				title: "Edit Campaign",
-				content: (
+				content: () => (
 					<CampaignForm
 						defaultValues={{
 							code: campaign.code,

--- a/packages/web/src/routes/_admin/categories.tsx
+++ b/packages/web/src/routes/_admin/categories.tsx
@@ -50,7 +50,7 @@ const CategoriesActions = ({ row }: { row: Row<Category> }) => {
 		openSheet({
 			title: "Edit Category",
 			description: `Editing ID ${category.id}`,
-			content: (
+			content: () => (
 				<CategoryForm
 					defaultValues={{
 						name: category.name,
@@ -129,7 +129,7 @@ function CategoriesPage() {
 		openSheet({
 			title: "Add Category",
 			description: "Create a new category",
-			content: (
+			content: () => (
 				<CategoryForm
 					handleOnSubmit={async (values: CategoryFormState) => {
 						await createMutation.mutateAsync(values);

--- a/packages/web/src/routes/_admin/customers.tsx
+++ b/packages/web/src/routes/_admin/customers.tsx
@@ -52,7 +52,7 @@ function CustomersPage() {
 		(customer: Customer) => {
 			openSheet({
 				title: "Edit Customer",
-				content: <CustomerSheetContent editingCustomer={customer} />,
+				content: () => <CustomerSheetContent editingCustomer={customer} />,
 			});
 		},
 		[openSheet],
@@ -61,7 +61,7 @@ function CustomersPage() {
 	const handleOpenCreateSheet = useCallback(() => {
 		openSheet({
 			title: "Add Customer",
-			content: <CustomerSheetContent />,
+			content: () => <CustomerSheetContent />,
 		});
 	}, [openSheet]);
 

--- a/packages/web/src/routes/_admin/orders.$orderId.tsx
+++ b/packages/web/src/routes/_admin/orders.$orderId.tsx
@@ -168,7 +168,7 @@ function ServiceStatusUpdateButton({
 			description: isCancel
 				? "Please provide a reason for cancelling this service."
 				: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
-			content: (
+			content: () => (
 				<DialogForm
 					orderId={orderId}
 					isCancel={isCancel}

--- a/packages/web/src/routes/_admin/orders.index.tsx
+++ b/packages/web/src/routes/_admin/orders.index.tsx
@@ -185,7 +185,7 @@ function OrdersPage() {
 		openSheet({
 			title: "Pickup Radar",
 			description: "Orders that can leave the store now.",
-			content: <PickupRadar orders={orders} />,
+			content: () => <PickupRadar orders={orders} />,
 		});
 	}, [openSheet, orders]);
 

--- a/packages/web/src/routes/_admin/payment-methods.tsx
+++ b/packages/web/src/routes/_admin/payment-methods.tsx
@@ -69,7 +69,7 @@ function PaymentMethodsPage() {
 		(paymentMethod: PaymentMethod) => {
 			openSheet({
 				title: "Edit Payment Method",
-				content: (
+				content: () => (
 					<PaymentMethodForm
 						defaultValues={{
 							name: paymentMethod.name,
@@ -94,7 +94,7 @@ function PaymentMethodsPage() {
 	const handleOpenCreateSheet = useCallback(() => {
 		openSheet({
 			title: "Add Payment Method",
-			content: (
+			content: () => (
 				<PaymentMethodForm
 					handleOnSubmit={async (values: PaymentMethodFormState) => {
 						await createMutation.mutateAsync(values);

--- a/packages/web/src/routes/_admin/products.tsx
+++ b/packages/web/src/routes/_admin/products.tsx
@@ -64,7 +64,7 @@ function ProductsPage() {
 		(product: Product) => {
 			openSheet({
 				title: "Edit Product",
-				content: (
+				content: () => (
 					<ProductForm
 						defaultValues={{
 							name: product.name,
@@ -95,7 +95,7 @@ function ProductsPage() {
 	const handleOpenCreateSheet = useCallback(() => {
 		openSheet({
 			title: "Add Product",
-			content: (
+			content: () => (
 				<ProductForm
 					handleOnSubmit={async (values: ProductFormState) => {
 						await createMutation.mutateAsync(values);

--- a/packages/web/src/routes/_admin/services.tsx
+++ b/packages/web/src/routes/_admin/services.tsx
@@ -64,7 +64,7 @@ function ServicesPage() {
 		(service: Service) => {
 			openSheet({
 				title: "Edit Service",
-				content: (
+				content: () => (
 					<ServiceForm
 						defaultValues={{
 							category_id: service.category_id,
@@ -94,7 +94,7 @@ function ServicesPage() {
 	const handleOpenCreateSheet = useCallback(() => {
 		openSheet({
 			title: "Add Service",
-			content: (
+			content: () => (
 				<ServiceForm
 					handleOnSubmit={async (values: ServiceFormState) => {
 						await createMutation.mutateAsync(values);

--- a/packages/web/src/routes/_admin/stores.tsx
+++ b/packages/web/src/routes/_admin/stores.tsx
@@ -58,7 +58,7 @@ function StoresPage() {
 		(store: Store) => {
 			openSheet({
 				title: "Edit Store",
-				content: (
+				content: () => (
 					<StoreForm
 						defaultValues={{
 							code: store.code,
@@ -87,7 +87,7 @@ function StoresPage() {
 	const handleOpenCreateSheet = useCallback(() => {
 		openSheet({
 			title: "Add Store",
-			content: (
+			content: () => (
 				<StoreForm
 					handleOnSubmit={async (values: StoreFormState) => {
 						await createMutation.mutateAsync(values);

--- a/packages/web/src/routes/_admin/transactions.tsx
+++ b/packages/web/src/routes/_admin/transactions.tsx
@@ -3,6 +3,7 @@ import { FormProvider } from "react-hook-form";
 import { Card, CardContent } from "@/components/ui/card";
 import { TransactionsWorkspace } from "@/features/transactions/components/transactions-workspace";
 import { useTransactionsPageBootstrap } from "@/features/transactions/hooks/use-transactions-page";
+import { TransactionsPageProvider } from "@/features/transactions/lib/transactions-context";
 import {
 	campaignsQueryOptions,
 	categoriesQueryOptions,
@@ -13,7 +14,6 @@ import {
 	storesQueryOptions,
 } from "@/lib/query-options";
 import { getCurrentUser } from "@/stores/auth-store";
-import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 export const Route = createFileRoute("/_admin/transactions")({
 	loader: async ({ context }) => {
@@ -52,10 +52,7 @@ export const Route = createFileRoute("/_admin/transactions")({
 });
 
 function TransactionsPage() {
-	const form = useTransactionsPageBootstrap();
-	const isBootstrapping = useTransactionsPageStore(
-		(state) => state.isBootstrapping,
-	);
+	const { form, isBootstrapping, pageContext } = useTransactionsPageBootstrap();
 
 	if (isBootstrapping) {
 		return (
@@ -71,7 +68,9 @@ function TransactionsPage() {
 
 	return (
 		<FormProvider {...form}>
-			<TransactionsWorkspace />
+			<TransactionsPageProvider value={pageContext}>
+				<TransactionsWorkspace />
+			</TransactionsPageProvider>
 		</FormProvider>
 	);
 }

--- a/packages/web/src/routes/_admin/users.tsx
+++ b/packages/web/src/routes/_admin/users.tsx
@@ -208,7 +208,7 @@ function UsersPage() {
 			});
 			openSheet({
 				title: "Edit User",
-				content: (
+				content: () => (
 					<FormProvider {...form}>
 						<UserForm
 							onSubmit={handleSubmit}
@@ -228,7 +228,7 @@ function UsersPage() {
 		form.reset(defaultForm);
 		openSheet({
 			title: "Add User",
-			content: (
+			content: () => (
 				<FormProvider {...form}>
 					<UserForm
 						onSubmit={handleSubmit}

--- a/packages/web/src/stores/dialog-store.ts
+++ b/packages/web/src/stores/dialog-store.ts
@@ -1,19 +1,21 @@
 import type { ReactNode } from "react";
 import { create } from "zustand";
 
+type RenderNode = () => ReactNode;
+
 type DialogState = {
 	open: boolean;
 	title: string | null;
 	description: string | null;
-	content: ReactNode | null;
-	footer: ReactNode | null;
+	content: RenderNode | null;
+	footer: RenderNode | null;
 };
 
 type OpenDialogPayload = {
 	title?: string | null;
 	description?: string | null;
-	content?: ReactNode | null;
-	footer?: ReactNode | null;
+	content?: RenderNode | null;
+	footer?: RenderNode | null;
 };
 
 type DialogStore = {

--- a/packages/web/src/stores/sheet-store.ts
+++ b/packages/web/src/stores/sheet-store.ts
@@ -1,17 +1,19 @@
 import type { ReactNode } from "react";
 import { create } from "zustand";
 
+type RenderNode = () => ReactNode;
+
 type SheetState = {
 	open: boolean;
 	title: string | null;
 	description: string | null;
-	content: ReactNode | null;
+	content: RenderNode | null;
 };
 
 type OpenSheetPayload = {
 	title?: string | null;
 	description?: string | null;
-	content: ReactNode;
+	content: RenderNode;
 };
 
 type SheetStore = {

--- a/packages/web/src/stores/transactions-store.ts
+++ b/packages/web/src/stores/transactions-store.ts
@@ -1,161 +1,40 @@
-import type { UseFormReturn } from "react-hook-form";
 import { create } from "zustand";
 import type {
 	CatalogMode,
 	CategoryFilter,
-	TransactionDraftValues,
 } from "@/features/transactions/lib/transactions";
-import type {
-	Campaign,
-	Category,
-	PaymentMethod,
-	Product,
-	Service,
-	Store,
-} from "@/lib/api";
-import { useTransactionPreferencesStore } from "@/stores/transaction-preferences-store";
 
-type TransactionsPageController = {
-	form: UseFormReturn<TransactionDraftValues>;
-	currentUserKey: string;
-	submit: () => void;
-};
-
-type TransactionsPageActions = {
-	setMode: (mode: CatalogMode) => void;
-	setSearchTerm: (value: string) => void;
-	setActiveProductCategory: (category: CategoryFilter) => void;
-	setActiveServiceCategory: (category: CategoryFilter) => void;
-	setSubmitError: (message: string) => void;
-	handleStoreChange: (value: string) => void;
-	resetCart: () => void;
-	removeProductFromCart: (productId: number) => void;
-	removeServiceFromCart: (lineId: string) => void;
-	updateProductQty: (
-		productId: number,
-		nextQty: number,
-		maxStock: number,
-	) => void;
-	updateServiceColor: (lineId: string, value: string) => void;
-	updateServiceBrand: (lineId: string, value: string) => void;
-	updateServiceModel: (lineId: string, value: string) => void;
-	updateServiceSize: (lineId: string, value: string) => void;
-	handleAddProduct: (product: Product) => void;
-	handleAddService: (service: Service) => void;
-	handleSubmit: () => void;
-};
-
-export type TransactionsPageData = {
-	isBootstrapping: boolean;
-	isAdmin: boolean;
+type TransactionsPageUiState = {
 	mode: CatalogMode;
 	searchTerm: string;
 	activeProductCategory: CategoryFilter;
 	activeServiceCategory: CategoryFilter;
 	submitError: string;
-	visibleStores: Store[];
-	categories: Category[];
-	products: Product[];
-	services: Service[];
-	campaigns: Campaign[];
-	paymentMethods: PaymentMethod[];
-	campaignsLoading: boolean;
-	paymentMethodsLoading: boolean;
-	isSubmitting: boolean;
 };
 
-export type TransactionsPageStore = TransactionsPageData &
-	TransactionsPageActions;
+type TransactionsPageUiActions = {
+	setMode: (mode: CatalogMode) => void;
+	setSearchTerm: (value: string) => void;
+	setActiveProductCategory: (category: CategoryFilter) => void;
+	setActiveServiceCategory: (category: CategoryFilter) => void;
+	setSubmitError: (message: string) => void;
+	resetUi: () => void;
+};
 
-export const transactionsPageDataInitialState: TransactionsPageData = {
-	isBootstrapping: true,
-	isAdmin: false,
+export type TransactionsPageStore = TransactionsPageUiState &
+	TransactionsPageUiActions;
+
+const initialUiState: TransactionsPageUiState = {
 	mode: "services",
 	searchTerm: "",
 	activeProductCategory: "all",
 	activeServiceCategory: "all",
 	submitError: "",
-	visibleStores: [],
-	categories: [],
-	products: [],
-	services: [],
-	campaigns: [],
-	paymentMethods: [],
-	campaignsLoading: false,
-	paymentMethodsLoading: false,
-	isSubmitting: false,
 };
-
-let transactionsPageController: TransactionsPageController | null = null;
-
-export function bindTransactionsPageController(
-	controller: TransactionsPageController,
-) {
-	transactionsPageController = controller;
-}
-
-export function clearTransactionsPageController() {
-	transactionsPageController = null;
-}
-
-function getTransactionsPageController() {
-	if (!transactionsPageController) {
-		throw new Error("Transactions page controller is not initialized.");
-	}
-
-	return transactionsPageController;
-}
-
-function createServiceCartLineId() {
-	return (
-		globalThis.crypto?.randomUUID?.() ??
-		`service-${Date.now()}-${Math.random()}`
-	);
-}
-
-function setProductCart(
-	form: UseFormReturn<TransactionDraftValues>,
-	nextCart: TransactionDraftValues["productCart"],
-) {
-	form.setValue("productCart", nextCart, {
-		shouldDirty: true,
-		shouldValidate: true,
-	});
-}
-
-function setServiceCart(
-	form: UseFormReturn<TransactionDraftValues>,
-	nextCart: TransactionDraftValues["serviceCart"],
-) {
-	form.setValue("serviceCart", nextCart, {
-		shouldDirty: true,
-		shouldValidate: true,
-	});
-}
-
-function getNextProductCart(
-	form: UseFormReturn<TransactionDraftValues>,
-	updater: (
-		currentCart: TransactionDraftValues["productCart"],
-	) => TransactionDraftValues["productCart"],
-) {
-	const currentCart = form.getValues("productCart");
-	setProductCart(form, updater(currentCart));
-}
-
-function getNextServiceCart(
-	form: UseFormReturn<TransactionDraftValues>,
-	updater: (
-		currentCart: TransactionDraftValues["serviceCart"],
-	) => TransactionDraftValues["serviceCart"],
-) {
-	const currentCart = form.getValues("serviceCart");
-	setServiceCart(form, updater(currentCart));
-}
 
 export const useTransactionsPageStore = create<TransactionsPageStore>()(
 	(set) => ({
-		...transactionsPageDataInitialState,
+		...initialUiState,
 		setMode: (mode) => set({ mode }),
 		setSearchTerm: (searchTerm) => set({ searchTerm }),
 		setActiveProductCategory: (activeProductCategory) =>
@@ -163,171 +42,6 @@ export const useTransactionsPageStore = create<TransactionsPageStore>()(
 		setActiveServiceCategory: (activeServiceCategory) =>
 			set({ activeServiceCategory }),
 		setSubmitError: (submitError) => set({ submitError }),
-		handleStoreChange: (value) => {
-			const { currentUserKey, form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			form.setValue("selectedStoreId", value, {
-				shouldDirty: true,
-				shouldValidate: true,
-			});
-
-			if (currentUserKey) {
-				useTransactionPreferencesStore
-					.getState()
-					.setSelectedStoreId(currentUserKey, value);
-			}
-
-			form.setValue("selectedCampaignId", "", {
-				shouldDirty: true,
-				shouldValidate: true,
-			});
-		},
-		resetCart: () => {
-			const { form } = getTransactionsPageController();
-			const selectedStoreId = form.getValues("selectedStoreId");
-
-			set({ submitError: "" });
-			form.reset({
-				selectedStoreId,
-				selectedCustomerId: "",
-				selectedCampaignId: "",
-				selectedPaymentMethodId: "",
-				paymentStatus: "unpaid",
-				manualDiscount: "",
-				notes: "",
-				productCart: [],
-				serviceCart: [],
-			});
-		},
-		removeProductFromCart: (productId) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextProductCart(form, (currentCart) =>
-				currentCart.filter((line) => line.id !== productId),
-			);
-		},
-		removeServiceFromCart: (lineId) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextServiceCart(form, (currentCart) =>
-				currentCart.filter((line) => line.line_id !== lineId),
-			);
-		},
-		updateProductQty: (productId, nextQty, maxStock) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextProductCart(form, (currentCart) =>
-				currentCart.flatMap((line) => {
-					if (line.id !== productId) {
-						return [line];
-					}
-
-					if (nextQty <= 0) {
-						return [];
-					}
-
-					return [
-						{
-							...line,
-							qty: maxStock > 0 ? Math.min(nextQty, maxStock) : nextQty,
-						},
-					];
-				}),
-			);
-		},
-		updateServiceColor: (lineId, value) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextServiceCart(form, (currentCart) =>
-				currentCart.map((line) =>
-					line.line_id === lineId ? { ...line, color: value } : line,
-				),
-			);
-		},
-		updateServiceBrand: (lineId, value) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextServiceCart(form, (currentCart) =>
-				currentCart.map((line) =>
-					line.line_id === lineId ? { ...line, brand: value } : line,
-				),
-			);
-		},
-		updateServiceModel: (lineId, value) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextServiceCart(form, (currentCart) =>
-				currentCart.map((line) =>
-					line.line_id === lineId ? { ...line, model: value } : line,
-				),
-			);
-		},
-		updateServiceSize: (lineId, value) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			getNextServiceCart(form, (currentCart) =>
-				currentCart.map((line) =>
-					line.line_id === lineId ? { ...line, size: value } : line,
-				),
-			);
-		},
-		handleAddProduct: (product) => {
-			const { form } = getTransactionsPageController();
-			const currentCart = form.getValues("productCart");
-			const nextCart = [...currentCart];
-			const lineIndex = nextCart.findIndex((line) => line.id === product.id);
-			const maxStock = Number(product.stock ?? 0);
-
-			set({ submitError: "" });
-
-			if (lineIndex >= 0) {
-				const line = nextCart[lineIndex];
-
-				if (maxStock > 0 && line.qty >= maxStock) {
-					return;
-				}
-
-				nextCart[lineIndex] = { ...line, qty: line.qty + 1 };
-				setProductCart(form, nextCart);
-				return;
-			}
-
-			if (maxStock <= 0) {
-				return;
-			}
-
-			setProductCart(form, [
-				...nextCart,
-				{ kind: "product", id: product.id, qty: 1 },
-			]);
-		},
-		handleAddService: (service) => {
-			const { form } = getTransactionsPageController();
-
-			set({ submitError: "" });
-			setServiceCart(form, [
-				...form.getValues("serviceCart"),
-				{
-					kind: "service",
-					line_id: createServiceCartLineId(),
-					id: service.id,
-					brand: "",
-					color: "",
-					model: "",
-					size: "",
-				},
-			]);
-		},
-		handleSubmit: () => {
-			getTransactionsPageController().submit();
-		},
+		resetUi: () => set(initialUiState),
 	}),
 );


### PR DESCRIPTION
## Summary
- **SM1 + SM2**: Remove the `transactionsPageController` module-level singleton and the `useEffect` that copied server data into Zustand. Zustand now holds only UI state (mode, searchTerm, active categories, submitError). Cart mutations live in a new `useTransactionsCart` hook (uses `useFormContext`). Page meta (isAdmin, visibleStores, submit, handleStoreChange) flows through a new `TransactionsPageProvider`. Catalog and checkout read reference data from TanStack Query directly.
- **SM4**: `useSheet`/`useDialog` now store `() => ReactNode` render functions instead of pre-built `ReactNode`. `GlobalSheet`/`GlobalDialog` invoke the function during their own render, so hooks inside the content re-run and see fresh data. All 14 call sites updated.

23 files changed, +455/-539. Type-check and Ultracite clean.

## Test plan
- [ ] POS /transactions: store selector loads, persisted store restores, campaign clears on store change
- [ ] POS cart: add/remove products and services, qty +/-, service color/brand/model/size updates
- [ ] POS checkout: submit flow (paid + unpaid), validation errors, reset
- [ ] Sheet-driven CRUD across categories/customers/products/services/stores/users/payment-methods/campaigns still opens and submits correctly
- [ ] Orders detail status-change dialog still works
- [ ] Pickup radar sheet still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)