### PR TITLE
refactor(media): CDN-based image URLs + error/404 page polish

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,25 @@
+# TODO
+
+## AWS / CDN follow-ups
+
+- [ ] **Custom domain for CloudFront** — `cdn.fresclean.com`
+  - Request ACM cert in `us-east-1` (CloudFront requirement, not `ap-southeast-3`)
+  - Validate cert via DNS (CNAME at registrar)
+  - Attach cert + alternate domain name to distribution `d3jemt9o5eygkv`
+  - Add DNS CNAME: `cdn.fresclean.com` → `d3jemt9o5eygkv.cloudfront.net`
+  - Swap `CDN_BASE_URL` in `packages/server/.env` to `https://cdn.fresclean.com`
+  - ~20 min total
+
+- [ ] **Billing budget alert** — protect against surprise charges
+  - Console → Billing → Budgets → Create budget
+  - Monthly cost budget, $10 USD threshold
+  - Email alert at 80% actual + 100% forecasted
+
+- [ ] **Enable MFA on AWS root account** — security baseline
+  - IAM → Security credentials → Assign MFA device
+  - Use authenticator app (1Password, Authy, etc.)
+
+- [ ] **Prod environment separation** — decide strategy
+  - Option A: separate bucket + distribution per env (cleanest)
+  - Option B: single bucket with `dev/` / `prod/` key prefixes (cheaper, simpler)
+  - Recommendation: Option A for prod isolation

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -313,9 +313,8 @@ export const ordersTable = pgTable(
     customer_id: integer("customer_id")
       .references(() => customersTable.id)
       .notNull(),
-    intake_photo_s3_key: varchar("intake_photo_s3_key", { length: 512 }),
+    intake_photo_path: varchar("intake_photo_path", { length: 512 }),
     intake_photo_uploaded_at: timestamp("intake_photo_uploaded_at"),
-    intake_photo_url: varchar("intake_photo_url", { length: 255 }),
     discount_source: discountSourceEnum("discount_source")
       .default("none")
       .notNull(),
@@ -454,7 +453,7 @@ export const ordersServicesTable = pgTable(
 export const orderServicesImagesTable = pgTable("order_services_images", {
   created_at: timestamp("created_at").defaultNow().notNull(),
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  image_url: varchar("image_url", { length: 255 }).notNull(),
+  image_path: varchar("image_path", { length: 512 }).notNull(),
   photo_type: orderServicePhotoTypeEnum("photo_type")
     .default("progress")
     .notNull(),
@@ -462,7 +461,6 @@ export const orderServicesImagesTable = pgTable("order_services_images", {
     () => ordersServicesTable.id,
     { onDelete: "cascade" }
   ),
-  s3_key: varchar("s3_key", { length: 512 }).default("").notNull(),
   uploaded_by: integer("uploaded_by").references(() => usersTable.id),
   updated_at: timestamp("updated_at")
     .defaultNow()

--- a/packages/server/src/db/seed/run-seed.ts
+++ b/packages/server/src/db/seed/run-seed.ts
@@ -29,7 +29,6 @@ const ADMIN_PASSWORD = "rojpyp-2cuzdo-rozmoP";
 const CUSTOMER_COUNT = 120;
 const ORDER_COUNT = 180;
 const ORDER_LOOKBACK_DAYS = 45;
-const PHOTO_BASE_URL = "https://picsum.photos/seed";
 
 const STORE_PRESETS = [
   {
@@ -288,15 +287,6 @@ function createStatusNote(nextStatus: OrderServiceStatus): string {
     "Service cancelled and removed from active work queue",
     "Cancellation recorded in the service timeline",
   ]);
-}
-
-function createDummyPhotoUrl(
-  itemCode: string,
-  photoType: "dropoff" | "progress" | "pickup",
-  photoIndex: number
-): string {
-  const seed = sanitizeForS3(`${itemCode}-${photoType}-${photoIndex + 1}`);
-  return `${PHOTO_BASE_URL}/${seed}/960/720`;
 }
 
 function pickWeighted<T>(items: Array<{ item: T; weight: number }>): T {
@@ -1206,16 +1196,11 @@ async function seedOrders(params: {
     const photoRows = draftServices.flatMap((line) =>
       line.photos.map((photo, photoIndex) => {
         const safeItem = sanitizeForS3(line.item_code);
-        const s3Key = `seed/orders/${safeOrderCode}/${safeItem}/${photo.photo_type}-${photoIndex + 1}.jpg`;
+        const imagePath = `seed/orders/${safeOrderCode}/${safeItem}/${photo.photo_type}-${photoIndex + 1}.jpg`;
         return {
           order_service_id: serviceIdByItemCode.get(line.item_code) ?? 0,
           photo_type: photo.photo_type,
-          image_url: createDummyPhotoUrl(
-            line.item_code,
-            photo.photo_type,
-            photoIndex
-          ),
-          s3_key: s3Key,
+          image_path: imagePath,
           uploaded_by: photo.uploaded_by,
           created_at: photo.created_at,
           updated_at: photo.created_at,

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -52,11 +52,11 @@ export const POSTOrderIntakePhotoPresignSchema = z.object({
 
 export const POSTOrderServicePhotoSchema = z.object({
   photo_type: z.enum(orderServicePhotoTypeEnum.enumValues),
-  s3_key: z.string().trim().min(1).max(512),
+  image_path: z.string().trim().min(1).max(512),
 });
 
 export const PUTOrderIntakePhotoSchema = z.object({
-  s3_key: z.string().trim().min(1).max(512),
+  image_path: z.string().trim().min(1).max(512),
 });
 
 export const PATCHOrderServiceStatusSchema = z.object({

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -39,7 +39,7 @@ import {
 import type { JWTPayload } from "@/types";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
 import { buildPaginationMeta } from "@/utils/pagination";
-import { buildS3ObjectUrl, createPresignedUploadUrl } from "@/utils/s3";
+import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
 
 const numericSearchRegex = /^\d+$/;
 
@@ -573,6 +573,14 @@ export async function getOrderDetailById(id: number) {
 
   return {
     ...detail,
+    intake_photo_url: buildMediaUrl(detail.intake_photo_path),
+    services: detail.services.map((service) => ({
+      ...service,
+      images: service.images.map((image) => ({
+        ...image,
+        image_url: buildMediaUrl(image.image_path),
+      })),
+    })),
     fulfillment: summarizeOrderFulfillment(
       detail.services.map((service) => service.status)
     ),
@@ -909,13 +917,15 @@ export async function saveOrderServicePhoto({
     .values({
       order_service_id: serviceId,
       photo_type: body.photo_type,
-      s3_key: body.s3_key,
-      image_url: buildS3ObjectUrl(body.s3_key),
+      image_path: body.image_path,
       uploaded_by: user.id,
     })
     .returning();
 
-  return photo;
+  return {
+    ...photo,
+    image_url: buildMediaUrl(photo.image_path),
+  };
 }
 
 export async function saveOrderIntakePhoto({
@@ -930,23 +940,26 @@ export async function saveOrderIntakePhoto({
   const [order] = await db
     .update(ordersTable)
     .set({
-      intake_photo_s3_key: body.s3_key,
+      intake_photo_path: body.image_path,
       intake_photo_uploaded_at: new Date(),
-      intake_photo_url: buildS3ObjectUrl(body.s3_key),
       updated_by: user.id,
     })
     .where(eq(ordersTable.id, orderId))
     .returning({
       id: ordersTable.id,
       intake_photo_uploaded_at: ordersTable.intake_photo_uploaded_at,
-      intake_photo_url: ordersTable.intake_photo_url,
+      intake_photo_path: ordersTable.intake_photo_path,
     });
 
   if (!order) {
     throw new BadRequestException("Order not found");
   }
 
-  return order;
+  return {
+    id: order.id,
+    intake_photo_uploaded_at: order.intake_photo_uploaded_at,
+    intake_photo_url: buildMediaUrl(order.intake_photo_path),
+  };
 }
 
 export async function completeOrderPickup({

--- a/packages/server/src/routes/public/orders.ts
+++ b/packages/server/src/routes/public/orders.ts
@@ -1,22 +1,16 @@
-import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
 import { db } from "@/db";
+import { phoneSchema } from "@/schema/common";
 import { failure, success } from "@/utils/http";
 import { buildMediaUrl } from "@/utils/s3";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
 
 const POSTPublicTrackOrderSchema = z.object({
   code: z.string().trim().min(1).max(32),
-  phone_number: z.string().trim().min(6).max(20),
+  phone_number: phoneSchema,
 });
-
-const nonDigitRegex = /\D/g;
-
-function normalizePhoneNumber(value: string) {
-  return value.replace(nonDigitRegex, "");
-}
 
 function maskPhoneNumber(phone: string) {
   const suffix = phone.slice(-4);
@@ -28,13 +22,9 @@ const app = new Hono().post(
   zodValidator("json", POSTPublicTrackOrderSchema),
   async (c) => {
     const { code, phone_number } = c.req.valid("json");
-    const normalizedPhone = normalizePhoneNumber(phone_number);
 
     const customer = await db.query.customersTable.findFirst({
-      where: {
-        RAW: (c2) =>
-          sql`REGEXP_REPLACE(${c2.phone_number}, '[^0-9]', '', 'g') = ${normalizedPhone}`,
-      },
+      where: { phone_number },
       columns: { id: true },
     });
 

--- a/packages/server/src/routes/public/orders.ts
+++ b/packages/server/src/routes/public/orders.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
 import { db } from "@/db";
 import { failure, success } from "@/utils/http";
+import { buildMediaUrl } from "@/utils/s3";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
 
 const POSTPublicTrackOrderSchema = z.object({
@@ -41,7 +42,7 @@ const app = new Hono().post(
         id: true,
         code: true,
         intake_photo_uploaded_at: true,
-        intake_photo_url: true,
+        intake_photo_path: true,
         status: true,
         payment_status: true,
         discount: true,
@@ -108,12 +109,14 @@ const app = new Hono().post(
       );
     }
 
+    const { intake_photo_path, ...rest } = order;
     const customer = order.customer;
 
     return c.json(
       success(
         {
-          ...order,
+          ...rest,
+          intake_photo_url: buildMediaUrl(intake_photo_path),
           services: order.services,
           customer: {
             id: customer.id,

--- a/packages/server/src/routes/public/orders.ts
+++ b/packages/server/src/routes/public/orders.ts
@@ -30,13 +30,25 @@ const app = new Hono().post(
     const { code, phone_number } = c.req.valid("json");
     const normalizedPhone = normalizePhoneNumber(phone_number);
 
+    const customer = await db.query.customersTable.findFirst({
+      where: {
+        RAW: (c2) =>
+          sql`REGEXP_REPLACE(${c2.phone_number}, '[^0-9]', '', 'g') = ${normalizedPhone}`,
+      },
+      columns: { id: true },
+    });
+
+    if (!customer) {
+      return c.json(
+        failure("Order code or phone number is invalid"),
+        StatusCodes.NOT_FOUND
+      );
+    }
+
     const order = await db.query.ordersTable.findFirst({
       where: {
         code,
-        customer: {
-          RAW: (customer) =>
-            sql`REGEXP_REPLACE(${customer.phone_number}, '\D', '', 'g') = ${normalizedPhone}`,
-        },
+        customer_id: customer.id,
       },
       columns: {
         id: true,
@@ -110,7 +122,7 @@ const app = new Hono().post(
     }
 
     const { intake_photo_path, ...rest } = order;
-    const customer = order.customer;
+    const orderCustomer = order.customer;
 
     return c.json(
       success(
@@ -119,9 +131,9 @@ const app = new Hono().post(
           intake_photo_url: buildMediaUrl(intake_photo_path),
           services: order.services,
           customer: {
-            id: customer.id,
-            name: customer.name,
-            phone_number_masked: maskPhoneNumber(customer.phone_number),
+            id: orderCustomer.id,
+            name: orderCustomer.name,
+            phone_number_masked: maskPhoneNumber(orderCustomer.phone_number),
           },
         },
         "Order status retrieved successfully"

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -40,9 +40,23 @@ function getS3Client() {
   return cachedClient;
 }
 
-export function buildS3ObjectUrl(key: string) {
-  const { bucket, region } = getS3Config();
-  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+export function buildMediaUrl(path: string): string;
+export function buildMediaUrl(path: null | undefined): null;
+export function buildMediaUrl(path: string | null | undefined): string | null;
+export function buildMediaUrl(path: string | null | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+
+  const base = process.env.CDN_BASE_URL;
+  if (!base) {
+    throw new BadRequestException("Missing CDN_BASE_URL configuration");
+  }
+
+  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+  // biome-ignore lint/performance/useTopLevelRegex: <i dont care>
+  const normalizedPath = path.replace(/^\/+/, "");
+  return new URL(normalizedPath, normalizedBase).toString();
 }
 
 interface CreatePresignedUploadInput {

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -1,6 +1,5 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { BadRequestException } from "@/errors";
 
 const DEFAULT_PRESIGNED_EXPIRES_SECONDS = 300;
 
@@ -9,7 +8,7 @@ function getS3Config() {
   const bucket = process.env.AWS_S3_BUCKET;
 
   if (!(region && bucket)) {
-    throw new BadRequestException(
+    throw new Error(
       "Missing AWS S3 configuration: AWS_S3_REGION and AWS_S3_BUCKET"
     );
   }
@@ -50,7 +49,7 @@ export function buildMediaUrl(path: string | null | undefined): string | null {
 
   const base = process.env.CDN_BASE_URL;
   if (!base) {
-    throw new BadRequestException("Missing CDN_BASE_URL configuration");
+    throw new Error("Missing CDN_BASE_URL configuration");
   }
 
   const normalizedBase = base.endsWith("/") ? base : `${base}/`;

--- a/packages/web/src/components/not-found-page.tsx
+++ b/packages/web/src/components/not-found-page.tsx
@@ -1,9 +1,9 @@
 import {
-	ArrowClockwiseIcon,
+	ArrowUUpLeftIcon,
 	HouseIcon,
-	WarningCircleIcon,
+	MapPinSimpleAreaIcon,
 } from "@phosphor-icons/react";
-import { type ErrorComponentProps, Link } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,60 +14,53 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 
-const getErrorMessage = (error: unknown): string => {
-	if (error instanceof Error) {
-		return error.message;
-	}
-	if (typeof error === "string") {
-		return error;
-	}
-	try {
-		return JSON.stringify(error, null, 2);
-	} catch {
-		return "Unknown error";
-	}
-};
-
-const GlobalErrorPage = ({ error, reset }: ErrorComponentProps) => {
+const NotFoundPage = () => {
 	useEffect(() => {
-		document.title = "Application Error | Fresclean POS";
+		document.title = "Page Not Found | Fresclean POS";
 	}, []);
+
+	const handleBack = () => {
+		if (typeof window !== "undefined" && window.history.length > 1) {
+			window.history.back();
+			return;
+		}
+		window.location.assign("/");
+	};
 
 	return (
 		<div className="grid min-h-dvh place-items-center bg-background px-4 py-10">
 			<Card className="w-full max-w-xl">
 				<CardHeader className="border-b pb-4">
 					<CardTitle className="flex items-center gap-2 text-sm">
-						<WarningCircleIcon className="size-4 text-destructive" />
-						Application error
+						<MapPinSimpleAreaIcon className="size-4 text-muted-foreground" />
+						Page not found
 					</CardTitle>
 					<CardDescription>
-						Something broke while rendering this screen. Retry or return to the
-						dashboard.
+						The route you requested does not exist. Check the URL or head back.
 					</CardDescription>
 				</CardHeader>
 
 				<CardContent className="grid gap-3">
 					<div className="grid gap-1">
 						<div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-							Details
+							Status
 						</div>
-						<pre className="max-h-56 overflow-auto border bg-muted/50 px-3 py-2 text-[11px] leading-5 whitespace-pre-wrap break-words">
-							{getErrorMessage(error)}
-						</pre>
+						<div className="border bg-muted/50 px-3 py-2 font-mono text-[11px] leading-5">
+							404 · {window.location.pathname}
+						</div>
 					</div>
 
 					<div className="flex flex-wrap gap-2">
 						<Button
 							size="sm"
-							onClick={reset}
-							icon={<ArrowClockwiseIcon />}
+							variant="outline"
+							onClick={handleBack}
+							icon={<ArrowUUpLeftIcon />}
 						>
-							Retry
+							Go back
 						</Button>
 						<Button
 							size="sm"
-							variant="outline"
 							nativeButton={false}
 							render={<Link to="/" />}
 							icon={<HouseIcon />}
@@ -81,4 +74,4 @@ const GlobalErrorPage = ({ error, reset }: ErrorComponentProps) => {
 	);
 };
 
-export { GlobalErrorPage };
+export { NotFoundPage };

--- a/packages/web/src/features/orders/components/order-intake-photo-card.tsx
+++ b/packages/web/src/features/orders/components/order-intake-photo-card.tsx
@@ -51,7 +51,7 @@ export function OrderIntakePhotoCard({
 			});
 			await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
 			await saveOrderIntakePhoto(order.id, {
-				s3_key: presigned.key,
+				image_path: presigned.key,
 			});
 		},
 		onSuccess: async () => {

--- a/packages/web/src/features/orders/components/queue-service-detail.tsx
+++ b/packages/web/src/features/orders/components/queue-service-detail.tsx
@@ -320,7 +320,7 @@ export function QueueServiceDetail({
 			await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
 			await saveOrderServicePhoto(orderId, serviceId, {
 				photo_type: photoType,
-				s3_key: presigned.key,
+				image_path: presigned.key,
 			});
 		},
 		onSuccess: async () => {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -241,7 +241,7 @@ export type PresignOrderServicePhotoPayload = {
 
 export type SaveOrderServicePhotoPayload = {
 	photo_type: OrderServicePhotoType;
-	s3_key: string;
+	image_path: string;
 };
 
 export type PresignOrderIntakePhotoPayload = {
@@ -249,7 +249,7 @@ export type PresignOrderIntakePhotoPayload = {
 };
 
 export type SaveOrderIntakePhotoPayload = {
-	s3_key: string;
+	image_path: string;
 };
 
 export type OrderRefundReason = "damaged" | "cannot_process" | "lost" | "other";

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
-import { useEffect } from "react";
 import { GlobalErrorPage } from "@/components/global-error-page";
+import { NotFoundPage } from "@/components/not-found-page";
 import { GlobalDialog } from "@/components/ui/global-dialog";
 import { GlobalSheet } from "@/components/ui/global-sheet";
 import { Toaster } from "@/components/ui/sonner";
@@ -16,25 +16,6 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 	errorComponent: GlobalErrorPage,
 	notFoundComponent: NotFoundPage,
 });
-
-function NotFoundPage() {
-	useEffect(() => {
-		document.title = "Page Not Found | Fresclean POS";
-	}, []);
-
-	return (
-		<div className="grid min-h-dvh place-items-center bg-background px-6 text-center">
-			<div>
-				<h1 className="text-2xl font-semibold tracking-tight">
-					Page not found
-				</h1>
-				<p className="mt-2 text-sm text-muted-foreground">
-					The route does not exist in the new React router tree.
-				</p>
-			</div>
-		</div>
-	);
-}
 
 function RootComponent() {
 	return (

--- a/packages/web/src/routes/_admin/orders.$orderId.tsx
+++ b/packages/web/src/routes/_admin/orders.$orderId.tsx
@@ -244,7 +244,7 @@ function DialogForm({
 					);
 					await saveOrderServicePhoto(orderId, serviceId, {
 						photo_type: "pickup",
-						s3_key: presigned.key,
+						image_path: presigned.key,
 					});
 				}
 			} catch {
@@ -458,7 +458,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 			await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
 			await saveOrderServicePhoto(id, serviceId, {
 				photo_type: photoType,
-				s3_key: presigned.key,
+				image_path: presigned.key,
 			});
 		},
 		onSuccess: async (_, variables) => {


### PR DESCRIPTION
## Summary
- Store relative image paths only; compute URLs at response time via `buildMediaUrl(CDN_BASE_URL + path)`. Drops redundant `image_url` / `intake_photo_url` columns and renames `s3_key` → `image_path` so the DB is provider-agnostic.
- Rewrite `GlobalErrorPage` to match the operational card-based visual language (no gradients / uppercase tracking). Extract `NotFoundPage` into its own component with Go back + Dashboard actions.
- Fix Base UI `nativeButton` warning on the Link-rendered button.
- Surface missing `CDN_BASE_URL` / `AWS_S3_*` env as HTTP 500 (plain `Error`) instead of 400 `BadRequestException` — server misconfig should not read as client bad request.
- Fix public `/track` order lookup: Drizzle RQB v2 does not support filtering parent rows via a nested relation object in `where`, and PostgreSQL ARE does not treat `\D` as a non-digit shorthand. Split into a customer query (top-level `RAW` with `[^0-9]`) then an order query keyed on `{ code, customer_id }`.

## Test plan
- [x] `bun run push:dev` accepts rename prompts (s3_key → image_path, intake_photo_s3_key → intake_photo_path, drop *_url)
- [x] `bun run seed:dev` populates new schema
- [x] Admin order detail shows intake photo + service photos via CDN URL
- [x] Public `/track` order lookup returns the order for a valid code + phone (exact and non-digit-formatted input); wrong phone / wrong code → 404
- [x] Presigned upload flow still writes `image_path` on save
- [x] Trigger route error → new error page renders, Retry + Dashboard work
- [x] Hit unknown route → 404 renders path, Go back + Dashboard work
- [x] No Base UI `nativeButton` console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)