### PR TITLE
feat: business rules alignment (server + web)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+.playwright-cli

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -6,18 +6,27 @@ import {
 	HouseIcon,
 	IdentificationCardIcon,
 	ListIcon,
+	MonitorIcon,
+	MoonIcon,
 	PackageIcon,
 	ScissorsIcon,
 	ShoppingCartIcon,
 	SignOutIcon,
 	StorefrontIcon,
+	SunIcon,
 	UserGearIcon,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { type ComponentType, type PropsWithChildren, useEffect } from "react";
-import { ModeToggle } from "@/components/mode-toggle";
+import { useTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
 	Sidebar,
 	SidebarContent,
@@ -125,6 +134,44 @@ interface AppShellProps extends PropsWithChildren {
 	title: string;
 	description?: string;
 }
+
+const FooterThemeButton = () => {
+	const { setTheme } = useTheme();
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						aria-label="Toggle theme"
+						icon={
+							<span className="relative size-4">
+								<SunIcon className="absolute inset-0 size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+								<MoonIcon className="absolute inset-0 size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+							</span>
+						}
+					/>
+				}
+			/>
+			<DropdownMenuContent align="end" side="top">
+				<DropdownMenuItem onClick={() => setTheme("light")}>
+					<SunIcon className="size-4" />
+					Light
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => setTheme("dark")}>
+					<MoonIcon className="size-4" />
+					Dark
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => setTheme("system")}>
+					<MonitorIcon className="size-4" />
+					System
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};
 
 function FloatingSidebarTrigger() {
 	const { isMobile, state } = useSidebar();
@@ -245,28 +292,43 @@ export function AppShell({ title, children }: AppShellProps) {
 				</SidebarContent>
 
 				<SidebarFooter>
-					<div className="space-y-3 border border-sidebar-border/70 bg-background px-3 py-3">
-						<ModeToggle />
-						<div>
-							<p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
-								Signed in as
-							</p>
-							<p className="mt-1 text-sm font-medium">
-								{user?.name ?? "Unknown User"}
-							</p>
-							<p className="text-xs text-muted-foreground">
-								@{user?.username ?? "-"}
-							</p>
+					<div className="border border-sidebar-border/70 bg-background">
+						<div className="flex items-center gap-2.5 px-2.5 py-2">
+							<div className="flex size-9 shrink-0 items-center justify-center border border-sidebar-border/70 bg-sidebar-accent/40 font-semibold text-sm uppercase tracking-wider">
+								{user?.name?.trim()?.charAt(0) ?? "?"}
+							</div>
+							<div className="min-w-0 flex-1">
+								<p className="truncate font-medium text-sm leading-tight">
+									{user?.name ?? "Unknown User"}
+								</p>
+								<p className="truncate font-mono text-[11px] text-muted-foreground leading-tight">
+									@{user?.username ?? "-"}
+								</p>
+							</div>
+							<div className="flex shrink-0 items-center gap-0.5">
+								<FooterThemeButton />
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									aria-label="Logout"
+									onClick={handleLogout}
+									icon={<SignOutIcon className="size-4" />}
+								/>
+							</div>
 						</div>
-						{user ? <ShiftClockCard stores={storesQuery.data ?? []} /> : null}
-						<Button
-							variant="outline"
-							className="w-full justify-start"
-							onClick={handleLogout}
-							icon={<SignOutIcon className="size-4" />}
-						>
-							Logout
-						</Button>
+						<div className="flex items-center justify-between border-sidebar-border/70 border-t px-2.5 py-1.5">
+							<span className="text-[10px] text-muted-foreground uppercase tracking-[0.2em]">
+								Role
+							</span>
+							<span className="font-semibold text-[10px] uppercase tracking-[0.2em]">
+								{role ?? "—"}
+							</span>
+						</div>
+						{user ? (
+							<div className="border-sidebar-border/70 border-t p-2">
+								<ShiftClockCard stores={storesQuery.data ?? []} />
+							</div>
+						) : null}
 					</div>
 				</SidebarFooter>
 			</Sidebar>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,5 +1,7 @@
 import {
 	BuildingsIcon,
+	ChartLineIcon,
+	ClockIcon,
 	CreditCardIcon,
 	HouseIcon,
 	IdentificationCardIcon,
@@ -11,6 +13,7 @@ import {
 	StorefrontIcon,
 	UserGearIcon,
 } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { type ComponentType, type PropsWithChildren, useEffect } from "react";
 import { ModeToggle } from "@/components/mode-toggle";
@@ -32,6 +35,8 @@ import {
 	SidebarTrigger,
 	useSidebar,
 } from "@/components/ui/sidebar";
+import { ShiftClockCard } from "@/features/shifts/components/shift-clock-card";
+import { storesQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { getCurrentUser, useAuthStore } from "@/stores/auth-store";
 
@@ -91,6 +96,18 @@ const masterDataNavigation: NavItem[] = [
 		to: "/payment-methods",
 		label: "Payment Methods",
 		icon: CreditCardIcon,
+		roles: ["admin"],
+	},
+	{
+		to: "/shifts",
+		label: "Shifts",
+		icon: ClockIcon,
+		roles: ["admin"],
+	},
+	{
+		to: "/reports",
+		label: "Reports",
+		icon: ChartLineIcon,
 		roles: ["admin"],
 	},
 ] as const;
@@ -164,6 +181,10 @@ export function AppShell({ title, children }: AppShellProps) {
 	const clearToken = useAuthStore((state) => state.clearToken);
 	const user = getCurrentUser();
 	const role = user?.role as Role | undefined;
+	const storesQuery = useQuery({
+		...storesQueryOptions(),
+		enabled: !!user,
+	});
 
 	useEffect(() => {
 		document.title = `${title} | Fresclean POS`;
@@ -237,6 +258,7 @@ export function AppShell({ title, children }: AppShellProps) {
 								@{user?.username ?? "-"}
 							</p>
 						</div>
+						{user ? <ShiftClockCard stores={storesQuery.data ?? []} /> : null}
 						<Button
 							variant="outline"
 							className="w-full justify-start"

--- a/apps/web/src/features/orders/components/campaign-autocomplete.tsx
+++ b/apps/web/src/features/orders/components/campaign-autocomplete.tsx
@@ -1,6 +1,6 @@
 import { CaretDownIcon, XIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -72,6 +72,27 @@ export const CampaignAutocomplete = ({
 
 	const hasSelection = selectedCampaigns.length > 0;
 
+	useEffect(() => {
+		if (
+			!isCampaignQueryEnabled ||
+			campaignQuery.isPending ||
+			values.length === 0
+		) {
+			return;
+		}
+		const validIds = new Set(selectableCampaigns.map((c) => String(c.id)));
+		const pruned = values.filter((id) => validIds.has(id));
+		if (pruned.length !== values.length) {
+			onValuesChange(pruned);
+		}
+	}, [
+		isCampaignQueryEnabled,
+		campaignQuery.isPending,
+		selectableCampaigns,
+		values,
+		onValuesChange,
+	]);
+
 	const handleToggle = (campaignId: string) => {
 		if (valueSet.has(campaignId)) {
 			onValuesChange(values.filter((value) => value !== campaignId));
@@ -85,20 +106,25 @@ export const CampaignAutocomplete = ({
 	};
 
 	const triggerDisabled = disabled || parsedStoreId === undefined;
+	const [isOpen, setIsOpen] = useState(false);
 
 	return (
 		<Field data-invalid={!!error}>
 			<FieldLabel htmlFor={id}>{label}</FieldLabel>
-			<Popover>
+			<Popover open={isOpen} onOpenChange={setIsOpen}>
 				<PopoverTrigger
+					nativeButton={false}
 					render={
-						<button
-							type="button"
+						<div
 							id={id}
-							disabled={triggerDisabled}
+							role="combobox"
+							aria-haspopup="listbox"
+							aria-expanded={isOpen}
+							tabIndex={triggerDisabled ? -1 : 0}
+							aria-disabled={triggerDisabled}
 							className={cn(
-								"flex h-auto min-h-10 w-full items-center justify-between gap-2 border border-input bg-background px-3 py-2 text-left text-sm",
-								"disabled:cursor-not-allowed disabled:opacity-50",
+								"flex h-auto min-h-10 w-full cursor-pointer items-center justify-between gap-2 border border-input bg-background px-3 py-2 text-left text-sm",
+								"aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
 							)}
 						/>
 					}

--- a/apps/web/src/features/orders/components/campaign-autocomplete.tsx
+++ b/apps/web/src/features/orders/components/campaign-autocomplete.tsx
@@ -1,27 +1,38 @@
+import { CaretDownIcon, XIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { Combobox } from "@/components/ui/combobox";
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { isCampaignAvailable } from "@/features/transactions/lib/transactions";
 import { fetchCampaigns, queryKeys } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
-type CampaignAutocompleteProps = {
+interface CampaignAutocompleteProps {
 	id?: string;
 	label?: string;
 	storeId?: string;
-	value: string;
-	onValueChange: (value: string) => void;
+	values: string[];
+	onValuesChange: (values: string[]) => void;
 	disabled?: boolean;
 	error?: { message?: string };
-};
+}
 
-export function CampaignAutocomplete({
+export const CampaignAutocomplete = ({
 	id = "order-campaign",
-	label = "Campaign (optional)",
+	label = "Campaigns (optional)",
 	storeId,
-	value,
-	onValueChange,
+	values,
+	onValuesChange,
 	disabled,
 	error,
-}: CampaignAutocompleteProps) {
+}: CampaignAutocompleteProps) => {
 	const numericStoreId = storeId ? Number(storeId) : undefined;
 	const parsedStoreId =
 		numericStoreId !== undefined && Number.isFinite(numericStoreId)
@@ -42,48 +53,133 @@ export function CampaignAutocomplete({
 	});
 
 	const campaigns = campaignQuery.data ?? [];
-	const now = new Date();
-	const selectableCampaigns = campaigns.filter((campaign) => {
-		if (campaign.starts_at && new Date(campaign.starts_at) > now) {
-			return false;
-		}
 
-		if (campaign.ends_at && new Date(campaign.ends_at) < now) {
-			return false;
-		}
+	const { selectableCampaigns, selectedCampaigns, valueSet } = useMemo(() => {
+		const now = new Date();
+		const selectable = campaigns.filter((campaign) =>
+			isCampaignAvailable(campaign, now),
+		);
+		const selectedIds = new Set(values);
+		const selected = selectable.filter((campaign) =>
+			selectedIds.has(String(campaign.id)),
+		);
+		return {
+			selectableCampaigns: selectable,
+			selectedCampaigns: selected,
+			valueSet: selectedIds,
+		};
+	}, [campaigns, values]);
 
-		return true;
-	});
-	const isLoadingCampaigns = isCampaignQueryEnabled && campaignQuery.isFetching;
+	const hasSelection = selectedCampaigns.length > 0;
+
+	const handleToggle = (campaignId: string) => {
+		if (valueSet.has(campaignId)) {
+			onValuesChange(values.filter((value) => value !== campaignId));
+		} else {
+			onValuesChange([...values, campaignId]);
+		}
+	};
+
+	const handleRemove = (campaignId: string) => {
+		onValuesChange(values.filter((value) => value !== campaignId));
+	};
+
+	const triggerDisabled = disabled || parsedStoreId === undefined;
 
 	return (
 		<Field data-invalid={!!error}>
 			<FieldLabel htmlFor={id}>{label}</FieldLabel>
-			<Combobox
-				id={id}
-				triggerClassName="h-10 w-full text-sm"
-				options={[
-					{ value: "none", label: "No campaign" },
-					...selectableCampaigns.map((campaign) => ({
-						value: String(campaign.id),
-						label: `${campaign.code} - ${campaign.name}`,
-					})),
-				]}
-				value={value || "none"}
-				onValueChange={(nextValue) =>
-					onValueChange(!nextValue || nextValue === "none" ? "" : nextValue)
-				}
-				loading={isLoadingCampaigns}
-				placeholder={
-					parsedStoreId ? "No campaign" : "Select store first to load campaigns"
-				}
-				searchPlaceholder="Search campaign..."
-				emptyText={
-					parsedStoreId ? "No campaign found" : "Please choose store first"
-				}
-				disabled={disabled || parsedStoreId === undefined}
-			/>
+			<Popover>
+				<PopoverTrigger
+					render={
+						<button
+							type="button"
+							id={id}
+							disabled={triggerDisabled}
+							className={cn(
+								"flex h-auto min-h-10 w-full items-center justify-between gap-2 border border-input bg-background px-3 py-2 text-left text-sm",
+								"disabled:cursor-not-allowed disabled:opacity-50",
+							)}
+						/>
+					}
+				>
+					<div className="flex flex-1 flex-wrap items-center gap-1.5">
+						{hasSelection ? (
+							selectedCampaigns.map((campaign) => (
+								<Badge
+									key={campaign.id}
+									variant="secondary"
+									className="gap-1 pr-1"
+								>
+									{campaign.code}
+									{!disabled ? (
+										<button
+											type="button"
+											onClick={(event) => {
+												event.stopPropagation();
+												handleRemove(String(campaign.id));
+											}}
+											className="hover:text-destructive"
+											aria-label={`Remove ${campaign.code}`}
+										>
+											<XIcon className="size-3" />
+										</button>
+									) : null}
+								</Badge>
+							))
+						) : (
+							<span className="text-muted-foreground">
+								{parsedStoreId
+									? "Select campaigns"
+									: "Select store first to load campaigns"}
+							</span>
+						)}
+					</div>
+					<CaretDownIcon className="size-4 shrink-0 opacity-50" />
+				</PopoverTrigger>
+				<PopoverContent
+					align="start"
+					className="w-(--radix-popover-trigger-width) max-h-72 overflow-y-auto p-0"
+				>
+					{selectableCampaigns.length === 0 ? (
+						<p className="p-3 text-muted-foreground text-sm">
+							{parsedStoreId ? "No campaigns available" : "Select store first"}
+						</p>
+					) : (
+						<ul className="divide-y">
+							{selectableCampaigns.map((campaign) => {
+								const campaignId = String(campaign.id);
+								const isChecked = valueSet.has(campaignId);
+								return (
+									<li key={campaign.id}>
+										<Button
+											type="button"
+											variant="ghost"
+											className="h-auto w-full justify-start gap-2 rounded-none px-3 py-2 text-left"
+											onClick={() => handleToggle(campaignId)}
+										>
+											<Checkbox
+												checked={isChecked}
+												className="pointer-events-none"
+												tabIndex={-1}
+											/>
+											<div className="flex flex-col">
+												<span className="text-sm font-medium">
+													{campaign.code}
+												</span>
+												<span className="text-muted-foreground text-xs">
+													{campaign.name}
+												</span>
+											</div>
+										</Button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</PopoverContent>
+			</Popover>
 			<FieldError errors={[error]} />
 		</Field>
 	);
-}
+};

--- a/apps/web/src/features/orders/components/order-form.tsx
+++ b/apps/web/src/features/orders/components/order-form.tsx
@@ -31,7 +31,7 @@ import { servicesQueryOptions } from "@/lib/query-options";
 export type OrderFormState = {
 	customer_id: string;
 	store_id: string;
-	campaign_id: string;
+	campaign_ids: string[];
 	payment_method_id: string;
 	payment_status: "paid" | "unpaid";
 	discount: string;
@@ -53,7 +53,7 @@ export type OrderFormState = {
 const defaultForm: OrderFormState = {
 	customer_id: "",
 	store_id: "",
-	campaign_id: "",
+	campaign_ids: [],
 	payment_method_id: "",
 	payment_status: "unpaid",
 	discount: "",
@@ -75,7 +75,7 @@ function toOrderPayload(values: OrderFormState): CreateOrderPayload {
 	return {
 		customer_id: Number(values.customer_id),
 		store_id: Number(values.store_id),
-		campaign_id: values.campaign_id ? Number(values.campaign_id) : undefined,
+		campaign_ids: values.campaign_ids.map((id) => Number(id)),
 		products: values.products
 			.filter((product) => !!product.id)
 			.map((product) => ({
@@ -115,7 +115,7 @@ const orderFormResolverSchema = z
 				(value) => value.trim() === "" || Number(value) > 0,
 				"Discount must be positive",
 			),
-		campaign_id: z.string(),
+		campaign_ids: z.array(z.string()),
 		notes: z.string(),
 		products: z.array(
 			z.object({
@@ -233,13 +233,13 @@ export function OrderForm({
 				/>
 
 				<Controller
-					name="campaign_id"
+					name="campaign_ids"
 					control={form.control}
 					render={({ field, fieldState }) => (
 						<CampaignAutocomplete
-							value={field.value}
+							values={field.value}
 							storeId={selectedStoreId}
-							onValueChange={field.onChange}
+							onValuesChange={field.onChange}
 							disabled={isSubmitting}
 							error={fieldState.error}
 						/>

--- a/apps/web/src/features/reports/components/daily-report.tsx
+++ b/apps/web/src/features/reports/components/daily-report.tsx
@@ -1,0 +1,134 @@
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	dailyReportQueryOptions,
+	storesQueryOptions,
+} from "@/lib/query-options";
+import { formatIDRCurrency } from "@/shared/utils";
+
+interface DailyReportProps {
+	date: string;
+	storeId?: number;
+	onDateChange: (date: string) => void;
+	onStoreChange: (storeId: number | undefined) => void;
+}
+
+interface MetricCardProps {
+	label: string;
+	value: string;
+	helper?: string;
+}
+
+const MetricCard = ({ label, value, helper }: MetricCardProps) => (
+	<Card>
+		<CardContent className="grid gap-1 pt-5">
+			<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+				{label}
+			</p>
+			<p className="text-2xl font-semibold tabular-nums">{value}</p>
+			{helper ? (
+				<p className="text-muted-foreground text-xs">{helper}</p>
+			) : null}
+		</CardContent>
+	</Card>
+);
+
+export const DailyReport = ({
+	date,
+	storeId,
+	onDateChange,
+	onStoreChange,
+}: DailyReportProps) => {
+	const reportQuery = useQuery(
+		dailyReportQueryOptions({ date, store_id: storeId }),
+	);
+	const storesQuery = useQuery(storesQueryOptions());
+	const stores = storesQuery.data ?? [];
+	const report = reportQuery.data;
+
+	return (
+		<div className="grid gap-4">
+			<div className="flex flex-wrap items-end gap-3">
+				<div className="grid gap-1">
+					<label
+						htmlFor="report-date"
+						className="text-muted-foreground text-xs font-medium uppercase"
+					>
+						Date (Asia/Jakarta)
+					</label>
+					<Input
+						id="report-date"
+						type="date"
+						value={date}
+						max={dayjs().format("YYYY-MM-DD")}
+						onChange={(event) => {
+							if (event.target.value) {
+								onDateChange(event.target.value);
+							}
+						}}
+					/>
+				</div>
+				<div className="grid gap-1">
+					<label
+						htmlFor="report-store"
+						className="text-muted-foreground text-xs font-medium uppercase"
+					>
+						Store
+					</label>
+					<Select
+						value={storeId !== undefined ? String(storeId) : "all"}
+						onValueChange={(value) =>
+							onStoreChange(
+								!value || value === "all" ? undefined : Number(value),
+							)
+						}
+					>
+						<SelectTrigger id="report-store" size="md" className="min-w-48">
+							<SelectValue placeholder="All stores" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All stores</SelectItem>
+							{stores.map((store) => (
+								<SelectItem key={store.id} value={String(store.id)}>
+									{store.code} · {store.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				<MetricCard
+					label="Revenue"
+					value={formatIDRCurrency(String(report?.revenue ?? 0))}
+					helper="Paid minus refunded"
+				/>
+				<MetricCard
+					label="Items processed"
+					value={String(report?.items_processed ?? 0)}
+					helper="Moved to QC or ready"
+				/>
+				<MetricCard
+					label="Orders in"
+					value={String(report?.orders_in ?? 0)}
+					helper="Created today"
+				/>
+				<MetricCard
+					label="Orders out"
+					value={String(report?.orders_out ?? 0)}
+					helper="Picked up today"
+				/>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/shifts/components/shift-clock-card.tsx
+++ b/apps/web/src/features/shifts/components/shift-clock-card.tsx
@@ -1,0 +1,127 @@
+import { ClockIcon } from "@phosphor-icons/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { useCurrentShift } from "@/features/shifts/hooks/useCurrentShift";
+import { clockInShift, clockOutShift, queryKeys, type Store } from "@/lib/api";
+
+const formatElapsed = (start: Date, now: Date) => {
+	const ms = Math.max(0, now.getTime() - start.getTime());
+	const totalSeconds = Math.floor(ms / 1000);
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+};
+
+interface ShiftClockCardProps {
+	stores: Store[];
+}
+
+export const ShiftClockCard = ({ stores }: ShiftClockCardProps) => {
+	const queryClient = useQueryClient();
+	const { data: currentShift, isPending } = useCurrentShift();
+	const [storeOverride, setStoreOverride] = useState<string | null>(null);
+	const [now, setNow] = useState(() => new Date());
+
+	const selectedStoreId =
+		storeOverride ?? (stores[0] ? String(stores[0].id) : "");
+
+	useEffect(() => {
+		if (!currentShift) {
+			return;
+		}
+		const interval = setInterval(() => setNow(new Date()), 1000);
+		return () => clearInterval(interval);
+	}, [currentShift]);
+
+	const invalidateShiftQueries = () =>
+		Promise.all([
+			queryClient.invalidateQueries({ queryKey: queryKeys.shiftCurrent }),
+			queryClient.invalidateQueries({ queryKey: ["shifts"] }),
+		]);
+
+	const clockInMutation = useMutation({
+		mutationKey: ["shift-clock-in"],
+		mutationFn: clockInShift,
+		onSuccess: invalidateShiftQueries,
+	});
+
+	const clockOutMutation = useMutation({
+		mutationKey: ["shift-clock-out"],
+		mutationFn: clockOutShift,
+		onSuccess: invalidateShiftQueries,
+	});
+
+	if (isPending) {
+		return null;
+	}
+
+	if (currentShift) {
+		const elapsed = formatElapsed(new Date(currentShift.clock_in_at), now);
+		return (
+			<div className="flex items-center gap-2 border border-border/70 px-2 py-1 text-xs">
+				<ClockIcon className="size-4 text-emerald-500" />
+				<span className="hidden font-mono tabular-nums sm:inline">
+					{elapsed}
+				</span>
+				<span className="hidden text-muted-foreground md:inline">
+					{currentShift.store?.code ?? ""}
+				</span>
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={clockOutMutation.isPending}
+					onClick={() => clockOutMutation.mutate()}
+				>
+					Clock out
+				</Button>
+			</div>
+		);
+	}
+
+	if (stores.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="flex items-center gap-2">
+			{stores.length > 1 ? (
+				<Select
+					value={selectedStoreId}
+					onValueChange={(value) => setStoreOverride(value ?? null)}
+				>
+					<SelectTrigger size="sm" className="h-8 min-w-24 text-xs">
+						<SelectValue placeholder="Store" />
+					</SelectTrigger>
+					<SelectContent>
+						{stores.map((store) => (
+							<SelectItem key={store.id} value={String(store.id)}>
+								{store.code}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			) : null}
+			<Button
+				size="sm"
+				variant="outline"
+				disabled={!selectedStoreId || clockInMutation.isPending}
+				icon={<ClockIcon className="size-4" />}
+				onClick={() =>
+					clockInMutation.mutate({ store_id: Number(selectedStoreId) })
+				}
+			>
+				Clock in
+			</Button>
+		</div>
+	);
+};

--- a/apps/web/src/features/shifts/hooks/useCurrentShift.ts
+++ b/apps/web/src/features/shifts/hooks/useCurrentShift.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { currentShiftQueryOptions } from "@/lib/query-options";
+
+export function useCurrentShift() {
+	return useQuery(currentShiftQueryOptions());
+}

--- a/apps/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/apps/web/src/features/transactions/components/transactions-checkout.tsx
@@ -7,7 +7,7 @@ import {
 	XIcon,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { CurrencyInput } from "@/components/form/currency-input";
 import { Badge } from "@/components/ui/badge";
@@ -25,12 +25,13 @@ import {
 	SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
+import { CampaignAutocomplete } from "@/features/orders/components/campaign-autocomplete";
 import { CustomerAutocomplete } from "@/features/orders/components/customer-autocomplete";
 import { useCartTotals } from "@/features/transactions/hooks/use-cart-totals";
 import { useTransactionsCart } from "@/features/transactions/hooks/use-transactions-cart";
 import {
-	getCampaignDiscount,
 	getEntityCategoryName,
+	getStackedDiscount,
 	isCampaignAvailable,
 	type TransactionDraftValues,
 } from "@/features/transactions/lib/transactions";
@@ -88,7 +89,7 @@ export function TransactionsCheckout({
 	const form = useFormContext<TransactionDraftValues>();
 	const [
 		selectedCustomerId = "",
-		selectedCampaignId = "",
+		selectedCampaignIds = [],
 		selectedPaymentMethodId = "",
 		paymentStatus = "unpaid",
 		manualDiscount = "",
@@ -97,7 +98,7 @@ export function TransactionsCheckout({
 		control: form.control,
 		name: [
 			"selectedCustomerId",
-			"selectedCampaignId",
+			"selectedCampaignIds",
 			"selectedPaymentMethodId",
 			"paymentStatus",
 			"manualDiscount",
@@ -132,33 +133,11 @@ export function TransactionsCheckout({
 		);
 	}, [campaignsQuery.data]);
 
-	useEffect(() => {
-		if (!selectedCampaignId) {
-			return;
-		}
-		const hasCampaign = availableCampaigns.some(
-			(campaign) => campaign.id === Number(selectedCampaignId),
-		);
-		if (!hasCampaign) {
-			form.setValue("selectedCampaignId", "", { shouldValidate: true });
-		}
-	}, [availableCampaigns, form, selectedCampaignId]);
-
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),
 		[categories],
 	);
 
-	const campaignOptions = useMemo<ComboboxOption[]>(
-		() => [
-			{ value: "none", label: "No campaign" },
-			...availableCampaigns.map((campaign) => ({
-				value: String(campaign.id),
-				label: `${campaign.code} - ${campaign.name}`,
-			})),
-		],
-		[availableCampaigns],
-	);
 	const paymentMethodOptions = useMemo<ComboboxOption[]>(
 		() => [
 			{ value: "none", label: "No payment method" },
@@ -177,15 +156,12 @@ export function TransactionsCheckout({
 				: undefined,
 		[selectedStoreNumber, visibleStores],
 	);
-	const selectedCampaign = useMemo(
-		() =>
-			selectedCampaignId
-				? availableCampaigns.find(
-						(campaign) => campaign.id === Number(selectedCampaignId),
-					)
-				: undefined,
-		[availableCampaigns, selectedCampaignId],
-	);
+	const selectedCampaigns = useMemo(() => {
+		const selectedIdSet = new Set(selectedCampaignIds);
+		return availableCampaigns.filter((campaign) =>
+			selectedIdSet.has(String(campaign.id)),
+		);
+	}, [availableCampaigns, selectedCampaignIds]);
 	const selectedPaymentMethodLabel = useMemo(
 		() =>
 			selectedPaymentMethodId
@@ -196,41 +172,30 @@ export function TransactionsCheckout({
 		[paymentMethodOptions, selectedPaymentMethodId],
 	);
 
-	const campaignDiscount = getCampaignDiscount(subtotal, selectedCampaign);
+	const stackedDiscount = useMemo(
+		() => getStackedDiscount(subtotal, selectedCampaigns),
+		[subtotal, selectedCampaigns],
+	);
+	const campaignDiscount = stackedDiscount.total;
 	const discountValue = Number(manualDiscount || 0);
 	const totalDiscount = Math.min(subtotal, discountValue + campaignDiscount);
 	const total = Math.max(0, subtotal - totalDiscount);
 
 	const isSubmitting = form.formState.isSubmitting;
 
-	const orderMeta = useMemo(
-		() => [
-			{
-				label: "Campaign",
-				value: selectedCampaign?.code ?? "None",
-				variant: selectedCampaignId
-					? ("success" as const)
-					: ("outline" as const),
-			},
-			{
-				label: "Payment",
-				value:
-					paymentStatus === "paid"
-						? (selectedPaymentMethodLabel ?? "Method required")
-						: "Unpaid",
-				variant:
-					paymentStatus === "paid"
-						? ("warning" as const)
-						: ("outline" as const),
-			},
-		],
-		[
-			paymentStatus,
-			selectedCampaign?.code,
-			selectedCampaignId,
-			selectedPaymentMethodLabel,
-		],
-	);
+	const campaignSummary =
+		selectedCampaigns.length === 0
+			? "None"
+			: selectedCampaigns.length === 1
+				? (selectedCampaigns[0]?.code ?? "1 applied")
+				: `${selectedCampaigns.length} applied`;
+
+	const paymentValue =
+		paymentStatus === "paid"
+			? (selectedPaymentMethodLabel ?? "Method required")
+			: "Unpaid";
+	const campaignVariant = selectedCampaigns.length > 0 ? "success" : "outline";
+	const paymentVariant = paymentStatus === "paid" ? "warning" : "outline";
 
 	return (
 		<>
@@ -259,7 +224,9 @@ export function TransactionsCheckout({
 							size="sm"
 							onClick={resetCart}
 							disabled={
-								cartCount === 0 && !selectedCustomerId && !selectedCampaignId
+								cartCount === 0 &&
+								!selectedCustomerId &&
+								selectedCampaignIds.length === 0
 							}
 							icon={<TrashIcon className="size-4" />}
 						>
@@ -500,14 +467,19 @@ export function TransactionsCheckout({
 										{formatIDRCurrency(String(subtotal))}
 									</span>
 								</div>
-								<div className="flex items-center justify-between gap-3 text-sm">
-									<span className="text-muted-foreground">
-										Campaign Discount
-									</span>
-									<span className="font-medium">
-										-{formatIDRCurrency(String(Math.round(campaignDiscount)))}
-									</span>
-								</div>
+								{stackedDiscount.breakdown.map(({ campaign, amount }) => (
+									<div
+										key={campaign.id}
+										className="flex items-center justify-between gap-3 text-sm"
+									>
+										<span className="text-muted-foreground">
+											{campaign.code} ({campaign.name})
+										</span>
+										<span className="font-medium">
+											-{formatIDRCurrency(String(amount))}
+										</span>
+									</div>
+								))}
 								<div className="flex items-center justify-between gap-3 text-sm">
 									<span className="text-muted-foreground">Manual Discount</span>
 									<span className="font-medium">
@@ -521,14 +493,16 @@ export function TransactionsCheckout({
 							</div>
 
 							<div className="grid gap-2 sm:grid-cols-3">
-								{orderMeta.map((item) => (
-									<OrderMetaBadge
-										key={item.label}
-										label={item.label}
-										value={item.value}
-										variant={item.variant}
-									/>
-								))}
+								<OrderMetaBadge
+									label="Campaign"
+									value={campaignSummary}
+									variant={campaignVariant}
+								/>
+								<OrderMetaBadge
+									label="Payment"
+									value={paymentValue}
+									variant={paymentVariant}
+								/>
 							</div>
 
 							{submitError ? <FieldError>{submitError}</FieldError> : null}
@@ -559,37 +533,17 @@ export function TransactionsCheckout({
 
 					<div className="grid gap-5 overflow-y-auto p-4">
 						<Controller
-							name="selectedCampaignId"
+							name="selectedCampaignIds"
 							control={form.control}
 							render={({ field, fieldState }) => (
-								<Field data-invalid={fieldState.invalid}>
-									<FieldLabel htmlFor="transaction-campaign">
-										Campaign
-									</FieldLabel>
-									<Combobox
-										id="transaction-campaign"
-										triggerClassName="h-10 w-full text-sm"
-										options={campaignOptions}
-										value={field.value || "none"}
-										onValueChange={(value) =>
-											field.onChange(value === "none" ? "" : value)
-										}
-										loading={campaignsQuery.isFetching}
-										placeholder={
-											selectedStoreNumber
-												? "No campaign"
-												: "Select store first to unlock campaigns"
-										}
-										searchPlaceholder="Search campaign..."
-										emptyText={
-											selectedStoreNumber
-												? "No campaign found"
-												: "Select store first"
-										}
-										disabled={selectedStoreNumber === undefined}
-									/>
-									<FieldError errors={[fieldState.error]} />
-								</Field>
+								<CampaignAutocomplete
+									id="transaction-campaign"
+									label="Campaigns"
+									storeId={selectedStoreId}
+									values={field.value}
+									onValuesChange={field.onChange}
+									error={fieldState.error}
+								/>
 							)}
 						/>
 
@@ -646,21 +600,26 @@ export function TransactionsCheckout({
 							)}
 						/>
 
-						{selectedCampaign ? (
-							<div className="flex items-center justify-between gap-3 border border-emerald-300/60 bg-emerald-50/70 p-3 text-sm dark:border-emerald-800 dark:bg-emerald-950/30">
-								<div>
-									<p className="font-medium">{selectedCampaign.name}</p>
-									<p className="text-xs text-muted-foreground">
-										{selectedCampaign.code} active on this store
-									</p>
-								</div>
-								<Badge variant="success">
-									{selectedCampaign.discount_type === "percentage"
-										? `${selectedCampaign.discount_value}%`
-										: formatIDRCurrency(
-												String(selectedCampaign.discount_value),
-											)}
-								</Badge>
+						{selectedCampaigns.length > 0 ? (
+							<div className="grid gap-2">
+								{selectedCampaigns.map((campaign) => (
+									<div
+										key={campaign.id}
+										className="flex items-center justify-between gap-3 border border-emerald-300/60 bg-emerald-50/70 p-3 text-sm dark:border-emerald-800 dark:bg-emerald-950/30"
+									>
+										<div>
+											<p className="font-medium">{campaign.name}</p>
+											<p className="text-xs text-muted-foreground">
+												{campaign.code} active on this store
+											</p>
+										</div>
+										<Badge variant="success">
+											{campaign.discount_type === "percentage"
+												? `${campaign.discount_value}%`
+												: formatIDRCurrency(String(campaign.discount_value))}
+										</Badge>
+									</div>
+								))}
 							</div>
 						) : null}
 

--- a/apps/web/src/features/transactions/hooks/use-transactions-cart.ts
+++ b/apps/web/src/features/transactions/hooks/use-transactions-cart.ts
@@ -47,7 +47,7 @@ export function useTransactionsCart() {
 		form.reset({
 			selectedStoreId,
 			selectedCustomerId: "",
-			selectedCampaignId: "",
+			selectedCampaignIds: [],
 			selectedPaymentMethodId: "",
 			paymentStatus: "unpaid",
 			manualDiscount: "",

--- a/apps/web/src/features/transactions/hooks/use-transactions-page.ts
+++ b/apps/web/src/features/transactions/hooks/use-transactions-page.ts
@@ -23,7 +23,7 @@ import { useTransactionsPageStore } from "@/stores/transactions-store";
 const defaultDraftValues: TransactionDraftValues = {
 	selectedStoreId: "",
 	selectedCustomerId: "",
-	selectedCampaignId: "",
+	selectedCampaignIds: [],
 	selectedPaymentMethodId: "",
 	paymentStatus: "unpaid",
 	manualDiscount: "",
@@ -39,7 +39,7 @@ const transactionDraftSchema = z
 			.trim()
 			.min(1, "Store is required before creating a transaction."),
 		selectedCustomerId: z.string().trim().min(1, "Customer is required."),
-		selectedCampaignId: z.string(),
+		selectedCampaignIds: z.array(z.string()),
 		selectedPaymentMethodId: z.string(),
 		paymentStatus: z.enum(["paid", "unpaid"]),
 		manualDiscount: z
@@ -82,14 +82,6 @@ const transactionDraftSchema = z
 				code: "custom",
 				path: ["selectedPaymentMethodId"],
 				message: "Payment method is required for paid orders.",
-			});
-		}
-
-		if (Number(values.manualDiscount || 0) > 0 && values.selectedCampaignId) {
-			ctx.addIssue({
-				code: "custom",
-				path: ["selectedCampaignId"],
-				message: "Campaign discount cannot be combined with manual discount.",
 			});
 		}
 	});
@@ -263,7 +255,7 @@ export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 					.getState()
 					.setSelectedStoreId(currentUserKey, value);
 			}
-			form.setValue("selectedCampaignId", "", {
+			form.setValue("selectedCampaignIds", [], {
 				shouldDirty: true,
 				shouldValidate: true,
 			});

--- a/apps/web/src/features/transactions/lib/transactions.ts
+++ b/apps/web/src/features/transactions/lib/transactions.ts
@@ -1,3 +1,7 @@
+import {
+	type CampaignContribution,
+	stackCampaignDiscounts,
+} from "@fresclean/api/schema";
 import type {
 	Campaign,
 	Category,
@@ -36,7 +40,7 @@ export type ServiceCartDisplayLine = ServiceCartLine & {
 export type TransactionDraftValues = {
 	selectedStoreId: string;
 	selectedCustomerId: string;
-	selectedCampaignId: string;
+	selectedCampaignIds: string[];
 	selectedPaymentMethodId: string;
 	paymentStatus: CreateOrderPayload["payment_status"];
 	manualDiscount: string;
@@ -107,35 +111,16 @@ export function isCampaignAvailable(campaign: Campaign, now: Date) {
 	return true;
 }
 
-export function getCampaignDiscount(subtotal: number, campaign?: Campaign) {
-	if (!campaign) {
-		return 0;
-	}
+export type CampaignBreakdown = CampaignContribution<Campaign>;
 
-	const minimumOrderTotal = Number(campaign.min_order_total ?? 0);
-
-	if (subtotal < minimumOrderTotal) {
-		return 0;
-	}
-
-	if (campaign.discount_type === "percentage") {
-		const rawDiscount = (subtotal * Number(campaign.discount_value ?? 0)) / 100;
-		const maxDiscount = Number(campaign.max_discount ?? 0);
-
-		if (maxDiscount > 0) {
-			return Math.min(rawDiscount, maxDiscount);
-		}
-
-		return rawDiscount;
-	}
-
-	return Number(campaign.discount_value ?? 0);
+export function getStackedDiscount(subtotal: number, campaigns: Campaign[]) {
+	return stackCampaignDiscounts(subtotal, campaigns);
 }
 
 export function toTransactionPayload({
 	selectedCustomerId,
 	selectedStoreId,
-	selectedCampaignId,
+	selectedCampaignIds,
 	selectedPaymentMethodId,
 	paymentStatus,
 	manualDiscount,
@@ -146,7 +131,7 @@ export function toTransactionPayload({
 	return {
 		customer_id: Number(selectedCustomerId),
 		store_id: Number(selectedStoreId),
-		campaign_id: selectedCampaignId ? Number(selectedCampaignId) : undefined,
+		campaign_ids: selectedCampaignIds.map((id) => Number(id)),
 		discount: manualDiscount || "0",
 		payment_method_id: selectedPaymentMethodId
 			? Number(selectedPaymentMethodId)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -58,6 +58,9 @@ const orderServiceByItemCodeRoute =
 const orderServiceQueueRoute = rpc.api.admin.orders.services.queue.$get;
 const myOrderServicesRoute = rpc.api.admin.orders.services.me.$get;
 const dashboardCountsRoute = rpc.api.admin.dashboard.counts.$get;
+const shiftsRoute = rpc.api.admin.shifts.$get;
+const shiftCurrentRoute = rpc.api.admin.shifts.current.$get;
+const dailyReportRoute = rpc.api.admin.reports.daily.$get;
 const publicTrackOrderRoute = rpc.api.public.orders.track.$post;
 
 type LoginSuccessResponse = Extract<
@@ -113,6 +116,31 @@ export type PublicTrackedOrder = Extract<
 	InferResponseType<typeof publicTrackOrderRoute>,
 	{ success: true }
 >["data"];
+export type Shift = Extract<
+	InferResponseType<typeof shiftsRoute>,
+	{ success: true }
+>["data"][number];
+export type CurrentShift = Extract<
+	InferResponseType<typeof shiftCurrentRoute>,
+	{ success: true }
+>["data"];
+
+export type FetchShiftsQuery = {
+	user_id?: number;
+	store_id?: number;
+	from?: string;
+	to?: string;
+};
+
+export type DailyReport = Extract<
+	InferResponseType<typeof dailyReportRoute>,
+	{ success: true }
+>["data"];
+
+export type FetchDailyReportQuery = {
+	date: string;
+	store_id?: number;
+};
 
 export type LoginPayload = {
 	username: string;
@@ -192,8 +220,6 @@ export type FetchUsersQuery = {
 };
 
 export type FetchCampaignsQuery = {
-	limit?: number;
-	offset?: number;
 	store_id?: number;
 	is_active?: boolean;
 };
@@ -212,6 +238,7 @@ export type CampaignPayload = {
 };
 
 export type UpdateOrderServiceStatusPayload = {
+	cancel_reason?: string;
 	note?: string;
 	status:
 		| "queued"
@@ -293,8 +320,6 @@ export const queryKeys = {
 	orderDetail: (id: number) => ["order-detail", id] as const,
 	campaigns: (query?: FetchCampaignsQuery) =>
 		["campaigns", query ?? {}] as const,
-	campaignsList: (query?: FetchCampaignsQuery) =>
-		["campaigns-list", query ?? {}] as const,
 	campaignDetail: (id: number) => ["campaign-detail", id] as const,
 	orderServiceLookup: (itemCode: string) =>
 		["order-service-lookup", itemCode] as const,
@@ -307,6 +332,10 @@ export const queryKeys = {
 	myOrderServices: (storeId?: number) =>
 		["my-order-services", storeId ?? "all"] as const,
 	dashboard: ["dashboard"] as const,
+	shifts: (query?: FetchShiftsQuery) => ["shifts", query ?? {}] as const,
+	shiftCurrent: ["shift-current"] as const,
+	dailyReport: (query: FetchDailyReportQuery) =>
+		["daily-report", query] as const,
 };
 
 export async function login(payload: LoginPayload) {
@@ -515,37 +544,6 @@ export async function fetchCampaigns(query?: FetchCampaignsQuery) {
 		}),
 	);
 	return response.data;
-}
-
-export async function fetchCampaignsPage(
-	query?: FetchCampaignsQuery,
-): Promise<PaginatedData<Campaign>> {
-	const response = await parseResponse(
-		rpcWithAuth().api.admin.campaigns.$get({
-			query:
-				query && Object.keys(query).length > 0
-					? {
-							...(query.limit !== undefined
-								? { limit: String(query.limit) }
-								: {}),
-							...(query.offset !== undefined
-								? { offset: String(query.offset) }
-								: {}),
-							...(query.store_id !== undefined
-								? { store_id: String(query.store_id) }
-								: {}),
-							...(query.is_active !== undefined
-								? { is_active: String(query.is_active) }
-								: {}),
-						}
-					: undefined,
-		}),
-	);
-
-	return {
-		items: response.data,
-		meta: response.meta as PaginationMeta,
-	};
 }
 
 export async function fetchCampaignById(id: number) {
@@ -949,5 +947,55 @@ export type DashboardCounts = InferResponseType<
 export async function fetchDashboardCounts() {
 	return parseSuccessData<DashboardCounts>(
 		rpcWithAuth().api.admin.dashboard.counts.$get(),
+	);
+}
+
+export async function fetchCurrentShift() {
+	return parseSuccessData<CurrentShift>(
+		rpcWithAuth().api.admin.shifts.current.$get(),
+	);
+}
+
+export async function fetchShifts(query?: FetchShiftsQuery) {
+	const response = await parseResponse(
+		rpcWithAuth().api.admin.shifts.$get({
+			query:
+				query && Object.keys(query).length > 0
+					? {
+							...(query.user_id !== undefined
+								? { user_id: String(query.user_id) }
+								: {}),
+							...(query.store_id !== undefined
+								? { store_id: String(query.store_id) }
+								: {}),
+							...(query.from ? { from: query.from } : {}),
+							...(query.to ? { to: query.to } : {}),
+						}
+					: undefined,
+		}),
+	);
+	return response.data;
+}
+
+export async function clockInShift(payload: { store_id: number }) {
+	return parseResponse(
+		rpcWithAuth().api.admin.shifts["clock-in"].$post({ json: payload }),
+	);
+}
+
+export async function clockOutShift() {
+	return parseResponse(rpcWithAuth().api.admin.shifts["clock-out"].$post());
+}
+
+export async function fetchDailyReport(query: FetchDailyReportQuery) {
+	return parseSuccessData<DailyReport>(
+		rpcWithAuth().api.admin.reports.daily.$get({
+			query: {
+				date: query.date,
+				...(query.store_id !== undefined
+					? { store_id: String(query.store_id) }
+					: {}),
+			},
+		}),
 	);
 }

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -2,13 +2,16 @@ import { queryOptions } from "@tanstack/react-query";
 import {
 	type FetchCampaignsQuery,
 	type FetchCustomersQuery,
+	type FetchDailyReportQuery,
 	type FetchOrdersQuery,
+	type FetchShiftsQuery,
 	type FetchUsersQuery,
 	fetchCampaigns,
-	fetchCampaignsPage,
 	fetchCategories,
+	fetchCurrentShift,
 	fetchCurrentUserDetail,
 	fetchCustomersPage,
+	fetchDailyReport,
 	fetchDashboardCounts,
 	fetchMyOrderServices,
 	fetchOrderDetail,
@@ -16,6 +19,7 @@ import {
 	fetchPaymentMethods,
 	fetchProducts,
 	fetchServices,
+	fetchShifts,
 	fetchStores,
 	fetchUsersPage,
 	queryKeys,
@@ -96,18 +100,30 @@ export const orderDetailQueryOptions = (id: number) =>
 
 export const campaignsQueryOptions = (query?: FetchCampaignsQuery) =>
 	queryOptions({
-		queryKey: queryKeys.campaignsList(query),
-		queryFn: () => fetchCampaigns(query),
-	});
-
-export const campaignsPageQueryOptions = (query?: FetchCampaignsQuery) =>
-	queryOptions({
 		queryKey: queryKeys.campaigns(query),
-		queryFn: () => fetchCampaignsPage(query),
+		queryFn: () => fetchCampaigns(query),
 	});
 
 export const myOrderServicesQueryOptions = (storeId?: number) =>
 	queryOptions({
 		queryKey: queryKeys.myOrderServices(storeId),
 		queryFn: () => fetchMyOrderServices(storeId),
+	});
+
+export const currentShiftQueryOptions = () =>
+	queryOptions({
+		queryKey: queryKeys.shiftCurrent,
+		queryFn: fetchCurrentShift,
+	});
+
+export const shiftsQueryOptions = (query?: FetchShiftsQuery) =>
+	queryOptions({
+		queryKey: queryKeys.shifts(query),
+		queryFn: () => fetchShifts(query),
+	});
+
+export const dailyReportQueryOptions = (query: FetchDailyReportQuery) =>
+	queryOptions({
+		queryKey: queryKeys.dailyReport(query),
+		queryFn: () => fetchDailyReport(query),
 	});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -17,7 +17,9 @@ import { Route as AuthLoginRouteImport } from "./routes/auth/login";
 import { Route as AdminUsersRouteImport } from "./routes/_admin/users";
 import { Route as AdminTransactionsRouteImport } from "./routes/_admin/transactions";
 import { Route as AdminStoresRouteImport } from "./routes/_admin/stores";
+import { Route as AdminShiftsRouteImport } from "./routes/_admin/shifts";
 import { Route as AdminServicesRouteImport } from "./routes/_admin/services";
+import { Route as AdminReportsRouteImport } from "./routes/_admin/reports";
 import { Route as AdminProductsRouteImport } from "./routes/_admin/products";
 import { Route as AdminPaymentMethodsRouteImport } from "./routes/_admin/payment-methods";
 import { Route as AdminCustomersRouteImport } from "./routes/_admin/customers";
@@ -67,9 +69,19 @@ const AdminStoresRoute = AdminStoresRouteImport.update({
   path: "/stores",
   getParentRoute: () => AdminRouteRoute,
 } as any);
+const AdminShiftsRoute = AdminShiftsRouteImport.update({
+  id: "/shifts",
+  path: "/shifts",
+  getParentRoute: () => AdminRouteRoute,
+} as any);
 const AdminServicesRoute = AdminServicesRouteImport.update({
   id: "/services",
   path: "/services",
+  getParentRoute: () => AdminRouteRoute,
+} as any);
+const AdminReportsRoute = AdminReportsRouteImport.update({
+  id: "/reports",
+  path: "/reports",
   getParentRoute: () => AdminRouteRoute,
 } as any);
 const AdminProductsRoute = AdminProductsRouteImport.update({
@@ -127,7 +139,9 @@ export interface FileRoutesByFullPath {
   "/customers": typeof AdminCustomersRoute;
   "/payment-methods": typeof AdminPaymentMethodsRoute;
   "/products": typeof AdminProductsRoute;
+  "/reports": typeof AdminReportsRoute;
   "/services": typeof AdminServicesRoute;
+  "/shifts": typeof AdminShiftsRoute;
   "/stores": typeof AdminStoresRoute;
   "/transactions": typeof AdminTransactionsRoute;
   "/users": typeof AdminUsersRoute;
@@ -145,7 +159,9 @@ export interface FileRoutesByTo {
   "/customers": typeof AdminCustomersRoute;
   "/payment-methods": typeof AdminPaymentMethodsRoute;
   "/products": typeof AdminProductsRoute;
+  "/reports": typeof AdminReportsRoute;
   "/services": typeof AdminServicesRoute;
+  "/shifts": typeof AdminShiftsRoute;
   "/stores": typeof AdminStoresRoute;
   "/transactions": typeof AdminTransactionsRoute;
   "/users": typeof AdminUsersRoute;
@@ -166,7 +182,9 @@ export interface FileRoutesById {
   "/_admin/customers": typeof AdminCustomersRoute;
   "/_admin/payment-methods": typeof AdminPaymentMethodsRoute;
   "/_admin/products": typeof AdminProductsRoute;
+  "/_admin/reports": typeof AdminReportsRoute;
   "/_admin/services": typeof AdminServicesRoute;
+  "/_admin/shifts": typeof AdminShiftsRoute;
   "/_admin/stores": typeof AdminStoresRoute;
   "/_admin/transactions": typeof AdminTransactionsRoute;
   "/_admin/users": typeof AdminUsersRoute;
@@ -188,7 +206,9 @@ export interface FileRouteTypes {
     | "/customers"
     | "/payment-methods"
     | "/products"
+    | "/reports"
     | "/services"
+    | "/shifts"
     | "/stores"
     | "/transactions"
     | "/users"
@@ -206,7 +226,9 @@ export interface FileRouteTypes {
     | "/customers"
     | "/payment-methods"
     | "/products"
+    | "/reports"
     | "/services"
+    | "/shifts"
     | "/stores"
     | "/transactions"
     | "/users"
@@ -226,7 +248,9 @@ export interface FileRouteTypes {
     | "/_admin/customers"
     | "/_admin/payment-methods"
     | "/_admin/products"
+    | "/_admin/reports"
     | "/_admin/services"
+    | "/_admin/shifts"
     | "/_admin/stores"
     | "/_admin/transactions"
     | "/_admin/users"
@@ -303,11 +327,25 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AdminStoresRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
+    "/_admin/shifts": {
+      id: "/_admin/shifts";
+      path: "/shifts";
+      fullPath: "/shifts";
+      preLoaderRoute: typeof AdminShiftsRouteImport;
+      parentRoute: typeof AdminRouteRoute;
+    };
     "/_admin/services": {
       id: "/_admin/services";
       path: "/services";
       fullPath: "/services";
       preLoaderRoute: typeof AdminServicesRouteImport;
+      parentRoute: typeof AdminRouteRoute;
+    };
+    "/_admin/reports": {
+      id: "/_admin/reports";
+      path: "/reports";
+      fullPath: "/reports";
+      preLoaderRoute: typeof AdminReportsRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
     "/_admin/products": {
@@ -382,7 +420,9 @@ interface AdminRouteRouteChildren {
   AdminCustomersRoute: typeof AdminCustomersRoute;
   AdminPaymentMethodsRoute: typeof AdminPaymentMethodsRoute;
   AdminProductsRoute: typeof AdminProductsRoute;
+  AdminReportsRoute: typeof AdminReportsRoute;
   AdminServicesRoute: typeof AdminServicesRoute;
+  AdminShiftsRoute: typeof AdminShiftsRoute;
   AdminStoresRoute: typeof AdminStoresRoute;
   AdminTransactionsRoute: typeof AdminTransactionsRoute;
   AdminUsersRoute: typeof AdminUsersRoute;
@@ -399,7 +439,9 @@ const AdminRouteRouteChildren: AdminRouteRouteChildren = {
   AdminCustomersRoute: AdminCustomersRoute,
   AdminPaymentMethodsRoute: AdminPaymentMethodsRoute,
   AdminProductsRoute: AdminProductsRoute,
+  AdminReportsRoute: AdminReportsRoute,
   AdminServicesRoute: AdminServicesRoute,
+  AdminShiftsRoute: AdminShiftsRoute,
   AdminStoresRoute: AdminStoresRoute,
   AdminTransactionsRoute: AdminTransactionsRoute,
   AdminUsersRoute: AdminUsersRoute,

--- a/apps/web/src/routes/_admin/campaigns.tsx
+++ b/apps/web/src/routes/_admin/campaigns.tsx
@@ -10,7 +10,6 @@ import { useCallback, useMemo } from "react";
 import { z } from "zod";
 import { DataTable } from "@/components/data-table";
 import { PageHeader } from "@/components/page-header";
-import { TablePagination } from "@/components/table-pagination";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -33,21 +32,15 @@ import {
 	queryKeys,
 	updateCampaign,
 } from "@/lib/api";
-import {
-	campaignsPageQueryOptions,
-	storesQueryOptions,
-} from "@/lib/query-options";
+import { campaignsQueryOptions, storesQueryOptions } from "@/lib/query-options";
 import { formatIDRCurrency } from "@/shared/utils";
 import { getCurrentUser } from "@/stores/auth-store";
 import { useDialog } from "@/stores/dialog-store";
 import { useSheet } from "@/stores/sheet-store";
 
 const campaignsSearchSchema = z.object({
-	page: z.coerce.number().int().positive().catch(1),
 	status: z.enum(["all", "active", "inactive"]).catch("all"),
 });
-
-const PAGE_SIZE = 25;
 
 export const Route = createFileRoute("/_admin/campaigns")({
 	validateSearch: (search) => campaignsSearchSchema.parse(search),
@@ -55,14 +48,10 @@ export const Route = createFileRoute("/_admin/campaigns")({
 	loader: ({ context, deps }) =>
 		Promise.all([
 			context.queryClient.ensureQueryData(
-				campaignsPageQueryOptions(
+				campaignsQueryOptions(
 					deps.status === "all"
-						? { limit: PAGE_SIZE, offset: (deps.page - 1) * PAGE_SIZE }
-						: {
-								is_active: deps.status === "active",
-								limit: PAGE_SIZE,
-								offset: (deps.page - 1) * PAGE_SIZE,
-							},
+						? undefined
+						: { is_active: deps.status === "active" },
 				),
 			),
 			context.queryClient.ensureQueryData(storesQueryOptions()),
@@ -159,22 +148,15 @@ function CampaignsPage() {
 
 	const campaignQueryFilters =
 		search.status === "all"
-			? { limit: PAGE_SIZE, offset: (search.page - 1) * PAGE_SIZE }
-			: {
-					is_active: search.status === "active",
-					limit: PAGE_SIZE,
-					offset: (search.page - 1) * PAGE_SIZE,
-				};
+			? undefined
+			: { is_active: search.status === "active" };
 
-	const campaignsQuery = useQuery(
-		campaignsPageQueryOptions(campaignQueryFilters),
-	);
+	const campaignsQuery = useQuery(campaignsQueryOptions(campaignQueryFilters));
 
 	const storesQuery = useQuery(storesQueryOptions());
 
 	const stores = storesQuery.data ?? [];
-	const campaigns = campaignsQuery.data?.items ?? [];
-	const campaignsMeta = campaignsQuery.data?.meta;
+	const campaigns = campaignsQuery.data ?? [];
 
 	const createMutation = useMutation({
 		mutationKey: ["create-campaign"],
@@ -344,7 +326,7 @@ function CampaignsPage() {
 				actions={
 					<>
 						<Badge variant={campaignsQuery.isPending ? "secondary" : "outline"}>
-							{`${campaignsMeta?.total ?? 0} items`}
+							{`${campaigns.length} items`}
 						</Badge>
 						<Button
 							onClick={handleOpenCreateSheet}
@@ -364,9 +346,7 @@ function CampaignsPage() {
 								value={search.status}
 								onValueChange={(value) => {
 									void navigate({
-										search: (prev) => ({
-											...prev,
-											page: 1,
+										search: () => ({
 											status:
 												(value as z.infer<
 													typeof campaignsSearchSchema
@@ -385,25 +365,11 @@ function CampaignsPage() {
 								</SelectContent>
 							</Select>
 						</div>
-						<div className="grid gap-4">
-							<DataTable
-								columns={columns}
-								data={campaigns}
-								isLoading={campaignsQuery.isPending || storesQuery.isPending}
-							/>
-							<TablePagination
-								meta={campaignsMeta}
-								isLoading={campaignsQuery.isPending}
-								onPageChange={(page) => {
-									void navigate({
-										search: (prev) => ({
-											...prev,
-											page,
-										}),
-									});
-								}}
-							/>
-						</div>
+						<DataTable
+							columns={columns}
+							data={campaigns}
+							isLoading={campaignsQuery.isPending || storesQuery.isPending}
+						/>
 					</CardContent>
 				</Card>
 			</div>

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -219,11 +219,16 @@ function DialogForm({
 	const isPending = updateStatusMutation.isPending;
 
 	const handleConfirm = async () => {
+		const trimmed = note.trim();
 		await updateStatusMutation.mutateAsync({
 			serviceId,
 			payload: {
 				status: nextStatus,
-				note: note.trim() || undefined,
+				...(isCancel
+					? { cancel_reason: trimmed }
+					: trimmed
+						? { note: trimmed }
+						: {}),
 			},
 		});
 		closeDialog();
@@ -611,8 +616,22 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 								<dt className="text-muted-foreground">Subtotal</dt>
 								<dd>{formatIDRCurrency(String(detail.total ?? 0))}</dd>
 							</div>
+							{detail.campaigns.map((row) => (
+								<div key={row.id} className="flex justify-between gap-4">
+									<dt className="text-muted-foreground">
+										{row.campaign?.code ?? "Campaign"}
+										{row.campaign?.name ? (
+											<span className="text-muted-foreground/70">
+												{" "}
+												· {row.campaign.name}
+											</span>
+										) : null}
+									</dt>
+									<dd>-{formatIDRCurrency(String(row.applied_amount ?? 0))}</dd>
+								</div>
+							))}
 							<div className="flex justify-between gap-4">
-								<dt className="text-muted-foreground">Discount</dt>
+								<dt className="text-muted-foreground">Discount total</dt>
 								<dd>-{formatIDRCurrency(String(detail.discount ?? 0))}</dd>
 							</div>
 						</dl>
@@ -905,6 +924,15 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 											</dd>
 										</div>
 									</dl>
+
+									{service.status === "cancelled" && service.cancel_reason ? (
+										<div className="border-destructive/40 bg-destructive/5 border p-3">
+											<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+												Cancel reason
+											</p>
+											<p className="mt-1 text-sm">{service.cancel_reason}</p>
+										</div>
+									) : null}
 
 									<div className="flex flex-wrap gap-2 border-t pt-4">
 										{(ORDER_STATUS_TRANSITIONS[service.status] || []).map(

--- a/apps/web/src/routes/_admin/reports.tsx
+++ b/apps/web/src/routes/_admin/reports.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import dayjs from "dayjs";
+import { z } from "zod";
+import { PageHeader } from "@/components/page-header";
+import { DailyReport } from "@/features/reports/components/daily-report";
+import {
+	dailyReportQueryOptions,
+	storesQueryOptions,
+} from "@/lib/query-options";
+
+const reportsSearchSchema = z.object({
+	date: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/)
+		.catch(() => dayjs().format("YYYY-MM-DD")),
+	store_id: z.coerce.number().int().positive().optional().catch(undefined),
+});
+
+export const Route = createFileRoute("/_admin/reports")({
+	validateSearch: (search) => reportsSearchSchema.parse(search),
+	loaderDeps: ({ search }) => search,
+	loader: ({ context, deps }) =>
+		Promise.all([
+			context.queryClient.ensureQueryData(
+				dailyReportQueryOptions({
+					date: deps.date,
+					store_id: deps.store_id,
+				}),
+			),
+			context.queryClient.ensureQueryData(storesQueryOptions()),
+		]),
+	component: ReportsPage,
+});
+
+function ReportsPage() {
+	const navigate = useNavigate({ from: Route.fullPath });
+	const search = Route.useSearch();
+
+	return (
+		<>
+			<PageHeader
+				title="Daily Report"
+				description="Today's revenue, throughput, and order flow."
+			/>
+			<DailyReport
+				date={search.date}
+				storeId={search.store_id}
+				onDateChange={(date) => {
+					void navigate({
+						search: (prev) => ({ ...prev, date }),
+					});
+				}}
+				onStoreChange={(storeId) => {
+					void navigate({
+						search: (prev) => ({ ...prev, store_id: storeId }),
+					});
+				}}
+			/>
+		</>
+	);
+}

--- a/apps/web/src/routes/_admin/route.tsx
+++ b/apps/web/src/routes/_admin/route.tsx
@@ -72,6 +72,14 @@ const pageMeta: Record<string, { title: string; description?: string }> = {
 		title: "Stores",
 		description: "Insert and edit store master data.",
 	},
+	"/reports": {
+		title: "Daily Report",
+		description: "Revenue, items processed, and order flow for a single day.",
+	},
+	"/shifts": {
+		title: "Shifts",
+		description: "Track worker clock in and clock out history across stores.",
+	},
 	"/users": {
 		title: "Users",
 		description: "Insert and edit users with role management.",

--- a/apps/web/src/routes/_admin/shifts.tsx
+++ b/apps/web/src/routes/_admin/shifts.tsx
@@ -1,0 +1,219 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import dayjs from "dayjs";
+import { useMemo } from "react";
+import { z } from "zod";
+import { DataTable } from "@/components/data-table";
+import { PageHeader } from "@/components/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { Shift } from "@/lib/api";
+import { shiftsQueryOptions, storesQueryOptions } from "@/lib/query-options";
+
+const shiftsSearchSchema = z.object({
+	from: z.string().optional().catch(undefined),
+	store_id: z.coerce.number().int().positive().optional().catch(undefined),
+	to: z.string().optional().catch(undefined),
+});
+
+export const Route = createFileRoute("/_admin/shifts")({
+	validateSearch: (search) => shiftsSearchSchema.parse(search),
+	loaderDeps: ({ search }) => search,
+	loader: ({ context, deps }) =>
+		Promise.all([
+			context.queryClient.ensureQueryData(shiftsQueryOptions(deps)),
+			context.queryClient.ensureQueryData(storesQueryOptions()),
+		]),
+	component: ShiftsPage,
+});
+
+const formatDate = (value: Date | string) =>
+	dayjs(value).format("DD MMM YYYY HH:mm");
+
+const formatDuration = (
+	clockIn: Date | string,
+	clockOut: Date | string | null,
+) => {
+	if (!clockOut) {
+		return "Open";
+	}
+	const ms = dayjs(clockOut).diff(dayjs(clockIn));
+	const totalMinutes = Math.max(0, Math.floor(ms / 60_000));
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+};
+
+function ShiftsPage() {
+	const navigate = useNavigate({ from: Route.fullPath });
+	const search = Route.useSearch();
+	const shiftsQuery = useQuery(shiftsQueryOptions(search));
+	const storesQuery = useQuery(storesQueryOptions());
+	const shifts = shiftsQuery.data ?? [];
+	const stores = storesQuery.data ?? [];
+
+	const columns = useMemo<ColumnDef<Shift>[]>(
+		() => [
+			{
+				id: "user",
+				header: "Worker",
+				cell: ({ row }) => (
+					<div className="flex flex-col">
+						<span className="font-medium">
+							{row.original.user?.name ?? `User #${row.original.user_id}`}
+						</span>
+						<span className="text-muted-foreground text-xs">
+							{row.original.user?.role ?? ""}
+						</span>
+					</div>
+				),
+			},
+			{
+				id: "store",
+				header: "Store",
+				cell: ({ row }) => row.original.store?.code ?? "-",
+			},
+			{
+				id: "clock_in",
+				header: "Clock in",
+				cell: ({ row }) => formatDate(row.original.clock_in_at),
+			},
+			{
+				id: "clock_out",
+				header: "Clock out",
+				cell: ({ row }) =>
+					row.original.clock_out_at
+						? formatDate(row.original.clock_out_at)
+						: "—",
+			},
+			{
+				id: "duration",
+				header: "Duration",
+				cell: ({ row }) => {
+					const open = !row.original.clock_out_at;
+					return (
+						<Badge variant={open ? "success" : "outline"}>
+							{formatDuration(
+								row.original.clock_in_at,
+								row.original.clock_out_at,
+							)}
+						</Badge>
+					);
+				},
+			},
+		],
+		[],
+	);
+
+	return (
+		<>
+			<PageHeader title="Shifts" />
+			<div className="grid gap-4">
+				<Card>
+					<CardContent className="pt-6">
+						<div className="mb-4 flex flex-wrap items-end gap-2">
+							<div className="grid gap-1">
+								<label
+									htmlFor="shifts-store"
+									className="text-muted-foreground text-xs font-medium uppercase"
+								>
+									Store
+								</label>
+								<Select
+									value={
+										search.store_id !== undefined
+											? String(search.store_id)
+											: "all"
+									}
+									onValueChange={(value) => {
+										void navigate({
+											search: (prev) => ({
+												...prev,
+												store_id:
+													!value || value === "all" ? undefined : Number(value),
+											}),
+										});
+									}}
+								>
+									<SelectTrigger
+										id="shifts-store"
+										size="md"
+										className="min-w-40"
+									>
+										<SelectValue placeholder="All stores" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="all">All stores</SelectItem>
+										{stores.map((store) => (
+											<SelectItem key={store.id} value={String(store.id)}>
+												{store.code} · {store.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="grid gap-1">
+								<label
+									htmlFor="shifts-from"
+									className="text-muted-foreground text-xs font-medium uppercase"
+								>
+									From
+								</label>
+								<Input
+									id="shifts-from"
+									type="date"
+									value={search.from ?? ""}
+									onChange={(event) => {
+										const value = event.target.value;
+										void navigate({
+											search: (prev) => ({
+												...prev,
+												from: value || undefined,
+											}),
+										});
+									}}
+								/>
+							</div>
+							<div className="grid gap-1">
+								<label
+									htmlFor="shifts-to"
+									className="text-muted-foreground text-xs font-medium uppercase"
+								>
+									To
+								</label>
+								<Input
+									id="shifts-to"
+									type="date"
+									value={search.to ?? ""}
+									onChange={(event) => {
+										const value = event.target.value;
+										void navigate({
+											search: (prev) => ({
+												...prev,
+												to: value || undefined,
+											}),
+										});
+									}}
+								/>
+							</div>
+						</div>
+						<DataTable
+							columns={columns}
+							data={shifts}
+							isLoading={shiftsQuery.isPending}
+						/>
+					</CardContent>
+				</Card>
+			</div>
+		</>
+	);
+}

--- a/packages/server/src/db/relations.ts
+++ b/packages/server/src/db/relations.ts
@@ -38,6 +38,7 @@ export const relations = defineRelations(schema, (r) => ({
       to: r.ordersTable.created_by,
     }),
     pickupEventsPickedUp: r.many.orderPickupEventsTable(),
+    shifts: r.many.shiftsTable(),
     userStores: r.many.userStoresTable(),
   },
 
@@ -45,6 +46,7 @@ export const relations = defineRelations(schema, (r) => ({
     campaignStores: r.many.campaignStoresTable(),
     customers: r.many.customersTable(),
     orders: r.many.ordersTable(),
+    shifts: r.many.shiftsTable(),
     userStores: r.many.userStoresTable(),
   },
 
@@ -96,7 +98,7 @@ export const relations = defineRelations(schema, (r) => ({
       alias: "campaign_created_by",
       optional: false,
     }),
-    orders: r.many.ordersTable(),
+    orderCampaigns: r.many.orderCampaignsTable(),
     stores: r.many.campaignStoresTable(),
     updatedBy: r.one.usersTable({
       from: r.campaignsTable.updated_by,
@@ -133,10 +135,7 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   ordersTable: {
-    campaign: r.one.campaignsTable({
-      from: r.ordersTable.campaign_id,
-      to: r.campaignsTable.id,
-    }),
+    campaigns: r.many.orderCampaignsTable(),
     createdBy: r.one.usersTable({
       from: r.ordersTable.created_by,
       to: r.usersTable.id,
@@ -287,6 +286,32 @@ export const relations = defineRelations(schema, (r) => ({
     product: r.one.productsTable({
       from: r.ordersProductsTable.product_id,
       to: r.productsTable.id,
+    }),
+  },
+
+  orderCampaignsTable: {
+    campaign: r.one.campaignsTable({
+      from: r.orderCampaignsTable.campaign_id,
+      to: r.campaignsTable.id,
+      optional: false,
+    }),
+    order: r.one.ordersTable({
+      from: r.orderCampaignsTable.order_id,
+      to: r.ordersTable.id,
+      optional: false,
+    }),
+  },
+
+  shiftsTable: {
+    store: r.one.storesTable({
+      from: r.shiftsTable.store_id,
+      to: r.storesTable.id,
+      optional: false,
+    }),
+    user: r.one.usersTable({
+      from: r.shiftsTable.user_id,
+      to: r.usersTable.id,
+      optional: false,
     }),
   },
 }));

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -292,6 +292,37 @@ export const userStoresTable = pgTable(
   ]
 );
 
+export const shiftsTable = pgTable(
+  "shifts",
+  {
+    clock_in_at: timestamp("clock_in_at").defaultNow().notNull(),
+    clock_out_at: timestamp("clock_out_at"),
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    store_id: integer("store_id")
+      .references(() => storesTable.id, { onDelete: "restrict" })
+      .notNull(),
+    updated_at: timestamp("updated_at")
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+    user_id: integer("user_id")
+      .references(() => usersTable.id, { onDelete: "cascade" })
+      .notNull(),
+  },
+  (table) => [
+    index("shifts_user_clock_in_idx").on(table.user_id, table.clock_in_at),
+    index("shifts_store_clock_in_idx").on(table.store_id, table.clock_in_at),
+    uniqueIndex("shifts_user_open_uidx")
+      .on(table.user_id)
+      .where(sql`${table.clock_out_at} IS NULL`),
+    check(
+      "shifts_clock_out_after_clock_in_check",
+      sql`${table.clock_out_at} IS NULL OR ${table.clock_out_at} >= ${table.clock_in_at}`
+    ),
+  ]
+);
+
 export const ordersTable = pgTable(
   "orders",
   {
@@ -303,7 +334,6 @@ export const ordersTable = pgTable(
     created_at: timestamp("created_at").notNull().defaultNow(),
 
     // cashier
-    campaign_id: integer("campaign_id").references(() => campaignsTable.id),
     created_by: integer("created_by")
       .references(() => usersTable.id)
       .notNull(),
@@ -357,7 +387,6 @@ export const ordersTable = pgTable(
     index("order_store_idx").on(table.store_id),
     index("order_store_created_at_idx").on(table.store_id, table.created_at),
     index("order_customer_idx").on(table.customer_id),
-    index("order_campaign_idx").on(table.campaign_id),
     index("order_payment_status_idx").on(table.payment_status),
     index("order_status_idx").on(table.status),
     index("order_created_at_idx").on(table.created_at),
@@ -397,11 +426,46 @@ export const orderCountersTable = pgTable(
   ]
 );
 
+export const orderCampaignsTable = pgTable(
+  "order_campaigns",
+  {
+    applied_amount: decimal("applied_amount", { precision: 12 })
+      .default("0")
+      .notNull(),
+    campaign_id: integer("campaign_id")
+      .references(() => campaignsTable.id, { onDelete: "restrict" })
+      .notNull(),
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    discount_type: campaignDiscountTypeEnum("discount_type").notNull(),
+    discount_value: decimal("discount_value", { precision: 12 })
+      .default("0")
+      .notNull(),
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    max_discount: decimal("max_discount", { precision: 12 }),
+    order_id: integer("order_id")
+      .references(() => ordersTable.id, { onDelete: "cascade" })
+      .notNull(),
+  },
+  (table) => [
+    index("order_campaigns_order_idx").on(table.order_id),
+    index("order_campaigns_campaign_idx").on(table.campaign_id),
+    uniqueIndex("order_campaigns_order_campaign_uidx").on(
+      table.order_id,
+      table.campaign_id
+    ),
+    check(
+      "order_campaigns_applied_amount_non_negative_check",
+      sql`${table.applied_amount} >= 0`
+    ),
+  ]
+);
+
 export const ordersServicesTable = pgTable(
   "orders_services",
   {
     discount: decimal("discount", { precision: 12 }).default("0").notNull(),
 
+    cancel_reason: text("cancel_reason"),
     handler_id: integer("handler_id").references(() => usersTable.id),
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
     is_priority: boolean("is_priority").default(false).notNull(),

--- a/packages/server/src/db/seed/run-seed.ts
+++ b/packages/server/src/db/seed/run-seed.ts
@@ -7,6 +7,7 @@ import {
   campaignsTable,
   categoriesTable,
   customersTable,
+  orderCampaignsTable,
   orderCountersTable,
   orderPickupEventsTable,
   orderRefundItemsTable,
@@ -509,6 +510,7 @@ async function resetDatabase() {
       "order_pickup_events",
       "orders_products",
       "orders_services",
+      "order_campaigns",
       "orders",
       "order_counters",
       "campaign_stores",
@@ -717,7 +719,20 @@ async function seedCatalog(adminId: number) {
 
   const campaignSeed = [
     {
+      code: "GOOGLE_REVIEW",
+      name: "Google review",
+      discount_type: "percentage" as const,
+      discount_value: 10,
+      min_order_total: 0,
+      max_discount: null,
+      starts_at: null,
+      ends_at: null,
+      is_active: true,
+      scope_codes: [],
+    },
+    {
       code: "WEEKEND10",
+      name: faker.company.buzzPhrase(),
       discount_type: "percentage" as const,
       discount_value: 10,
       min_order_total: 120_000,
@@ -729,6 +744,7 @@ async function seedCatalog(adminId: number) {
     },
     {
       code: "NEWCUST15",
+      name: faker.company.buzzPhrase(),
       discount_type: "fixed" as const,
       discount_value: 15_000,
       min_order_total: 75_000,
@@ -740,6 +756,7 @@ async function seedCatalog(adminId: number) {
     },
     {
       code: "PAYDAY20",
+      name: faker.company.buzzPhrase(),
       discount_type: "percentage" as const,
       discount_value: 20,
       min_order_total: 150_000,
@@ -751,6 +768,7 @@ async function seedCatalog(adminId: number) {
     },
     {
       code: "BKSOPEN25",
+      name: faker.company.buzzPhrase(),
       discount_type: "fixed" as const,
       discount_value: 25_000,
       min_order_total: 100_000,
@@ -767,7 +785,7 @@ async function seedCatalog(adminId: number) {
     .values(
       campaignSeed.map((campaign) => ({
         code: campaign.code,
-        name: faker.company.buzzPhrase(),
+        name: campaign.name,
         discount_type: campaign.discount_type,
         discount_value: asMoney(campaign.discount_value),
         min_order_total: asMoney(campaign.min_order_total),
@@ -1119,7 +1137,6 @@ async function seedOrders(params: {
         code: orderCode,
         customer_id: customerId,
         store_id: store.id,
-        campaign_id: discountRes.campaign_id,
         discount_source: discountRes.discount_source,
         discount: asMoney(discount),
         dropoff_photo_path: dropoffPhotoPath,
@@ -1141,6 +1158,26 @@ async function seedOrders(params: {
         updated_at: updatedAt,
       })
       .returning({ id: ordersTable.id });
+
+    if (discountRes.campaign_id !== null && discount > 0) {
+      const campaign = params.campaigns.find(
+        (item) => item.id === discountRes.campaign_id
+      );
+      if (campaign) {
+        await db.insert(orderCampaignsTable).values({
+          order_id: order.id,
+          campaign_id: campaign.id,
+          discount_type: campaign.discount_type,
+          discount_value: asMoney(campaign.discount_value),
+          max_discount:
+            campaign.max_discount === null
+              ? null
+              : asMoney(campaign.max_discount),
+          applied_amount: asMoney(discount),
+          created_at: createdAt,
+        });
+      }
+    }
 
     const insertedServices = draftServices.length
       ? await db

--- a/packages/server/src/modules/campaigns/campaign.repository.ts
+++ b/packages/server/src/modules/campaigns/campaign.repository.ts
@@ -11,11 +11,14 @@ export function listCampaigns(filters: CampaignFilters) {
   return db.query.campaignsTable.findMany({
     where: {
       is_active: filters.is_active,
-      stores: filters.store_id
+      ...(filters.store_id !== undefined
         ? {
-            OR: [{ store_id: filters.store_id }, { NOT: { store: true } }],
+            OR: [
+              { stores: { store_id: filters.store_id } },
+              { NOT: { stores: true } },
+            ],
           }
-        : undefined,
+        : {}),
     },
     orderBy: { id: "asc" },
     with: {

--- a/packages/server/src/modules/campaigns/campaign.repository.ts
+++ b/packages/server/src/modules/campaigns/campaign.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, type SQL, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { campaignStoresTable, campaignsTable } from "@/db/schema";
 
@@ -7,41 +7,7 @@ interface CampaignFilters {
   store_id?: number;
 }
 
-function buildCountWhere(filters: CampaignFilters) {
-  const conditions: SQL[] = [];
-
-  if (filters.is_active !== undefined) {
-    conditions.push(eq(campaignsTable.is_active, filters.is_active));
-  }
-
-  if (filters.store_id !== undefined) {
-    conditions.push(sql`(
-      EXISTS (
-        SELECT 1
-        FROM ${campaignStoresTable} scoped_store
-        WHERE scoped_store.campaign_id = ${campaignsTable.id}
-        AND scoped_store.store_id = ${filters.store_id}
-      )
-      OR NOT EXISTS (
-        SELECT 1
-        FROM ${campaignStoresTable} any_store
-        WHERE any_store.campaign_id = ${campaignsTable.id}
-      )
-    )`);
-  }
-
-  return conditions.length > 0 ? and(...conditions) : undefined;
-}
-
-export function listCampaigns({
-  filters,
-  limit,
-  offset,
-}: {
-  filters: CampaignFilters;
-  limit: number;
-  offset: number;
-}) {
+export function listCampaigns(filters: CampaignFilters) {
   return db.query.campaignsTable.findMany({
     where: {
       is_active: filters.is_active,
@@ -52,8 +18,6 @@ export function listCampaigns({
         : undefined,
     },
     orderBy: { id: "asc" },
-    limit,
-    offset,
     with: {
       stores: {
         columns: { store_id: true },
@@ -69,10 +33,6 @@ export function listCampaigns({
       },
     },
   });
-}
-
-export function countCampaigns(filters: CampaignFilters) {
-  return db.$count(campaignsTable, buildCountWhere(filters));
 }
 
 export function findCampaignById(id: number) {

--- a/packages/server/src/modules/campaigns/campaign.schema.ts
+++ b/packages/server/src/modules/campaigns/campaign.schema.ts
@@ -21,8 +21,6 @@ export const CampaignPayloadSchema = z.object({
 export const GETCampaignsQuerySchema = z
   .object({
     is_active: z.stringbool().optional(),
-    limit: z.coerce.number().int().min(1).max(100).optional(),
-    offset: z.coerce.number().int().min(0).optional(),
     store_id: z.coerce.number().int().positive().optional(),
   })
   .optional();

--- a/packages/server/src/modules/campaigns/campaign.service.ts
+++ b/packages/server/src/modules/campaigns/campaign.service.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, ForbiddenException } from "@/errors";
 import {
-  countCampaigns,
   deleteCampaignById,
   findCampaignById,
   findStoresByIds,
@@ -13,7 +12,6 @@ import type {
   GetCampaignsQuery,
 } from "@/modules/campaigns/campaign.schema";
 import type { JWTPayload } from "@/types";
-import { buildPaginationMeta, normalizePagination } from "@/utils/pagination";
 
 function assertIsAdmin(user: JWTPayload) {
   if (user.role !== "admin") {
@@ -33,26 +31,11 @@ async function ensureStoresExist(storeIds: number[]) {
   }
 }
 
-export async function getCampaigns(query?: GetCampaignsQuery) {
-  const pagination = normalizePagination(query, { maxPageSize: 100 });
-  const filters = {
+export function getCampaigns(query?: GetCampaignsQuery) {
+  return listCampaigns({
     is_active: query?.is_active,
     store_id: query?.store_id,
-  };
-
-  const [items, total] = await Promise.all([
-    listCampaigns({
-      filters,
-      limit: pagination.limit,
-      offset: pagination.offset,
-    }),
-    countCampaigns(filters),
-  ]);
-
-  return {
-    items,
-    meta: buildPaginationMeta(total, pagination),
-  };
+  });
 }
 
 export function getCampaignById(id: number) {

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 import { orderServiceStatusEnum } from "@/db/schema";
 import { MAX_PAGE_SIZE } from "@/modules/orders/order.schema";
+import { dateStringSchema } from "@/schema/common";
 import { normalizePagination } from "@/utils/pagination";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
-
-const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 export const ORDER_STATUS_TRANSITIONS: Record<
   (typeof orderServiceStatusEnum.enumValues)[number],
@@ -62,10 +61,21 @@ export const POSTOrderPickupEventSchema = z.object({
   service_ids: z.array(z.coerce.number().int().positive()).min(1),
 });
 
-export const PATCHOrderServiceStatusSchema = z.object({
-  note: z.string().trim().optional(),
-  status: z.enum(orderServiceStatusEnum.enumValues),
-});
+export const PATCHOrderServiceStatusSchema = z
+  .object({
+    cancel_reason: z.string().trim().max(1000).optional(),
+    note: z.string().trim().optional(),
+    status: z.enum(orderServiceStatusEnum.enumValues),
+  })
+  .superRefine((value, ctx) => {
+    if (value.status === "cancelled" && !value.cancel_reason?.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Cancel reason is required when cancelling a service",
+        path: ["cancel_reason"],
+      });
+    }
+  });
 
 export const PATCHOrderServiceHandlerSchema = z.object({
   handler_id: z.coerce.number().int().positive().nullable(),
@@ -119,14 +129,8 @@ export const GETOrderServiceQueueQuerySchema = z
     store_id: z.coerce.number().int().positive().optional(),
     search: z.string().trim().min(1).max(100).optional(),
     status: z.enum(orderServiceStatusEnum.enumValues).optional(),
-    date_from: z
-      .string()
-      .regex(dateRegex, "date_from must use YYYY-MM-DD format")
-      .optional(),
-    date_to: z
-      .string()
-      .regex(dateRegex, "date_to must use YYYY-MM-DD format")
-      .optional(),
+    date_from: dateStringSchema("date_from").optional(),
+    date_to: dateStringSchema("date_to").optional(),
   })
   .refine(
     (query) =>

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -509,7 +509,12 @@ export async function getOrderDetailById(id: number) {
   const detail = await db.query.ordersTable.findFirst({
     where: { id },
     with: {
-      campaign: true,
+      campaigns: {
+        with: {
+          campaign: true,
+        },
+        orderBy: { id: "asc" },
+      },
       customer: true,
       paymentMethod: true,
       pickupEvents: {
@@ -854,10 +859,20 @@ export async function updateOrderServiceStatus({
     const needsHandlerAssign =
       isClaimTransition && locked.handler_id !== user.id;
 
+    const cancelReason =
+      body.status === "cancelled" ? body.cancel_reason?.trim() : undefined;
+    const cancelReasonPatch = cancelReason
+      ? { cancel_reason: cancelReason }
+      : {};
+
     if (needsHandlerAssign) {
       await tx
         .update(ordersServicesTable)
-        .set({ handler_id: user.id, status: body.status })
+        .set({
+          handler_id: user.id,
+          status: body.status,
+          ...cancelReasonPatch,
+        })
         .where(eq(ordersServicesTable.id, serviceId));
 
       await tx.insert(orderServiceHandlerLogsTable).values({
@@ -870,7 +885,10 @@ export async function updateOrderServiceStatus({
     } else {
       await tx
         .update(ordersServicesTable)
-        .set({ status: body.status })
+        .set({
+          status: body.status,
+          ...cancelReasonPatch,
+        })
         .where(eq(ordersServicesTable.id, serviceId));
     }
 

--- a/packages/server/src/modules/orders/order.schema.ts
+++ b/packages/server/src/modules/orders/order.schema.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import { orderPaymentStatusEnum, orderStatusEnum } from "@/db/schema";
+import { dateStringSchema } from "@/schema/common";
 import { normalizePagination } from "@/utils/pagination";
 
 export const DEFAULT_PAGE_SIZE = 25;
 export const MAX_PAGE_SIZE = 100;
-
-const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 export const GETOrdersQuerySchema = z
   .object({
@@ -21,14 +20,8 @@ export const GETOrdersQuerySchema = z
     created_by: z.coerce.number().int().positive().optional(),
     payment_method_id: z.coerce.number().int().positive().optional(),
 
-    date_from: z
-      .string()
-      .regex(dateRegex, "date_from must use YYYY-MM-DD format")
-      .optional(),
-    date_to: z
-      .string()
-      .regex(dateRegex, "date_to must use YYYY-MM-DD format")
-      .optional(),
+    date_from: dateStringSchema("date_from").optional(),
+    date_to: dateStringSchema("date_to").optional(),
 
     sort_by: z.enum(["created_at", "code", "id", "total"]).default("id"),
     sort_order: z.enum(["asc", "desc"]).default("desc"),

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { eq } from "drizzle-orm";
 import type z from "zod";
 import { db } from "@/db";
-import { ordersTable } from "@/db/schema";
+import { orderCampaignsTable, ordersTable } from "@/db/schema";
 import {
   BadRequestException,
   ForbiddenException,
@@ -27,6 +27,7 @@ import {
 import { findServices } from "@/modules/services/service.repository";
 import { findUserById } from "@/modules/users/user.repository";
 import type { POSTOrderSchema } from "@/schema";
+import { stackCampaignDiscounts } from "@/schema/discount";
 import type { JWTPayload } from "@/types";
 import type { Store } from "@/types/entity";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
@@ -46,9 +47,18 @@ interface ExpandedServiceItem {
   size?: string;
 }
 
+interface ResolvedCampaignRow {
+  applied_amount: string;
+  campaign_id: number;
+  discount_type: "fixed" | "percentage";
+  discount_value: string;
+  max_discount: string | null;
+}
+
 interface ResolvedDiscount {
   discountAmount: number;
   discountSource: "none" | "manual" | "campaign";
+  campaignRows: ResolvedCampaignRow[];
 }
 
 function expandServices(
@@ -100,79 +110,139 @@ function buildOrderServiceRows({
   });
 }
 
+type ValidatedCampaign = Awaited<
+  ReturnType<OrderTx["query"]["campaignsTable"]["findFirst"]>
+>;
+
+async function loadAndValidateCampaigns({
+  tx,
+  campaignIds,
+  grossTotal,
+  storeId,
+  storeCode,
+}: {
+  tx: OrderTx;
+  campaignIds: number[];
+  grossTotal: number;
+  storeId: number;
+  storeCode: string;
+}) {
+  const campaigns = await tx.query.campaignsTable.findMany({
+    where: { id: { in: campaignIds } },
+    with: {
+      stores: { columns: { store_id: true } },
+    },
+  });
+
+  const campaignsById = new Map(campaigns.map((item) => [item.id, item]));
+  const missing = campaignIds.filter((id) => !campaignsById.has(id));
+  if (missing.length > 0) {
+    throw new NotFoundException(`Campaign not found: ${missing.join(", ")}`);
+  }
+
+  const now = new Date();
+  for (const campaign of campaigns) {
+    assertCampaignUsable(campaign, {
+      now,
+      grossTotal,
+      storeId,
+      storeCode,
+    });
+  }
+
+  return campaigns;
+}
+
+function assertCampaignUsable(
+  campaign: NonNullable<ValidatedCampaign> & { stores: { store_id: number }[] },
+  {
+    now,
+    grossTotal,
+    storeId,
+    storeCode,
+  }: { now: Date; grossTotal: number; storeId: number; storeCode: string }
+) {
+  if (!campaign.is_active) {
+    throw new BadRequestException(`Campaign ${campaign.code} is not active`);
+  }
+  if (campaign.starts_at && now < campaign.starts_at) {
+    throw new BadRequestException(
+      `Campaign ${campaign.code} has not started yet`
+    );
+  }
+  if (campaign.ends_at && now > campaign.ends_at) {
+    throw new BadRequestException(`Campaign ${campaign.code} has ended`);
+  }
+
+  const storeScopes = campaign.stores.map((item) => item.store_id);
+  if (storeScopes.length > 0 && !storeScopes.includes(storeId)) {
+    throw new BadRequestException(
+      `Campaign ${campaign.code} is not available for store ${storeCode}`
+    );
+  }
+
+  if (grossTotal < Number(campaign.min_order_total)) {
+    throw new BadRequestException(
+      `Order total does not meet minimum for campaign ${campaign.code}`
+    );
+  }
+}
+
 async function resolveDiscount({
   tx,
-  campaignId,
+  campaignIds,
   grossTotal,
   manualDiscount,
   storeId,
   storeCode,
 }: {
   tx: OrderTx;
-  campaignId?: number;
+  campaignIds: number[];
   grossTotal: number;
   manualDiscount: number;
   storeId: number;
   storeCode: string;
 }): Promise<ResolvedDiscount> {
-  if (campaignId === undefined) {
+  if (campaignIds.length === 0) {
     return {
       discountAmount: manualDiscount,
       discountSource: manualDiscount > 0 ? "manual" : "none",
+      campaignRows: [],
     };
   }
 
-  const campaign = await tx.query.campaignsTable.findFirst({
-    where: { id: campaignId },
-    with: {
-      stores: {
-        columns: {
-          store_id: true,
-        },
-      },
-    },
+  const campaigns = await loadAndValidateCampaigns({
+    tx,
+    campaignIds,
+    grossTotal,
+    storeId,
+    storeCode,
   });
 
-  if (!campaign) {
-    throw new NotFoundException(`Campaign not found: ${campaignId}`);
-  }
-  if (!campaign.is_active) {
-    throw new BadRequestException("Campaign is not active");
-  }
+  const { total: campaignDiscount, breakdown } = stackCampaignDiscounts(
+    grossTotal,
+    campaigns
+  );
 
-  const now = new Date();
-  if (campaign.starts_at && now < campaign.starts_at) {
-    throw new BadRequestException("Campaign has not started yet");
-  }
-  if (campaign.ends_at && now > campaign.ends_at) {
-    throw new BadRequestException("Campaign has ended");
-  }
+  const campaignRows: ResolvedCampaignRow[] = breakdown.map(
+    ({ campaign, amount }) => ({
+      applied_amount: amount.toString(),
+      campaign_id: campaign.id,
+      discount_type: campaign.discount_type,
+      discount_value: campaign.discount_value,
+      max_discount: campaign.max_discount,
+    })
+  );
 
-  const storeScopes = campaign.stores.map((item) => item.store_id);
-  if (storeScopes.length > 0 && !storeScopes.includes(storeId)) {
-    throw new BadRequestException(
-      `Campaign is not available for store ${storeCode}`
-    );
-  }
-
-  if (grossTotal < Number(campaign.min_order_total)) {
-    throw new BadRequestException(
-      "Order total does not meet campaign minimum order value"
-    );
-  }
-
-  let discountAmount =
-    campaign.discount_type === "fixed"
-      ? Number(campaign.discount_value)
-      : (grossTotal * Number(campaign.discount_value)) / 100;
-
-  if (campaign.max_discount !== null) {
-    discountAmount = Math.min(discountAmount, Number(campaign.max_discount));
-  }
+  const totalDiscount = Math.min(
+    grossTotal,
+    campaignDiscount + Math.max(0, manualDiscount)
+  );
 
   return {
-    discountAmount,
-    discountSource: discountAmount > 0 ? "campaign" : "none",
+    discountAmount: totalDiscount,
+    discountSource: campaignDiscount > 0 ? "campaign" : "manual",
+    campaignRows,
   };
 }
 
@@ -212,7 +282,7 @@ export async function createOrder(
   const {
     products = [],
     services = [],
-    campaign_id,
+    campaign_ids = [],
     ...orderPayload
   } = payload;
 
@@ -258,7 +328,6 @@ export async function createOrder(
       payment_status: orderPayload.payment_status,
       discount: "0",
       discount_source: "none",
-      campaign_id,
       paid_amount: "0",
       notes: orderPayload.notes,
       status: expandedServices.length > 0 ? "created" : "completed",
@@ -309,17 +378,31 @@ export async function createOrder(
     ]);
 
     const grossTotal = serviceSubtotal + productSubtotal;
-    const { discountAmount, discountSource } = await resolveDiscount({
-      tx,
-      campaignId: campaign_id,
-      grossTotal,
-      manualDiscount: Number(orderPayload.discount),
-      storeId: store.id,
-      storeCode: store.code,
-    });
+    const { discountAmount, discountSource, campaignRows } =
+      await resolveDiscount({
+        tx,
+        campaignIds: [...new Set(campaign_ids)],
+        grossTotal,
+        manualDiscount: Number(orderPayload.discount),
+        storeId: store.id,
+        storeCode: store.code,
+      });
 
     if (discountAmount > grossTotal) {
       throw new BadRequestException("Order discount cannot exceed order total");
+    }
+
+    if (campaignRows.length > 0) {
+      await tx.insert(orderCampaignsTable).values(
+        campaignRows.map((row) => ({
+          order_id: orderId,
+          campaign_id: row.campaign_id,
+          discount_type: row.discount_type,
+          discount_value: row.discount_value,
+          max_discount: row.max_discount,
+          applied_amount: row.applied_amount,
+        }))
+      );
     }
 
     const netTotal = grossTotal - discountAmount;
@@ -327,7 +410,6 @@ export async function createOrder(
     await tx
       .update(ordersTable)
       .set({
-        campaign_id,
         total: grossTotal.toString(),
         discount: discountAmount.toString(),
         discount_source: discountSource,

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -203,10 +203,12 @@ async function resolveDiscount({
   storeId: number;
   storeCode: string;
 }): Promise<ResolvedDiscount> {
+  const manual = Math.max(0, manualDiscount);
+
   if (campaignIds.length === 0) {
     return {
-      discountAmount: manualDiscount,
-      discountSource: manualDiscount > 0 ? "manual" : "none",
+      discountAmount: manual,
+      discountSource: manual > 0 ? "manual" : "none",
       campaignRows: [],
     };
   }
@@ -234,14 +236,20 @@ async function resolveDiscount({
     })
   );
 
-  const totalDiscount = Math.min(
-    grossTotal,
-    campaignDiscount + Math.max(0, manualDiscount)
-  );
+  const afterCampaign = Math.max(0, grossTotal - campaignDiscount);
+  const appliedManual = Math.min(manual, afterCampaign);
+  const totalDiscount = campaignDiscount + appliedManual;
+
+  let discountSource: ResolvedDiscount["discountSource"] = "none";
+  if (campaignDiscount > 0) {
+    discountSource = "campaign";
+  } else if (manual > 0) {
+    discountSource = "manual";
+  }
 
   return {
     discountAmount: totalDiscount,
-    discountSource: campaignDiscount > 0 ? "campaign" : "manual",
+    discountSource,
     campaignRows,
   };
 }

--- a/packages/server/src/modules/reports/report.repository.ts
+++ b/packages/server/src/modules/reports/report.repository.ts
@@ -1,0 +1,124 @@
+import { and, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  orderPickupEventsTable,
+  orderServiceStatusLogsTable,
+  ordersServicesTable,
+  ordersTable,
+} from "@/db/schema";
+
+const ITEM_PROCESSED_STATUSES = ["ready_for_pickup", "quality_check"] as const;
+
+interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+export async function sumDailyRevenue({
+  range,
+  storeId,
+}: {
+  range: DateRange;
+  storeId?: number;
+}) {
+  const conditions = [
+    gte(ordersTable.paid_at, range.start),
+    lt(ordersTable.paid_at, range.end),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const [row] = await db
+    .select({
+      revenue: sql<string>`COALESCE(SUM(${ordersTable.paid_amount} - ${ordersTable.refunded_amount}), 0)`,
+    })
+    .from(ordersTable)
+    .where(and(...conditions));
+
+  return Number(row?.revenue ?? 0);
+}
+
+export async function countDailyItemsProcessed({
+  range,
+  storeId,
+}: {
+  range: DateRange;
+  storeId?: number;
+}) {
+  const conditions = [
+    inArray(orderServiceStatusLogsTable.to_status, [
+      ...ITEM_PROCESSED_STATUSES,
+    ]),
+    gte(orderServiceStatusLogsTable.created_at, range.start),
+    lt(orderServiceStatusLogsTable.created_at, range.end),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const [row] = await db
+    .select({
+      count: sql<number>`COUNT(DISTINCT ${orderServiceStatusLogsTable.order_service_id})::int`,
+    })
+    .from(orderServiceStatusLogsTable)
+    .innerJoin(
+      ordersServicesTable,
+      eq(orderServiceStatusLogsTable.order_service_id, ordersServicesTable.id)
+    )
+    .innerJoin(ordersTable, eq(ordersServicesTable.order_id, ordersTable.id))
+    .where(and(...conditions));
+
+  return Number(row?.count ?? 0);
+}
+
+export async function countDailyOrdersIn({
+  range,
+  storeId,
+}: {
+  range: DateRange;
+  storeId?: number;
+}) {
+  const conditions = [
+    gte(ordersTable.created_at, range.start),
+    lt(ordersTable.created_at, range.end),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const [row] = await db
+    .select({
+      count: sql<number>`COUNT(*)::int`,
+    })
+    .from(ordersTable)
+    .where(and(...conditions));
+
+  return Number(row?.count ?? 0);
+}
+
+export async function countDailyOrdersOut({
+  range,
+  storeId,
+}: {
+  range: DateRange;
+  storeId?: number;
+}) {
+  const conditions = [
+    gte(orderPickupEventsTable.picked_up_at, range.start),
+    lt(orderPickupEventsTable.picked_up_at, range.end),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const [row] = await db
+    .select({
+      count: sql<number>`COUNT(DISTINCT ${orderPickupEventsTable.order_id})::int`,
+    })
+    .from(orderPickupEventsTable)
+    .innerJoin(ordersTable, eq(orderPickupEventsTable.order_id, ordersTable.id))
+    .where(and(...conditions));
+
+  return Number(row?.count ?? 0);
+}

--- a/packages/server/src/modules/reports/report.schema.ts
+++ b/packages/server/src/modules/reports/report.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { dateStringSchema } from "@/schema/common";
+
+export const GETDailyReportQuerySchema = z.object({
+  date: dateStringSchema("date"),
+  store_id: z.coerce.number().int().positive().optional(),
+});
+
+export type GetDailyReportQuery = z.infer<typeof GETDailyReportQuerySchema>;

--- a/packages/server/src/modules/reports/report.service.ts
+++ b/packages/server/src/modules/reports/report.service.ts
@@ -1,0 +1,40 @@
+import {
+  countDailyItemsProcessed,
+  countDailyOrdersIn,
+  countDailyOrdersOut,
+  sumDailyRevenue,
+} from "@/modules/reports/report.repository";
+import type { GetDailyReportQuery } from "@/modules/reports/report.schema";
+
+// Asia/Jakarta is UTC+7 year-round (no DST).
+const JAKARTA_OFFSET_MINUTES = 7 * 60;
+
+function getJakartaDayRange(date: string) {
+  const [year, month, day] = date.split("-").map(Number);
+  const startUtcMs =
+    Date.UTC(year, month - 1, day, 0, 0, 0) - JAKARTA_OFFSET_MINUTES * 60_000;
+  const start = new Date(startUtcMs);
+  const end = new Date(startUtcMs + 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
+export async function getDailyReport(query: GetDailyReportQuery) {
+  const range = getJakartaDayRange(query.date);
+  const storeId = query.store_id;
+
+  const [revenue, itemsProcessed, ordersIn, ordersOut] = await Promise.all([
+    sumDailyRevenue({ range, storeId }),
+    countDailyItemsProcessed({ range, storeId }),
+    countDailyOrdersIn({ range, storeId }),
+    countDailyOrdersOut({ range, storeId }),
+  ]);
+
+  return {
+    date: query.date,
+    store_id: storeId ?? null,
+    revenue,
+    items_processed: itemsProcessed,
+    orders_in: ordersIn,
+    orders_out: ordersOut,
+  };
+}

--- a/packages/server/src/modules/shifts/shift.repository.ts
+++ b/packages/server/src/modules/shifts/shift.repository.ts
@@ -1,0 +1,64 @@
+import dayjs from "dayjs";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { shiftsTable } from "@/db/schema";
+import type { GetShiftsQuery } from "@/modules/shifts/shift.schema";
+
+export function insertShift(values: { user_id: number; store_id: number }) {
+  return db
+    .insert(shiftsTable)
+    .values({
+      user_id: values.user_id,
+      store_id: values.store_id,
+    })
+    .returning()
+    .then((rows) => rows[0]);
+}
+
+export function findOpenShiftByUserId(userId: number) {
+  return db.query.shiftsTable.findFirst({
+    where: {
+      user_id: userId,
+      clock_out_at: { isNull: true },
+    },
+    with: {
+      store: {
+        columns: { id: true, code: true, name: true },
+      },
+    },
+  });
+}
+
+export function updateShiftClockOutById(shiftId: number) {
+  return db
+    .update(shiftsTable)
+    .set({ clock_out_at: new Date() })
+    .where(eq(shiftsTable.id, shiftId))
+    .returning()
+    .then((rows) => rows[0] ?? null);
+}
+
+export function listShifts(query?: GetShiftsQuery) {
+  return db.query.shiftsTable.findMany({
+    where: {
+      user_id: query?.user_id,
+      store_id: query?.store_id,
+      clock_in_at: {
+        gte: query?.from
+          ? dayjs(query.from).startOf("day").toDate()
+          : undefined,
+        lte: query?.to ? dayjs(query.to).endOf("day").toDate() : undefined,
+      },
+    },
+    orderBy: { clock_in_at: "desc" },
+    with: {
+      store: {
+        columns: { id: true, code: true, name: true },
+      },
+      user: {
+        columns: { id: true, name: true, username: true, role: true },
+      },
+    },
+    limit: 500,
+  });
+}

--- a/packages/server/src/modules/shifts/shift.schema.ts
+++ b/packages/server/src/modules/shifts/shift.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { dateStringSchema } from "@/schema/common";
+
+export const POSTClockInSchema = z.object({
+  store_id: z.coerce.number().int().positive(),
+});
+
+export const GETShiftsQuerySchema = z
+  .object({
+    from: dateStringSchema("from").optional(),
+    store_id: z.coerce.number().int().positive().optional(),
+    to: dateStringSchema("to").optional(),
+    user_id: z.coerce.number().int().positive().optional(),
+  })
+  .optional();
+
+export type ClockInInput = z.infer<typeof POSTClockInSchema>;
+export type GetShiftsQuery = z.infer<typeof GETShiftsQuerySchema>;

--- a/packages/server/src/modules/shifts/shift.service.ts
+++ b/packages/server/src/modules/shifts/shift.service.ts
@@ -23,7 +23,22 @@ export async function clockIn({
     throw new BadRequestException("You already have an open shift");
   }
 
-  return insertShift({ user_id: user.id, store_id: storeId });
+  try {
+    return await insertShift({ user_id: user.id, store_id: storeId });
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "cause" in error &&
+      typeof error.cause === "object" &&
+      error.cause !== null &&
+      "code" in error.cause &&
+      error.cause.code === "23505"
+    ) {
+      throw new BadRequestException("You already have an open shift");
+    }
+    throw error;
+  }
 }
 
 export async function clockOut(user: JWTPayload) {

--- a/packages/server/src/modules/shifts/shift.service.ts
+++ b/packages/server/src/modules/shifts/shift.service.ts
@@ -1,0 +1,47 @@
+import { BadRequestException, NotFoundException } from "@/errors";
+import {
+  findOpenShiftByUserId,
+  insertShift,
+  listShifts,
+  updateShiftClockOutById,
+} from "@/modules/shifts/shift.repository";
+import type { GetShiftsQuery } from "@/modules/shifts/shift.schema";
+import type { JWTPayload } from "@/types";
+import { assertStoreAccess } from "@/utils/authorization";
+
+export async function clockIn({
+  user,
+  storeId,
+}: {
+  user: JWTPayload;
+  storeId: number;
+}) {
+  await assertStoreAccess(user, storeId);
+
+  const existing = await findOpenShiftByUserId(user.id);
+  if (existing) {
+    throw new BadRequestException("You already have an open shift");
+  }
+
+  return insertShift({ user_id: user.id, store_id: storeId });
+}
+
+export async function clockOut(user: JWTPayload) {
+  const open = await findOpenShiftByUserId(user.id);
+  if (!open) {
+    throw new NotFoundException("No open shift to close");
+  }
+
+  return updateShiftClockOutById(open.id);
+}
+
+export function getCurrentShift(user: JWTPayload) {
+  return findOpenShiftByUserId(user.id);
+}
+
+export function getShifts(user: JWTPayload, query?: GetShiftsQuery) {
+  if (user.role !== "admin") {
+    return listShifts({ ...query, user_id: user.id });
+  }
+  return listShifts(query);
+}

--- a/packages/server/src/routes/admin/campaigns.ts
+++ b/packages/server/src/routes/admin/campaigns.ts
@@ -20,9 +20,9 @@ const app = new Hono()
   .get("/", zodValidator("query", GETCampaignsQuerySchema), async (c) => {
     const query = c.req.valid("query");
 
-    const { items, meta } = await getCampaigns(query);
+    const items = await getCampaigns(query);
 
-    return c.json(success(items, undefined, meta));
+    return c.json(success(items));
   })
   .get("/:id", idParamSchema, async (c) => {
     const { id } = c.req.valid("param");

--- a/packages/server/src/routes/admin/index.ts
+++ b/packages/server/src/routes/admin/index.ts
@@ -7,7 +7,9 @@ import orderServiceImagesRoutes from "@/routes/admin/order-service-images";
 import ordersRoutes from "@/routes/admin/orders";
 import paymentMethodsRoutes from "@/routes/admin/payment-methods";
 import productsRoutes from "@/routes/admin/products";
+import reportsRoutes from "@/routes/admin/reports";
 import servicesRoutes from "@/routes/admin/services";
+import shiftsRoutes from "@/routes/admin/shifts";
 import storeRoutes from "@/routes/admin/stores";
 import usersRoutes from "@/routes/admin/users";
 
@@ -22,6 +24,8 @@ const app = new Hono()
   .route("/payment-methods", paymentMethodsRoutes)
   .route("/orders", ordersRoutes)
   .route("/order-service-images", orderServiceImagesRoutes)
+  .route("/shifts", shiftsRoutes)
+  .route("/reports", reportsRoutes)
   .route("/dashboard", dashboardRoutes);
 
 export default app;

--- a/packages/server/src/routes/admin/reports.ts
+++ b/packages/server/src/routes/admin/reports.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import { GETDailyReportQuerySchema } from "@/modules/reports/report.schema";
+import { getDailyReport } from "@/modules/reports/report.service";
+import { success } from "@/utils/http";
+import { zodValidator } from "@/utils/zod-validator-wrapper";
+
+const app = new Hono().get(
+  "/daily",
+  zodValidator("query", GETDailyReportQuerySchema),
+  async (c) => {
+    const query = c.req.valid("query");
+    const data = await getDailyReport(query);
+    return c.json(success(data));
+  }
+);
+
+export default app;

--- a/packages/server/src/routes/admin/shifts.ts
+++ b/packages/server/src/routes/admin/shifts.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import {
+  GETShiftsQuerySchema,
+  POSTClockInSchema,
+} from "@/modules/shifts/shift.schema";
+import {
+  clockIn,
+  clockOut,
+  getCurrentShift,
+  getShifts,
+} from "@/modules/shifts/shift.service";
+import type { JWTPayload } from "@/types";
+import { success } from "@/utils/http";
+import { zodValidator } from "@/utils/zod-validator-wrapper";
+
+const app = new Hono()
+  .get("/", zodValidator("query", GETShiftsQuerySchema), async (c) => {
+    const user = c.get("jwtPayload") as JWTPayload;
+    const query = c.req.valid("query");
+
+    const items = await getShifts(user, query);
+
+    return c.json(success(items));
+  })
+  .get("/current", async (c) => {
+    const user = c.get("jwtPayload") as JWTPayload;
+    const shift = await getCurrentShift(user);
+    return c.json(success(shift ?? null));
+  })
+  .post("/clock-in", zodValidator("json", POSTClockInSchema), async (c) => {
+    const user = c.get("jwtPayload") as JWTPayload;
+    const body = c.req.valid("json");
+
+    const shift = await clockIn({ user, storeId: body.store_id });
+
+    return c.json(
+      success(shift, "Clocked in successfully"),
+      StatusCodes.CREATED
+    );
+  })
+  .post("/clock-out", async (c) => {
+    const user = c.get("jwtPayload") as JWTPayload;
+    const shift = await clockOut(user);
+    return c.json(success(shift, "Clocked out successfully"));
+  });
+
+export default app;

--- a/packages/server/src/schema/common.ts
+++ b/packages/server/src/schema/common.ts
@@ -48,6 +48,13 @@ export const currencySchema = (field: string) =>
     .pipe(z.number().nonnegative(`${field} cannot be negative`))
     .pipe(z.coerce.string());
 
+const DATE_YYYY_MM_DD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export const dateStringSchema = (field: string) =>
+  z
+    .string()
+    .regex(DATE_YYYY_MM_DD_REGEX, `${field} must use YYYY-MM-DD format`);
+
 export const phoneSchema = z
   .string("Phone number is required!")
   .min(1, "Phone number is required!")

--- a/packages/server/src/schema/discount.ts
+++ b/packages/server/src/schema/discount.ts
@@ -49,10 +49,11 @@ export function stackCampaignDiscounts<T extends CampaignDiscountInput>(
   grossTotal: number,
   campaigns: T[]
 ): StackedDiscount<T> {
-  const ordered = [
-    ...campaigns.filter((c) => c.discount_type === "percentage"),
-    ...campaigns.filter((c) => c.discount_type === "fixed"),
-  ];
+  const ordered = [...campaigns].sort(
+    (a, b) =>
+      computeCampaignContribution(b, grossTotal, grossTotal) -
+      computeCampaignContribution(a, grossTotal, grossTotal)
+  );
 
   let running = 0;
   const breakdown: CampaignContribution<T>[] = [];

--- a/packages/server/src/schema/discount.ts
+++ b/packages/server/src/schema/discount.ts
@@ -1,0 +1,71 @@
+export interface CampaignDiscountInput {
+  discount_type: "fixed" | "percentage";
+  discount_value: string;
+  max_discount: string | null;
+  min_order_total?: string | null;
+}
+
+export interface CampaignContribution<T extends CampaignDiscountInput> {
+  campaign: T;
+  amount: number;
+}
+
+export interface StackedDiscount<T extends CampaignDiscountInput> {
+  total: number;
+  breakdown: CampaignContribution<T>[];
+}
+
+export function computeCampaignContribution(
+  campaign: CampaignDiscountInput,
+  grossTotal: number,
+  remaining: number
+): number {
+  if (remaining <= 0) {
+    return 0;
+  }
+
+  const minOrderTotal = Number(campaign.min_order_total ?? 0);
+  if (grossTotal < minOrderTotal) {
+    return 0;
+  }
+
+  let contribution =
+    campaign.discount_type === "percentage"
+      ? (remaining * Number(campaign.discount_value)) / 100
+      : Number(campaign.discount_value);
+
+  const maxDiscount =
+    campaign.max_discount !== null && campaign.max_discount !== undefined
+      ? Number(campaign.max_discount)
+      : null;
+  if (maxDiscount !== null && maxDiscount > 0) {
+    contribution = Math.min(contribution, maxDiscount);
+  }
+  contribution = Math.min(contribution, remaining);
+  return Math.max(0, Math.round(contribution));
+}
+
+export function stackCampaignDiscounts<T extends CampaignDiscountInput>(
+  grossTotal: number,
+  campaigns: T[]
+): StackedDiscount<T> {
+  const ordered = [
+    ...campaigns.filter((c) => c.discount_type === "percentage"),
+    ...campaigns.filter((c) => c.discount_type === "fixed"),
+  ];
+
+  let running = 0;
+  const breakdown: CampaignContribution<T>[] = [];
+
+  for (const campaign of ordered) {
+    const amount = computeCampaignContribution(
+      campaign,
+      grossTotal,
+      grossTotal - running
+    );
+    running += amount;
+    breakdown.push({ campaign, amount });
+  }
+
+  return { total: running, breakdown };
+}

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -9,6 +9,22 @@ import { ORDER_STATUS_TRANSITIONS as _ORDER_STATUS_TRANSITIONS } from "@/modules
 export const ORDER_STATUS_TRANSITIONS = _ORDER_STATUS_TRANSITIONS;
 
 import {
+  type CampaignContribution as _CampaignContribution,
+  type CampaignDiscountInput as _CampaignDiscountInput,
+  computeCampaignContribution as _computeCampaignContribution,
+  type StackedDiscount as _StackedDiscount,
+  stackCampaignDiscounts as _stackCampaignDiscounts,
+} from "@/schema/discount";
+
+export type CampaignContribution<T extends _CampaignDiscountInput> =
+  _CampaignContribution<T>;
+export type CampaignDiscountInput = _CampaignDiscountInput;
+export type StackedDiscount<T extends _CampaignDiscountInput> =
+  _StackedDiscount<T>;
+export const computeCampaignContribution = _computeCampaignContribution;
+export const stackCampaignDiscounts = _stackCampaignDiscounts;
+
+import {
   currencySchema,
   isActiveSchema,
   optionalVarcharSchema,
@@ -180,7 +196,13 @@ export const POSTOrderSchema = z
   .object({
     customer_id: z.number("Customer is required"),
     store_id: z.number("Store ID is required"),
-    campaign_id: z.number().int().positive().optional(),
+    campaign_ids: z
+      .array(z.number().int().positive())
+      .default([])
+      .refine(
+        (ids) => new Set(ids).size === ids.length,
+        "Duplicate campaign IDs are not allowed"
+      ),
     products: z
       .array(
         z.object(
@@ -227,13 +249,6 @@ export const POSTOrderSchema = z
     {
       error: "Product or Service is required",
       path: ["products_ids", "services_ids"],
-    }
-  )
-  .refine(
-    (val) => !(Number(val.discount) > 0 && val.campaign_id !== undefined),
-    {
-      error: "Campaign discount cannot be combined with manual discount",
-      path: ["campaign_id"],
     }
   )
   .refine(


### PR DESCRIPTION
## Summary

- **Server**: voucher stacking via `order_campaigns` junction + shared discount math in `@fresclean/api/schema`; shift tracking (clock in/out) with partial unique index enforcing one open shift per user; campaign store-filter fix; discount math caps manual discount after campaign stacking; clock-in surfaces 23505 as a 400.
- **Web**: shift clock card + daily report; campaign multi-select autocomplete with store-scoped pruning (nested-button a11y fix via combobox trigger); sidebar footer redesign (avatar, theme dropdown, logout icon, role badge).

## Test plan

- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes (`bun x ultracite check`)
- [x] Smoke test: login → dashboard → sidebar footer renders avatar/name/role/theme toggle/logout/shift card
- [x] Theme dropdown: Light/Dark/System switches `html.className`
- [x] Orders/new → pick store → campaign autocomplete enables, select + remove works
- [x] No DOM validation / hydration warnings in console (nested-button fix verified)
- [ ] Manual: verify campaign pruning when selected campaign is store-scoped and store is changed
- [ ] Manual: clock-in twice → second attempt returns 400 "already open shift"
- [ ] Manual: order with campaign + manual discount → verify total discount caps at grossTotal and `discountSource` reflects the dominant type

🤖 Generated with [Claude Code](https://claude.com/claude-code)