### PR TITLE
refactor(orders): split cancel/refund by payment status

### DIFF
--- a/apps/web/src/features/orders/components/cancel-order-form.tsx
+++ b/apps/web/src/features/orders/components/cancel-order-form.tsx
@@ -1,0 +1,47 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+type CancelOrderMutation = UseMutationResult<unknown, Error, string, unknown>;
+
+interface CancelOrderFormProps {
+	closeDialog: () => void;
+	cancelOrderMutation: CancelOrderMutation;
+}
+
+export const CancelOrderForm = ({
+	closeDialog,
+	cancelOrderMutation,
+}: CancelOrderFormProps) => {
+	const [reason, setReason] = useState("");
+	const trimmed = reason.trim();
+	const isPending = cancelOrderMutation.isPending;
+
+	const handleConfirm = async () => {
+		await cancelOrderMutation.mutateAsync(trimmed);
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Textarea
+				placeholder="Cancel reason (required)"
+				value={reason}
+				onChange={(event) => setReason(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button
+					variant="destructive"
+					disabled={isPending || !trimmed}
+					onClick={handleConfirm}
+				>
+					{isPending ? "Cancelling…" : "Confirm Cancel Order"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/order-service-dialog.types.ts
+++ b/apps/web/src/features/orders/components/order-service-dialog.types.ts
@@ -1,0 +1,28 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { UpdateOrderServiceStatusPayload } from "@/lib/api";
+
+export type UpdateStatusMutation = UseMutationResult<
+	unknown,
+	Error,
+	{ serviceId: number; payload: UpdateOrderServiceStatusPayload },
+	unknown
+>;
+
+export type NonCancelServiceStatus = Exclude<
+	UpdateOrderServiceStatusPayload["status"],
+	"cancelled"
+>;
+
+export const STATUS_ACTION_LABELS: Record<
+	UpdateOrderServiceStatusPayload["status"],
+	string
+> = {
+	queued: "Queue",
+	processing: "Process",
+	quality_check: "Quality Check",
+	qc_reject: "Reject at QC",
+	ready_for_pickup: "Ready for Pickup",
+	picked_up: "Pick Up",
+	refunded: "Refund",
+	cancelled: "Cancel",
+};

--- a/apps/web/src/features/orders/components/refund-order-form.tsx
+++ b/apps/web/src/features/orders/components/refund-order-form.tsx
@@ -1,8 +1,75 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import type { UseMutationResult } from "@tanstack/react-query";
-import { useState } from "react";
+import {
+	Controller,
+	FormProvider,
+	useFieldArray,
+	useForm,
+	useFormContext,
+	useWatch,
+} from "react-hook-form";
+import { z } from "zod";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type { CreateOrderRefundPayload, OrderRefundReason } from "@/lib/api";
+
+const REFUND_REASONS = [
+	"damaged",
+	"cannot_process",
+	"lost",
+	"other",
+	"customer_cancelled",
+] as const satisfies readonly OrderRefundReason[];
+
+const formatRefundReason = (reason: OrderRefundReason) =>
+	reason.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+
+const refundFormSchema = z
+	.object({
+		items: z.array(
+			z.object({
+				order_service_id: z.number(),
+				selected: z.boolean(),
+				reason: z.enum(REFUND_REASONS),
+				note: z.string().optional(),
+			}),
+		),
+		note: z.string().optional(),
+	})
+	.superRefine((data, ctx) => {
+		const selectedCount = data.items.filter((item) => item.selected).length;
+		if (selectedCount === 0) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["items"],
+				message: "Select at least one item to refund.",
+			});
+		}
+		data.items.forEach((item, index) => {
+			if (
+				item.selected &&
+				item.reason === "other" &&
+				!(item.note ?? "").trim()
+			) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["items", index, "note"],
+					message: "Note is required when reason is Other.",
+				});
+			}
+		});
+	});
+
+type RefundFormValues = z.infer<typeof refundFormSchema>;
 
 type RefundOrderMutation = UseMutationResult<
 	unknown,
@@ -11,70 +78,225 @@ type RefundOrderMutation = UseMutationResult<
 	unknown
 >;
 
+export interface RefundableServiceOption {
+	id: number;
+	item_code: string | null;
+}
+
 interface RefundOrderFormProps {
 	closeDialog: () => void;
 	orderId: number;
-	refundServiceIds: number[];
+	refundableServices: RefundableServiceOption[];
 	refundMutation: RefundOrderMutation;
-	reason?: OrderRefundReason;
 }
 
 export const RefundOrderForm = ({
 	closeDialog,
 	orderId,
-	refundServiceIds,
+	refundableServices,
 	refundMutation,
-	reason = "customer_cancelled",
 }: RefundOrderFormProps) => {
-	const [note, setNote] = useState("");
+	const form = useForm<RefundFormValues>({
+		resolver: zodResolver(refundFormSchema),
+		defaultValues: {
+			items: refundableServices.map((service) => ({
+				order_service_id: service.id,
+				selected: false,
+				reason: "damaged",
+				note: "",
+			})),
+			note: "",
+		},
+	});
+	const { fields } = useFieldArray({ control: form.control, name: "items" });
 	const isPending = refundMutation.isPending;
-	const trimmedNote = note.trim();
-	const itemNoteRequired = reason === "other" && !trimmedNote;
+	const itemsError = form.formState.errors.items;
+	const itemsRootMessage =
+		itemsError && !Array.isArray(itemsError)
+			? (itemsError as { message?: string }).message
+			: undefined;
 
-	const handleConfirm = async () => {
+	const handleSelectAll = () => {
+		fields.forEach((_, index) => {
+			form.setValue(`items.${index}.selected`, true, { shouldDirty: true });
+		});
+		form.clearErrors("items");
+	};
+
+	const handleClear = () => {
+		fields.forEach((_, index) => {
+			form.setValue(`items.${index}.selected`, false, { shouldDirty: true });
+		});
+	};
+
+	const onSubmit = async (values: RefundFormValues) => {
+		const items = values.items
+			.filter((item) => item.selected)
+			.map((item) => ({
+				order_service_id: item.order_service_id,
+				reason: item.reason,
+				note: item.note?.trim() || undefined,
+			}));
+
 		await refundMutation.mutateAsync({
 			orderId,
 			payload: {
-				note: trimmedNote || undefined,
-				items: refundServiceIds.map((serviceId) => ({
-					order_service_id: serviceId,
-					reason,
-					note: trimmedNote || undefined,
-				})),
+				items,
+				note: values.note?.trim() || undefined,
 			},
 		});
 		closeDialog();
 	};
 
 	return (
-		<div className="flex flex-col gap-4">
-			<p className="text-muted-foreground text-sm">
-				Refund {refundServiceIds.length} remaining service
-				{refundServiceIds.length === 1 ? "" : "s"}.
-			</p>
-			<Textarea
-				placeholder={
-					reason === "other"
-						? "Refund note (required)"
-						: "Refund note (optional)"
-				}
-				value={note}
-				onChange={(event) => setNote(event.target.value)}
+		<FormProvider {...form}>
+			<form
+				className="flex flex-col gap-4"
+				onSubmit={form.handleSubmit(onSubmit)}
+			>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<p className="text-muted-foreground text-sm">
+						Select items to refund and choose a reason for each.
+					</p>
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleSelectAll}
+							disabled={isPending || fields.length === 0}
+						>
+							Select all
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleClear}
+							disabled={isPending || fields.length === 0}
+						>
+							Clear
+						</Button>
+					</div>
+				</div>
+
+				{itemsRootMessage ? (
+					<p className="text-destructive text-xs">{itemsRootMessage}</p>
+				) : null}
+
+				<div className="grid max-h-[50vh] gap-3 overflow-y-auto pr-1">
+					{fields.map((field, index) => (
+						<RefundItemRow
+							key={field.id}
+							index={index}
+							label={
+								refundableServices[index]?.item_code ??
+								`Service #${refundableServices[index]?.id ?? index + 1}`
+							}
+							disabled={isPending}
+						/>
+					))}
+				</div>
+
+				<Field>
+					<FieldLabel htmlFor="refund-note">Refund note (optional)</FieldLabel>
+					<Textarea
+						id="refund-note"
+						placeholder="General refund note"
+						disabled={isPending}
+						{...form.register("note")}
+					/>
+				</Field>
+
+				<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+					<Button
+						type="button"
+						variant="outline"
+						onClick={closeDialog}
+						disabled={isPending}
+					>
+						Go back
+					</Button>
+					<Button type="submit" variant="destructive" disabled={isPending}>
+						{isPending ? "Refunding…" : "Confirm refund"}
+					</Button>
+				</div>
+			</form>
+		</FormProvider>
+	);
+};
+
+interface RefundItemRowProps {
+	disabled: boolean;
+	index: number;
+	label: string;
+}
+
+const RefundItemRow = ({ disabled, index, label }: RefundItemRowProps) => {
+	const { control, register } = useFormContext<RefundFormValues>();
+	const selected =
+		useWatch({ control, name: `items.${index}.selected` }) ?? false;
+	const inputsDisabled = disabled || !selected;
+	const checkboxId = `refund-item-${index}`;
+
+	return (
+		<div className="grid gap-2 border p-3">
+			<Controller
+				control={control}
+				name={`items.${index}.selected`}
+				render={({ field }) => (
+					<Field orientation="horizontal">
+						<Checkbox
+							id={checkboxId}
+							checked={field.value}
+							onCheckedChange={(value) => field.onChange(Boolean(value))}
+							disabled={disabled}
+						/>
+						<FieldLabel htmlFor={checkboxId}>{label}</FieldLabel>
+					</Field>
+				)}
 			/>
-			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-				<Button variant="outline" onClick={closeDialog}>
-					Go back
-				</Button>
-				<Button
-					variant="destructive"
-					disabled={
-						isPending || refundServiceIds.length === 0 || itemNoteRequired
-					}
-					onClick={handleConfirm}
-				>
-					{isPending ? "Refunding…" : "Confirm Refund Order"}
-				</Button>
-			</div>
+
+			<Controller
+				control={control}
+				name={`items.${index}.reason`}
+				render={({ field }) => (
+					<Select
+						value={field.value}
+						onValueChange={(value) =>
+							field.onChange((value ?? "damaged") as OrderRefundReason)
+						}
+						disabled={inputsDisabled}
+					>
+						<SelectTrigger size="md" className="w-full">
+							<SelectValue placeholder="Select reason" />
+						</SelectTrigger>
+						<SelectContent>
+							{REFUND_REASONS.map((reason) => (
+								<SelectItem key={reason} value={reason}>
+									{formatRefundReason(reason)}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				)}
+			/>
+
+			<Controller
+				control={control}
+				name={`items.${index}.note`}
+				render={({ fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<Textarea
+							placeholder="Reason note"
+							disabled={inputsDisabled}
+							aria-invalid={fieldState.invalid}
+							{...register(`items.${index}.note`)}
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
 		</div>
 	);
 };

--- a/apps/web/src/features/orders/components/refund-order-form.tsx
+++ b/apps/web/src/features/orders/components/refund-order-form.tsx
@@ -1,0 +1,80 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { CreateOrderRefundPayload, OrderRefundReason } from "@/lib/api";
+
+type RefundOrderMutation = UseMutationResult<
+	unknown,
+	Error,
+	{ orderId: number; payload: CreateOrderRefundPayload },
+	unknown
+>;
+
+interface RefundOrderFormProps {
+	closeDialog: () => void;
+	orderId: number;
+	refundServiceIds: number[];
+	refundMutation: RefundOrderMutation;
+	reason?: OrderRefundReason;
+}
+
+export const RefundOrderForm = ({
+	closeDialog,
+	orderId,
+	refundServiceIds,
+	refundMutation,
+	reason = "customer_cancelled",
+}: RefundOrderFormProps) => {
+	const [note, setNote] = useState("");
+	const isPending = refundMutation.isPending;
+	const trimmedNote = note.trim();
+	const itemNoteRequired = reason === "other" && !trimmedNote;
+
+	const handleConfirm = async () => {
+		await refundMutation.mutateAsync({
+			orderId,
+			payload: {
+				note: trimmedNote || undefined,
+				items: refundServiceIds.map((serviceId) => ({
+					order_service_id: serviceId,
+					reason,
+					note: trimmedNote || undefined,
+				})),
+			},
+		});
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<p className="text-muted-foreground text-sm">
+				Refund {refundServiceIds.length} remaining service
+				{refundServiceIds.length === 1 ? "" : "s"}.
+			</p>
+			<Textarea
+				placeholder={
+					reason === "other"
+						? "Refund note (required)"
+						: "Refund note (optional)"
+				}
+				value={note}
+				onChange={(event) => setNote(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button
+					variant="destructive"
+					disabled={
+						isPending || refundServiceIds.length === 0 || itemNoteRequired
+					}
+					onClick={handleConfirm}
+				>
+					{isPending ? "Refunding…" : "Confirm Refund Order"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/service-cancel-button.tsx
+++ b/apps/web/src/features/orders/components/service-cancel-button.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/ui/button";
+import { useDialog } from "@/stores/dialog-store";
+import {
+	STATUS_ACTION_LABELS,
+	type UpdateStatusMutation,
+} from "./order-service-dialog.types";
+import { ServiceCancelForm } from "./service-cancel-form";
+
+interface ServiceCancelButtonProps {
+	serviceId: number;
+	updateStatusMutation: UpdateStatusMutation;
+}
+
+export const ServiceCancelButton = ({
+	serviceId,
+	updateStatusMutation,
+}: ServiceCancelButtonProps) => {
+	const openDialog = useDialog((s) => s.openDialog);
+	const closeDialog = useDialog((s) => s.closeDialog);
+
+	const handleClick = () => {
+		openDialog({
+			title: "Cancel Service",
+			description: "Please provide a reason for cancelling this service.",
+			content: () => (
+				<ServiceCancelForm
+					serviceId={serviceId}
+					updateStatusMutation={updateStatusMutation}
+					closeDialog={closeDialog}
+				/>
+			),
+		});
+	};
+
+	return (
+		<Button variant="destructive" size="sm" onClick={handleClick}>
+			{STATUS_ACTION_LABELS.cancelled}
+		</Button>
+	);
+};

--- a/apps/web/src/features/orders/components/service-cancel-form.tsx
+++ b/apps/web/src/features/orders/components/service-cancel-form.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { UpdateStatusMutation } from "./order-service-dialog.types";
+
+interface ServiceCancelFormProps {
+	serviceId: number;
+	updateStatusMutation: UpdateStatusMutation;
+	closeDialog: () => void;
+}
+
+export const ServiceCancelForm = ({
+	serviceId,
+	updateStatusMutation,
+	closeDialog,
+}: ServiceCancelFormProps) => {
+	const [reason, setReason] = useState("");
+	const trimmed = reason.trim();
+	const isPending = updateStatusMutation.isPending;
+
+	const handleConfirm = async () => {
+		await updateStatusMutation.mutateAsync({
+			serviceId,
+			payload: { status: "cancelled", cancel_reason: trimmed },
+		});
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Textarea
+				placeholder="Cancel reason (required)"
+				value={reason}
+				onChange={(event) => setReason(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button
+					variant="destructive"
+					disabled={isPending || !trimmed}
+					onClick={handleConfirm}
+				>
+					{isPending ? "Saving…" : "Confirm Cancel"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/service-status-confirm-form.tsx
+++ b/apps/web/src/features/orders/components/service-status-confirm-form.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+	NonCancelServiceStatus,
+	UpdateStatusMutation,
+} from "./order-service-dialog.types";
+
+interface ServiceStatusConfirmFormProps {
+	serviceId: number;
+	nextStatus: NonCancelServiceStatus;
+	updateStatusMutation: UpdateStatusMutation;
+	closeDialog: () => void;
+}
+
+export const ServiceStatusConfirmForm = ({
+	serviceId,
+	nextStatus,
+	updateStatusMutation,
+	closeDialog,
+}: ServiceStatusConfirmFormProps) => {
+	const [note, setNote] = useState("");
+	const isPending = updateStatusMutation.isPending;
+
+	const handleConfirm = async () => {
+		const trimmed = note.trim();
+		await updateStatusMutation.mutateAsync({
+			serviceId,
+			payload: {
+				status: nextStatus,
+				...(trimmed ? { note: trimmed } : {}),
+			},
+		});
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Textarea
+				placeholder="Optional status note"
+				value={note}
+				onChange={(event) => setNote(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button disabled={isPending} onClick={handleConfirm}>
+					{isPending ? "Saving…" : "Confirm Update"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/service-status-update-button.tsx
+++ b/apps/web/src/features/orders/components/service-status-update-button.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button";
+import { useDialog } from "@/stores/dialog-store";
+import {
+	type NonCancelServiceStatus,
+	STATUS_ACTION_LABELS,
+	type UpdateStatusMutation,
+} from "./order-service-dialog.types";
+import { ServiceStatusConfirmForm } from "./service-status-confirm-form";
+
+interface ServiceStatusUpdateButtonProps {
+	serviceId: number;
+	nextStatus: NonCancelServiceStatus;
+	updateStatusMutation: UpdateStatusMutation;
+}
+
+export const ServiceStatusUpdateButton = ({
+	serviceId,
+	nextStatus,
+	updateStatusMutation,
+}: ServiceStatusUpdateButtonProps) => {
+	const openDialog = useDialog((s) => s.openDialog);
+	const closeDialog = useDialog((s) => s.closeDialog);
+
+	const handleClick = () => {
+		openDialog({
+			title: `Update Status to ${STATUS_ACTION_LABELS[nextStatus]}`,
+			description: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
+			content: () => (
+				<ServiceStatusConfirmForm
+					serviceId={serviceId}
+					nextStatus={nextStatus}
+					updateStatusMutation={updateStatusMutation}
+					closeDialog={closeDialog}
+				/>
+			),
+		});
+	};
+
+	return (
+		<Button variant="secondary" size="sm" onClick={handleClick}>
+			{STATUS_ACTION_LABELS[nextStatus]}
+		</Button>
+	);
+};

--- a/apps/web/src/features/orders/lib/create-order-workflow.ts
+++ b/apps/web/src/features/orders/lib/create-order-workflow.ts
@@ -1,6 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { fetchOrderDetail, queryKeys } from "@/lib/api";
+import { queryKeys } from "@/lib/api";
 
 type HandleCreatedOrderSuccessOptions = {
 	created: unknown;
@@ -37,21 +36,9 @@ export async function handleCreatedOrderSuccess({
 	await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard });
 
 	if (!orderId) {
-		toast.success("Order created");
 		onFallbackNavigate();
 		return;
 	}
 
-	const detail = await fetchOrderDetail(orderId);
-	const itemCodes = detail.services
-		.map((item) => item.item_code)
-		.filter(Boolean) as string[];
-	const preview = itemCodes.slice(0, 3).join(", ");
-	const suffix = itemCodes.length > 3 ? ` +${itemCodes.length - 3} more` : "";
-
-	toast.success("Order created", {
-		description:
-			itemCodes.length > 0 ? `Item tags: ${preview}${suffix}` : undefined,
-	});
 	onOrderDetailNavigate(orderId);
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -378,6 +378,10 @@ export type CreateOrderRefundPayload = {
 	}>;
 };
 
+export type CancelOrderPayload = {
+	cancel_reason: string;
+};
+
 export type UpdateUserStoresPayload = {
 	store_ids: number[];
 };
@@ -1004,6 +1008,18 @@ export async function createOrderRefund(
 ) {
 	return parseResponse(
 		rpcWithAuth().api.admin.orders[":id"].refunds.$post({
+			param: { id: String(orderId) },
+			json: payload,
+		}),
+	);
+}
+
+export async function cancelOrder(
+	orderId: number,
+	payload: CancelOrderPayload,
+) {
+	return parseResponse(
+		rpcWithAuth().api.admin.orders[":id"].cancel.$post({
 			param: { id: String(orderId) },
 			json: payload,
 		}),

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -367,7 +367,12 @@ export type CreateOrderPickupEventPayload = z.infer<
 	typeof POSTOrderPickupEventSchema
 >;
 
-export type OrderRefundReason = "damaged" | "cannot_process" | "lost" | "other";
+export type OrderRefundReason =
+	| "damaged"
+	| "cannot_process"
+	| "lost"
+	| "other"
+	| "customer_cancelled";
 
 export type CreateOrderRefundPayload = {
 	note?: string;

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -9,8 +9,6 @@ import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
 	Select,
@@ -21,7 +19,6 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
 import { CancelOrderForm } from "@/features/orders/components/cancel-order-form";
 import { OrderDropoffPhotoCard } from "@/features/orders/components/order-dropoff-photo-card";
 import { OrderFulfillmentOverview } from "@/features/orders/components/order-fulfillment-overview";
@@ -82,14 +79,6 @@ export const Route = createFileRoute("/_admin/orders/$orderId")({
 	},
 	component: OrderDetailPage,
 });
-
-const REFUND_REASONS = [
-	"damaged",
-	"cannot_process",
-	"lost",
-	"other",
-	"customer_cancelled",
-] as const;
 
 const formatRefundReason = (reason: string) =>
 	reason.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
@@ -235,15 +224,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 	>({});
 	const [selectedPaymentMethodId, setSelectedPaymentMethodId] = useState("");
 
-	const [refundServiceIds, setRefundServiceIds] = useState<number[]>([]);
-	const [refundReasonByServiceId, setRefundReasonByServiceId] = useState<
-		Record<number, (typeof REFUND_REASONS)[number]>
-	>({});
-	const [refundItemNoteByServiceId, setRefundItemNoteByServiceId] = useState<
-		Record<number, string>
-	>({});
-	const [refundNote, setRefundNote] = useState("");
-
 	const detailQuery = useQuery(orderDetailQueryOptions(id));
 
 	const paymentMethodsQuery = useQuery(paymentMethodsQueryOptions());
@@ -331,10 +311,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 			payload: Parameters<typeof createOrderRefund>[1];
 		}) => createOrderRefund(targetOrderId, payload),
 		onSuccess: async () => {
-			setRefundServiceIds([]);
-			setRefundReasonByServiceId({});
-			setRefundItemNoteByServiceId({});
-			setRefundNote("");
 			await refreshOrderData();
 		},
 	});
@@ -439,28 +415,21 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 	const openRefundOrderDialog = () => {
 		openDialog({
 			title: "Refund order",
-			description:
-				"All remaining items will be refunded as customer cancelled.",
+			description: "Select items to refund and provide reasons.",
+			contentClassName: "sm:max-w-xl",
 			content: () => (
 				<RefundOrderForm
 					closeDialog={closeDialog}
 					orderId={id}
-					refundServiceIds={refundableServices.map((service) => service.id)}
+					refundableServices={refundableServices.map((service) => ({
+						id: service.id,
+						item_code: service.item_code ?? null,
+					}))}
 					refundMutation={refundMutation}
 				/>
 			),
 		});
 	};
-
-	const selectedRefundItems = refundServiceIds.map((serviceId) => ({
-		order_service_id: serviceId,
-		reason: refundReasonByServiceId[serviceId] ?? "damaged",
-		note: refundItemNoteByServiceId[serviceId]?.trim() || undefined,
-	}));
-
-	const refundValidationError = selectedRefundItems.find(
-		(item) => item.reason === "other" && !item.note,
-	);
 
 	const trackingUrl = (() => {
 		const phone = detail.customer?.phone_number ?? "";
@@ -687,139 +656,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 							</CardContent>
 						</Card>
 					) : null}
-
-					{isAdmin && (
-						<Card>
-							<CardHeader>
-								<CardTitle>Refund</CardTitle>
-							</CardHeader>
-							<CardContent className="grid gap-3">
-								<div className="flex gap-2">
-									<Button
-										variant="outline"
-										onClick={() =>
-											setRefundServiceIds(
-												refundableServices.map((service) => service.id),
-											)
-										}
-									>
-										Select all refundable
-									</Button>
-									<Button
-										variant="outline"
-										onClick={() => setRefundServiceIds([])}
-									>
-										Clear
-									</Button>
-								</div>
-
-								{refundableServices.map((service) => {
-									const selected = refundServiceIds.includes(service.id);
-									const reason =
-										refundReasonByServiceId[service.id] ?? "damaged";
-									return (
-										<div key={service.id} className="grid gap-2 border p-3">
-											<Field orientation="horizontal">
-												<Checkbox
-													id={`refund-service-${service.id}`}
-													checked={selected}
-													onCheckedChange={(value) => {
-														if (value) {
-															setRefundServiceIds((prev) =>
-																prev.includes(service.id)
-																	? prev
-																	: [...prev, service.id],
-															);
-															return;
-														}
-														setRefundServiceIds((prev) =>
-															prev.filter((id) => id !== service.id),
-														);
-													}}
-												/>
-												<FieldLabel htmlFor={`refund-service-${service.id}`}>
-													{service.item_code ?? `Service #${service.id}`}
-												</FieldLabel>
-											</Field>
-
-											<Select
-												value={reason}
-												onValueChange={(value) =>
-													setRefundReasonByServiceId((prev) => ({
-														...prev,
-														[service.id]: (value ??
-															"damaged") as (typeof REFUND_REASONS)[number],
-													}))
-												}
-												disabled={!selected}
-											>
-												<SelectTrigger size="md" className="w-full">
-													<SelectValue placeholder="Select reason" />
-												</SelectTrigger>
-												<SelectContent>
-													{REFUND_REASONS.map((refundReason) => (
-														<SelectItem key={refundReason} value={refundReason}>
-															{refundReason}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-
-											<Textarea
-												placeholder="Reason note"
-												value={refundItemNoteByServiceId[service.id] ?? ""}
-												onChange={(event) =>
-													setRefundItemNoteByServiceId((prev) => ({
-														...prev,
-														[service.id]: event.target.value,
-													}))
-												}
-												disabled={!selected}
-											/>
-										</div>
-									);
-								})}
-
-								<Field>
-									<FieldLabel htmlFor="refund-note">
-										Refund note (optional)
-									</FieldLabel>
-									<Textarea
-										id="refund-note"
-										placeholder="General refund note"
-										value={refundNote}
-										onChange={(event) => setRefundNote(event.target.value)}
-									/>
-								</Field>
-
-								<Button
-									disabled={
-										refundMutation.isPending ||
-										refundServiceIds.length === 0 ||
-										!!refundValidationError
-									}
-									onClick={async () => {
-										if (refundValidationError) {
-											toast.error(
-												"Refund note is required when reason is other",
-											);
-											return;
-										}
-
-										await refundMutation.mutateAsync({
-											orderId: id,
-											payload: {
-												items: selectedRefundItems,
-												note: refundNote.trim() || undefined,
-											},
-										});
-									}}
-								>
-									Process refund
-								</Button>
-							</CardContent>
-						</Card>
-					)}
 				</div>
 
 				<div className="grid gap-3 sm:gap-4 lg:col-span-8">
@@ -857,30 +693,55 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 					{orderServices.map((service) => {
 						const selectedPhotoFile = photoFileByServiceId[service.id] ?? null;
 						const selectedPhotoNote = photoNoteByServiceId[service.id] ?? "";
+						const availableTransitions = (
+							ORDER_STATUS_TRANSITIONS[service.status] || []
+						).filter((nextStatus) => !(nextStatus === "cancelled" && isPaid));
 
 						return (
 							<Card key={service.id}>
-								<CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-3">
-									<div className="min-w-0 space-y-1">
-										<CardTitle className="text-base leading-snug">
-											{service.item_code ?? `Service #${service.id}`}
-										</CardTitle>
-										<p className="text-muted-foreground text-sm">
-											{service.service?.name ?? "Service"}
-										</p>
+								<CardHeader className="space-y-3 pb-3">
+									<div className="flex flex-row items-start justify-between gap-3">
+										<div className="min-w-0 space-y-1">
+											<CardTitle className="text-base leading-snug">
+												{service.item_code ?? `Service #${service.id}`}
+											</CardTitle>
+											<p className="text-muted-foreground text-sm">
+												{service.service?.name ?? "Service"}
+											</p>
+										</div>
+										<div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+											{service.is_priority ? (
+												<Badge variant="warning">Priority</Badge>
+											) : null}
+											<Badge
+												variant={getOrderServiceStatusBadgeVariant(
+													service.status,
+												)}
+											>
+												{formatOrderServiceStatus(service.status)}
+											</Badge>
+										</div>
 									</div>
-									<div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
-										{service.is_priority ? (
-											<Badge variant="warning">Priority</Badge>
-										) : null}
-										<Badge
-											variant={getOrderServiceStatusBadgeVariant(
-												service.status,
+									{availableTransitions.length > 0 ? (
+										<div className="flex flex-wrap gap-2">
+											{availableTransitions.map((nextStatus) =>
+												nextStatus === "cancelled" ? (
+													<ServiceCancelButton
+														key={nextStatus}
+														serviceId={service.id}
+														updateStatusMutation={updateStatusMutation}
+													/>
+												) : (
+													<ServiceStatusUpdateButton
+														key={nextStatus}
+														serviceId={service.id}
+														nextStatus={nextStatus}
+														updateStatusMutation={updateStatusMutation}
+													/>
+												),
 											)}
-										>
-											{formatOrderServiceStatus(service.status)}
-										</Badge>
-									</div>
+										</div>
+									) : null}
 								</CardHeader>
 								<CardContent className="space-y-5 text-sm">
 									<dl className="grid gap-3 sm:grid-cols-2">
@@ -930,29 +791,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 											</ul>
 										</div>
 									) : null}
-
-									<div className="flex flex-wrap gap-2 border-t pt-4">
-										{(ORDER_STATUS_TRANSITIONS[service.status] || [])
-											.filter(
-												(nextStatus) => !(nextStatus === "cancelled" && isPaid),
-											)
-											.map((nextStatus) =>
-												nextStatus === "cancelled" ? (
-													<ServiceCancelButton
-														key={nextStatus}
-														serviceId={service.id}
-														updateStatusMutation={updateStatusMutation}
-													/>
-												) : (
-													<ServiceStatusUpdateButton
-														key={nextStatus}
-														serviceId={service.id}
-														nextStatus={nextStatus}
-														updateStatusMutation={updateStatusMutation}
-													/>
-												),
-											)}
-									</div>
 
 									<div className="border-t pt-4">
 										<p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
@@ -1016,7 +854,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 										</div>
 									</div>
 
-									<div className="space-y-2">
+									<div className="@container space-y-2">
 										<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
 											Photos ({service.images.length})
 										</p>
@@ -1028,7 +866,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 														image.note ??
 														`Photo for ${service.item_code ?? `service-${service.id}`}`,
 												}))}
-												gridClassName="sm:grid-cols-2"
+												gridClassName="@md:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4"
 												thumbnailClassName="bg-muted/30"
 												title={`Photos for ${service.item_code ?? `service-${service.id}`}`}
 											/>

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -28,6 +28,7 @@ import { OrderFulfillmentOverview } from "@/features/orders/components/order-ful
 import { OrderPhotoGallery } from "@/features/orders/components/order-photo-gallery";
 import { OrderPickupEventDialog } from "@/features/orders/components/order-pickup-event-dialog";
 import { QueueServiceDetail } from "@/features/orders/components/queue-service-detail";
+import { RefundOrderForm } from "@/features/orders/components/refund-order-form";
 import { ServiceCancelButton } from "@/features/orders/components/service-cancel-button";
 import { ServiceStatusUpdateButton } from "@/features/orders/components/service-status-update-button";
 import { StatusTimeline } from "@/features/orders/components/status-timeline";
@@ -82,7 +83,13 @@ export const Route = createFileRoute("/_admin/orders/$orderId")({
 	component: OrderDetailPage,
 });
 
-const REFUND_REASONS = ["damaged", "cannot_process", "lost", "other"] as const;
+const REFUND_REASONS = [
+	"damaged",
+	"cannot_process",
+	"lost",
+	"other",
+	"customer_cancelled",
+] as const;
 
 function OrderDetailSkeleton() {
 	return (
@@ -401,20 +408,42 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		(service) =>
 			!["picked_up", "refunded", "cancelled"].includes(service.status),
 	);
+	const isPaid = detail.payment_status === "paid";
 	const canCancelOrder =
-		isAdmin && detail.status !== "cancelled" && hasCancellableServices;
+		isAdmin &&
+		detail.status !== "cancelled" &&
+		!isPaid &&
+		hasCancellableServices;
+	const canRefundWholeOrder =
+		isAdmin &&
+		detail.status !== "cancelled" &&
+		isPaid &&
+		refundableServices.length > 0;
 
 	const openCancelOrderDialog = () => {
 		openDialog({
 			title: "Cancel order",
-			description:
-				detail.payment_status === "paid"
-					? "All remaining items will be cancelled and a refund will be issued."
-					: "All remaining items will be cancelled.",
+			description: "All remaining items will be cancelled.",
 			content: () => (
 				<CancelOrderForm
 					closeDialog={closeDialog}
 					cancelOrderMutation={cancelOrderMutation}
+				/>
+			),
+		});
+	};
+
+	const openRefundOrderDialog = () => {
+		openDialog({
+			title: "Refund order",
+			description:
+				"All remaining items will be refunded as customer cancelled.",
+			content: () => (
+				<RefundOrderForm
+					closeDialog={closeDialog}
+					orderId={id}
+					refundServiceIds={refundableServices.map((service) => service.id)}
+					refundMutation={refundMutation}
 				/>
 			),
 		});
@@ -483,6 +512,17 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 									onClick={openCancelOrderDialog}
 								>
 									Cancel order
+								</Button>
+							)}
+							{canRefundWholeOrder && (
+								<Button
+									type="button"
+									variant="destructive"
+									size="sm"
+									disabled={refundMutation.isPending}
+									onClick={openRefundOrderDialog}
+								>
+									Refund order
 								</Button>
 							)}
 							<Badge variant={getOrderStatusBadgeVariant(detail.status)}>
@@ -865,8 +905,11 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 									) : null}
 
 									<div className="flex flex-wrap gap-2 border-t pt-4">
-										{(ORDER_STATUS_TRANSITIONS[service.status] || []).map(
-											(nextStatus) =>
+										{(ORDER_STATUS_TRANSITIONS[service.status] || [])
+											.filter(
+												(nextStatus) => !(nextStatus === "cancelled" && isPaid),
+											)
+											.map((nextStatus) =>
 												nextStatus === "cancelled" ? (
 													<ServiceCancelButton
 														key={nextStatus}
@@ -881,7 +924,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 														updateStatusMutation={updateStatusMutation}
 													/>
 												),
-										)}
+											)}
 									</div>
 
 									<div className="border-t pt-4">

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -34,6 +34,7 @@ import { OrderPickupEventDialog } from "@/features/orders/components/order-picku
 import { QueueServiceDetail } from "@/features/orders/components/queue-service-detail";
 import { StatusTimeline } from "@/features/orders/components/status-timeline";
 import {
+	cancelOrder,
 	createOrderRefund,
 	type OrderDetail,
 	presignOrderServicePhoto,
@@ -143,36 +144,36 @@ function OrderDetailMessage({
 	);
 }
 
+type UpdateStatusMutation = UseMutationResult<
+	unknown,
+	Error,
+	{ serviceId: number; payload: UpdateOrderServiceStatusPayload },
+	unknown
+>;
+
+type NonCancelServiceStatus = Exclude<
+	UpdateOrderServiceStatusPayload["status"],
+	"cancelled"
+>;
+
 function ServiceStatusUpdateButton({
 	serviceId,
 	nextStatus,
-	isCancel,
 	updateStatusMutation,
 }: {
 	serviceId: number;
-	nextStatus: UpdateOrderServiceStatusPayload["status"];
-	isCancel: boolean;
-	updateStatusMutation: UseMutationResult<
-		unknown,
-		Error,
-		{ serviceId: number; payload: UpdateOrderServiceStatusPayload },
-		unknown
-	>;
+	nextStatus: NonCancelServiceStatus;
+	updateStatusMutation: UpdateStatusMutation;
 }) {
 	const openDialog = useDialog((s) => s.openDialog);
 	const closeDialog = useDialog((s) => s.closeDialog);
 
 	const handleClick = () => {
 		openDialog({
-			title: isCancel
-				? "Cancel Service"
-				: `Update Status to ${STATUS_ACTION_LABELS[nextStatus]}`,
-			description: isCancel
-				? "Please provide a reason for cancelling this service."
-				: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
+			title: `Update Status to ${STATUS_ACTION_LABELS[nextStatus]}`,
+			description: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
 			content: () => (
-				<DialogForm
-					isCancel={isCancel}
+				<ServiceStatusConfirmForm
 					serviceId={serviceId}
 					nextStatus={nextStatus}
 					updateStatusMutation={updateStatusMutation}
@@ -183,32 +184,52 @@ function ServiceStatusUpdateButton({
 	};
 
 	return (
-		<Button
-			variant={isCancel ? "destructive" : "secondary"}
-			size="sm"
-			onClick={handleClick}
-		>
+		<Button variant="secondary" size="sm" onClick={handleClick}>
 			{STATUS_ACTION_LABELS[nextStatus]}
 		</Button>
 	);
 }
 
-function DialogForm({
-	isCancel,
+function ServiceCancelButton({
+	serviceId,
+	updateStatusMutation,
+}: {
+	serviceId: number;
+	updateStatusMutation: UpdateStatusMutation;
+}) {
+	const openDialog = useDialog((s) => s.openDialog);
+	const closeDialog = useDialog((s) => s.closeDialog);
+
+	const handleClick = () => {
+		openDialog({
+			title: "Cancel Service",
+			description: "Please provide a reason for cancelling this service.",
+			content: () => (
+				<ServiceCancelForm
+					serviceId={serviceId}
+					updateStatusMutation={updateStatusMutation}
+					closeDialog={closeDialog}
+				/>
+			),
+		});
+	};
+
+	return (
+		<Button variant="destructive" size="sm" onClick={handleClick}>
+			{STATUS_ACTION_LABELS.cancelled}
+		</Button>
+	);
+}
+
+function ServiceStatusConfirmForm({
 	serviceId,
 	nextStatus,
 	updateStatusMutation,
 	closeDialog,
 }: {
-	isCancel: boolean;
 	serviceId: number;
-	nextStatus: UpdateOrderServiceStatusPayload["status"];
-	updateStatusMutation: UseMutationResult<
-		unknown,
-		Error,
-		{ serviceId: number; payload: UpdateOrderServiceStatusPayload },
-		unknown
-	>;
+	nextStatus: NonCancelServiceStatus;
+	updateStatusMutation: UpdateStatusMutation;
 	closeDialog: () => void;
 }) {
 	const [note, setNote] = useState("");
@@ -220,11 +241,7 @@ function DialogForm({
 			serviceId,
 			payload: {
 				status: nextStatus,
-				...(isCancel
-					? { cancel_reason: trimmed }
-					: trimmed
-						? { note: trimmed }
-						: {}),
+				...(trimmed ? { note: trimmed } : {}),
 			},
 		});
 		closeDialog();
@@ -233,26 +250,99 @@ function DialogForm({
 	return (
 		<div className="flex flex-col gap-4">
 			<Textarea
-				placeholder={
-					isCancel ? "Cancel reason (required)" : "Optional status note"
-				}
+				placeholder="Optional status note"
 				value={note}
-				onChange={(e) => setNote(e.target.value)}
+				onChange={(event) => setNote(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button disabled={isPending} onClick={handleConfirm}>
+					{isPending ? "Saving…" : "Confirm Update"}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function ServiceCancelForm({
+	serviceId,
+	updateStatusMutation,
+	closeDialog,
+}: {
+	serviceId: number;
+	updateStatusMutation: UpdateStatusMutation;
+	closeDialog: () => void;
+}) {
+	const [reason, setReason] = useState("");
+	const trimmed = reason.trim();
+	const isPending = updateStatusMutation.isPending;
+
+	const handleConfirm = async () => {
+		await updateStatusMutation.mutateAsync({
+			serviceId,
+			payload: { status: "cancelled", cancel_reason: trimmed },
+		});
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Textarea
+				placeholder="Cancel reason (required)"
+				value={reason}
+				onChange={(event) => setReason(event.target.value)}
 			/>
 			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
 				<Button variant="outline" onClick={closeDialog}>
 					Go back
 				</Button>
 				<Button
-					variant={isCancel ? "destructive" : "default"}
-					disabled={isPending || (isCancel && !note.trim())}
+					variant="destructive"
+					disabled={isPending || !trimmed}
 					onClick={handleConfirm}
 				>
-					{isPending
-						? "Saving…"
-						: isCancel
-							? "Confirm Cancel"
-							: "Confirm Update"}
+					{isPending ? "Saving…" : "Confirm Cancel"}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function CancelOrderForm({
+	closeDialog,
+	cancelOrderMutation,
+}: {
+	closeDialog: () => void;
+	cancelOrderMutation: UseMutationResult<unknown, Error, string, unknown>;
+}) {
+	const [reason, setReason] = useState("");
+	const trimmed = reason.trim();
+	const isPending = cancelOrderMutation.isPending;
+
+	const handleConfirm = async () => {
+		await cancelOrderMutation.mutateAsync(trimmed);
+		closeDialog();
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Textarea
+				placeholder="Cancel reason (required)"
+				value={reason}
+				onChange={(event) => setReason(event.target.value)}
+			/>
+			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+				<Button variant="outline" onClick={closeDialog}>
+					Go back
+				</Button>
+				<Button
+					variant="destructive"
+					disabled={isPending || !trimmed}
+					onClick={handleConfirm}
+				>
+					{isPending ? "Cancelling…" : "Confirm Cancel Order"}
 				</Button>
 			</div>
 		</div>
@@ -342,7 +432,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		user?.role === "admin" ||
 		user?.role === "cashier" ||
 		user?.can_process_pickup === true;
-	const isRefundAllowed = isPaymentAllowed;
+	const isAdmin = user?.role === "admin";
 	const openDialog = useDialog((s) => s.openDialog);
 	const closeDialog = useDialog((s) => s.closeDialog);
 
@@ -370,10 +460,10 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 	const paymentMethodsQuery = useQuery(paymentMethodsQueryOptions());
 
 	const refreshOrderData = async () => {
-		await queryClient.invalidateQueries({
-			queryKey: queryKeys.orderDetail(id),
-		});
-		await queryClient.invalidateQueries({ queryKey: ["orders"] });
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: queryKeys.orderDetail(id) }),
+			queryClient.invalidateQueries({ queryKey: ["orders"] }),
+		]);
 	};
 
 	const updateStatusMutation = useMutation({
@@ -385,7 +475,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 			payload: UpdateOrderServiceStatusPayload;
 		}) => updateOrderServiceStatus(id, serviceId, payload),
 		onSuccess: async () => {
-			toast.success("Service status updated");
 			await refreshOrderData();
 		},
 	});
@@ -394,11 +483,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		mutationFn: (paymentMethodId: number) =>
 			updateOrderPayment(id, { payment_method_id: paymentMethodId }),
 		onSuccess: async () => {
-			toast.success("Payment updated");
 			await refreshOrderData();
-		},
-		onError: (error: Error) => {
-			toast.error(error.message || "Failed to update payment");
 		},
 	});
 
@@ -436,7 +521,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 			});
 		},
 		onSuccess: async (_, variables) => {
-			toast.success("Photo uploaded");
 			setPhotoFileByServiceId((prev) => ({
 				...prev,
 				[variables.serviceId]: null,
@@ -458,11 +542,17 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 			payload: Parameters<typeof createOrderRefund>[1];
 		}) => createOrderRefund(targetOrderId, payload),
 		onSuccess: async () => {
-			toast.success("Refund processed");
 			setRefundServiceIds([]);
 			setRefundReasonByServiceId({});
 			setRefundItemNoteByServiceId({});
 			setRefundNote("");
+			await refreshOrderData();
+		},
+	});
+
+	const cancelOrderMutation = useMutation({
+		mutationFn: (cancel_reason: string) => cancelOrder(id, { cancel_reason }),
+		onSuccess: async () => {
 			await refreshOrderData();
 		},
 	});
@@ -525,9 +615,31 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 	};
 
 	const refundableServices = orderServices.filter(
+		(service) => !["refunded", "cancelled"].includes(service.status),
+	);
+
+	const hasCancellableServices = orderServices.some(
 		(service) =>
 			!["picked_up", "refunded", "cancelled"].includes(service.status),
 	);
+	const canCancelOrder =
+		isAdmin && detail.status !== "cancelled" && hasCancellableServices;
+
+	const openCancelOrderDialog = () => {
+		openDialog({
+			title: "Cancel order",
+			description:
+				detail.payment_status === "paid"
+					? "All remaining items will be cancelled and a refund will be issued."
+					: "All remaining items will be cancelled.",
+			content: () => (
+				<CancelOrderForm
+					closeDialog={closeDialog}
+					cancelOrderMutation={cancelOrderMutation}
+				/>
+			),
+		});
+	};
 
 	const selectedRefundItems = refundServiceIds.map((serviceId) => ({
 		order_service_id: serviceId,
@@ -581,6 +693,17 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 									onClick={handleCopyTrackingLink}
 								>
 									Copy tracking link
+								</Button>
+							) : null}
+							{canCancelOrder ? (
+								<Button
+									type="button"
+									variant="destructive"
+									size="sm"
+									disabled={cancelOrderMutation.isPending}
+									onClick={openCancelOrderDialog}
+								>
+									Cancel order
 								</Button>
 							) : null}
 							<Badge variant={getOrderStatusBadgeVariant(detail.status)}>
@@ -743,7 +866,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 						</Card>
 					) : null}
 
-					{isRefundAllowed ? (
+					{isAdmin ? (
 						<Card>
 							<CardHeader>
 								<CardTitle>Refund</CardTitle>
@@ -964,19 +1087,21 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 
 									<div className="flex flex-wrap gap-2 border-t pt-4">
 										{(ORDER_STATUS_TRANSITIONS[service.status] || []).map(
-											(nextStatus) => {
-												const isCancel = nextStatus === "cancelled";
-
-												return (
+											(nextStatus) =>
+												nextStatus === "cancelled" ? (
+													<ServiceCancelButton
+														key={nextStatus}
+														serviceId={service.id}
+														updateStatusMutation={updateStatusMutation}
+													/>
+												) : (
 													<ServiceStatusUpdateButton
 														key={nextStatus}
 														serviceId={service.id}
 														nextStatus={nextStatus}
-														isCancel={isCancel}
 														updateStatusMutation={updateStatusMutation}
 													/>
-												);
-											},
+												),
 										)}
 									</div>
 

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -1,11 +1,6 @@
 import { ORDER_STATUS_TRANSITIONS } from "@fresclean/api/schema";
 import { CameraIcon, LinkSimpleIcon } from "@phosphor-icons/react";
-import {
-	type UseMutationResult,
-	useMutation,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -27,11 +22,14 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
+import { CancelOrderForm } from "@/features/orders/components/cancel-order-form";
 import { OrderDropoffPhotoCard } from "@/features/orders/components/order-dropoff-photo-card";
 import { OrderFulfillmentOverview } from "@/features/orders/components/order-fulfillment-overview";
 import { OrderPhotoGallery } from "@/features/orders/components/order-photo-gallery";
 import { OrderPickupEventDialog } from "@/features/orders/components/order-pickup-event-dialog";
 import { QueueServiceDetail } from "@/features/orders/components/queue-service-detail";
+import { ServiceCancelButton } from "@/features/orders/components/service-cancel-button";
+import { ServiceStatusUpdateButton } from "@/features/orders/components/service-status-update-button";
 import { StatusTimeline } from "@/features/orders/components/status-timeline";
 import {
 	cancelOrder,
@@ -84,20 +82,6 @@ export const Route = createFileRoute("/_admin/orders/$orderId")({
 	component: OrderDetailPage,
 });
 
-const STATUS_ACTION_LABELS: Record<
-	UpdateOrderServiceStatusPayload["status"],
-	string
-> = {
-	queued: "Queue",
-	processing: "Process",
-	quality_check: "Quality Check",
-	qc_reject: "Reject at QC",
-	ready_for_pickup: "Ready for Pickup",
-	picked_up: "Pick Up",
-	refunded: "Refund",
-	cancelled: "Cancel",
-};
-
 const REFUND_REASONS = ["damaged", "cannot_process", "lost", "other"] as const;
 
 function OrderDetailSkeleton() {
@@ -140,211 +124,6 @@ function OrderDetailMessage({
 		>
 			<p className="font-medium">{title}</p>
 			<p className="text-muted-foreground">{description}</p>
-		</div>
-	);
-}
-
-type UpdateStatusMutation = UseMutationResult<
-	unknown,
-	Error,
-	{ serviceId: number; payload: UpdateOrderServiceStatusPayload },
-	unknown
->;
-
-type NonCancelServiceStatus = Exclude<
-	UpdateOrderServiceStatusPayload["status"],
-	"cancelled"
->;
-
-function ServiceStatusUpdateButton({
-	serviceId,
-	nextStatus,
-	updateStatusMutation,
-}: {
-	serviceId: number;
-	nextStatus: NonCancelServiceStatus;
-	updateStatusMutation: UpdateStatusMutation;
-}) {
-	const openDialog = useDialog((s) => s.openDialog);
-	const closeDialog = useDialog((s) => s.closeDialog);
-
-	const handleClick = () => {
-		openDialog({
-			title: `Update Status to ${STATUS_ACTION_LABELS[nextStatus]}`,
-			description: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
-			content: () => (
-				<ServiceStatusConfirmForm
-					serviceId={serviceId}
-					nextStatus={nextStatus}
-					updateStatusMutation={updateStatusMutation}
-					closeDialog={closeDialog}
-				/>
-			),
-		});
-	};
-
-	return (
-		<Button variant="secondary" size="sm" onClick={handleClick}>
-			{STATUS_ACTION_LABELS[nextStatus]}
-		</Button>
-	);
-}
-
-function ServiceCancelButton({
-	serviceId,
-	updateStatusMutation,
-}: {
-	serviceId: number;
-	updateStatusMutation: UpdateStatusMutation;
-}) {
-	const openDialog = useDialog((s) => s.openDialog);
-	const closeDialog = useDialog((s) => s.closeDialog);
-
-	const handleClick = () => {
-		openDialog({
-			title: "Cancel Service",
-			description: "Please provide a reason for cancelling this service.",
-			content: () => (
-				<ServiceCancelForm
-					serviceId={serviceId}
-					updateStatusMutation={updateStatusMutation}
-					closeDialog={closeDialog}
-				/>
-			),
-		});
-	};
-
-	return (
-		<Button variant="destructive" size="sm" onClick={handleClick}>
-			{STATUS_ACTION_LABELS.cancelled}
-		</Button>
-	);
-}
-
-function ServiceStatusConfirmForm({
-	serviceId,
-	nextStatus,
-	updateStatusMutation,
-	closeDialog,
-}: {
-	serviceId: number;
-	nextStatus: NonCancelServiceStatus;
-	updateStatusMutation: UpdateStatusMutation;
-	closeDialog: () => void;
-}) {
-	const [note, setNote] = useState("");
-	const isPending = updateStatusMutation.isPending;
-
-	const handleConfirm = async () => {
-		const trimmed = note.trim();
-		await updateStatusMutation.mutateAsync({
-			serviceId,
-			payload: {
-				status: nextStatus,
-				...(trimmed ? { note: trimmed } : {}),
-			},
-		});
-		closeDialog();
-	};
-
-	return (
-		<div className="flex flex-col gap-4">
-			<Textarea
-				placeholder="Optional status note"
-				value={note}
-				onChange={(event) => setNote(event.target.value)}
-			/>
-			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-				<Button variant="outline" onClick={closeDialog}>
-					Go back
-				</Button>
-				<Button disabled={isPending} onClick={handleConfirm}>
-					{isPending ? "Saving…" : "Confirm Update"}
-				</Button>
-			</div>
-		</div>
-	);
-}
-
-function ServiceCancelForm({
-	serviceId,
-	updateStatusMutation,
-	closeDialog,
-}: {
-	serviceId: number;
-	updateStatusMutation: UpdateStatusMutation;
-	closeDialog: () => void;
-}) {
-	const [reason, setReason] = useState("");
-	const trimmed = reason.trim();
-	const isPending = updateStatusMutation.isPending;
-
-	const handleConfirm = async () => {
-		await updateStatusMutation.mutateAsync({
-			serviceId,
-			payload: { status: "cancelled", cancel_reason: trimmed },
-		});
-		closeDialog();
-	};
-
-	return (
-		<div className="flex flex-col gap-4">
-			<Textarea
-				placeholder="Cancel reason (required)"
-				value={reason}
-				onChange={(event) => setReason(event.target.value)}
-			/>
-			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-				<Button variant="outline" onClick={closeDialog}>
-					Go back
-				</Button>
-				<Button
-					variant="destructive"
-					disabled={isPending || !trimmed}
-					onClick={handleConfirm}
-				>
-					{isPending ? "Saving…" : "Confirm Cancel"}
-				</Button>
-			</div>
-		</div>
-	);
-}
-
-function CancelOrderForm({
-	closeDialog,
-	cancelOrderMutation,
-}: {
-	closeDialog: () => void;
-	cancelOrderMutation: UseMutationResult<unknown, Error, string, unknown>;
-}) {
-	const [reason, setReason] = useState("");
-	const trimmed = reason.trim();
-	const isPending = cancelOrderMutation.isPending;
-
-	const handleConfirm = async () => {
-		await cancelOrderMutation.mutateAsync(trimmed);
-		closeDialog();
-	};
-
-	return (
-		<div className="flex flex-col gap-4">
-			<Textarea
-				placeholder="Cancel reason (required)"
-				value={reason}
-				onChange={(event) => setReason(event.target.value)}
-			/>
-			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-				<Button variant="outline" onClick={closeDialog}>
-					Go back
-				</Button>
-				<Button
-					variant="destructive"
-					disabled={isPending || !trimmed}
-					onClick={handleConfirm}
-				>
-					{isPending ? "Cancelling…" : "Confirm Cancel Order"}
-				</Button>
-			</div>
 		</div>
 	);
 }
@@ -695,7 +474,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 									Copy tracking link
 								</Button>
 							) : null}
-							{canCancelOrder ? (
+							{canCancelOrder && (
 								<Button
 									type="button"
 									variant="destructive"
@@ -705,7 +484,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 								>
 									Cancel order
 								</Button>
-							) : null}
+							)}
 							<Badge variant={getOrderStatusBadgeVariant(detail.status)}>
 								{formatOrderStatus(detail.status)}
 							</Badge>
@@ -866,7 +645,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 						</Card>
 					) : null}
 
-					{isAdmin ? (
+					{isAdmin && (
 						<Card>
 							<CardHeader>
 								<CardTitle>Refund</CardTitle>
@@ -997,7 +776,7 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 								</Button>
 							</CardContent>
 						</Card>
-					) : null}
+					)}
 				</div>
 
 				<div className="grid gap-3 sm:gap-4 lg:col-span-8">

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -91,6 +91,9 @@ const REFUND_REASONS = [
 	"customer_cancelled",
 ] as const;
 
+const formatRefundReason = (reason: string) =>
+	reason.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+
 function OrderDetailSkeleton() {
 	return (
 		<div className="grid gap-6">
@@ -901,6 +904,30 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 												Cancel reason
 											</p>
 											<p className="mt-1 text-sm">{service.cancel_reason}</p>
+										</div>
+									) : null}
+
+									{service.status === "refunded" &&
+									service.refundItems.length > 0 ? (
+										<div className="border-destructive/40 bg-destructive/5 border p-3">
+											<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+												Refund reason
+											</p>
+											<ul className="mt-1 grid gap-1 text-sm">
+												{service.refundItems.map((item) => (
+													<li key={item.id}>
+														<span className="font-medium">
+															{formatRefundReason(item.reason)}
+														</span>
+														{item.note ? (
+															<span className="text-muted-foreground">
+																{" "}
+																— {item.note}
+															</span>
+														) : null}
+													</li>
+												))}
+											</ul>
 										</div>
 									) : null}
 

--- a/docs/core-implementation-plan.md
+++ b/docs/core-implementation-plan.md
@@ -88,19 +88,25 @@ Follow-ups (not blocking merge):
 
 ---
 
-### Group C — Refund flow
+### Group C — Refund flow ✅ DONE
 
-10. **C-1. Allow refund after pickup (ambiguity 3.2)**
-    - `order-admin.service.ts` refund path: drop the "status must not be picked_up" guard. Keep payment_status=paid guard.
+Shipped: 2026-04-24 · branch `feat/group-c-refund-cancel`
 
-11. **C-2. Cancel auto-triggers refund if paid (ambiguity 3.6)**
-    - When admin cancels a **paid** order (or any paid service within), auto-create `order_refund` record with refund items = the cancelled services. Reason = `other`, note = cancel_reason text.
-    - Emit single success toast: "Order cancelled + refund issued".
+10. **C-1. Allow refund after pickup (ambiguity 3.2)** ✅
+    - `order-admin.service.ts` refund path: dropped the "status must not be picked_up" guard. Payment_status=paid guard kept.
 
-12. **C-3. Admin-only refund guard audit**
-    - Confirm `assertCanProcessPaymentOrRefund(user)` gates refund route to `role === 'admin'` only. (Currently may include cashier — verify + lock down.)
+11. **C-2. Split cancel vs refund by payment status** ✅ *(supersedes original auto-refund-on-paid design)*
+    - Business has binary payment (paid/unpaid — no partial). Cleaner split: cancel handles unpaid, refund handles paid. Removes auto-refund branching inside cancel.
+    - **Server**: `cancelOrder` rejects paid orders (`"Paid orders cannot be cancelled. Issue a refund instead."`). `updateOrderServiceStatus` rejects `cancelled` transition on paid orders. `createOrderRefund` already paid-only — unchanged.
+    - **Schema**: `refund_reason_enum` gains `customer_cancelled` for pre-pickup paid refunds initiated by the customer.
+    - **Web**: order detail header shows `Cancel order` (unpaid) or `Refund order` (paid) — never both. Paid refund dialog seeds all refundable services with reason `customer_cancelled`. Per-line `cancelled` transition hidden on paid orders.
 
-Commit: `feat(refund): allow post-pickup + auto-refund on paid cancel`
+12. **C-3. Admin-only refund guard audit** ✅
+    - `assertIsAdmin` gates `POST /admin/orders/:id/refunds` and `POST /admin/orders/:id/cancel`. Verified 2026-04-23: cashier + worker → 403.
+
+Commits:
+- `feat(refund): allow post-pickup + auto-refund on paid cancel` (12d8757 — C-1 + initial C-2 auto-refund)
+- `refactor(orders): split cancel/refund by payment status` (this PR — supersedes C-2 auto-refund)
 
 ---
 
@@ -179,7 +185,7 @@ Each group = one PR. Each PR independently shippable.
 ## Locked decisions (2026-04-22)
 
 1. **B-1 attempt logging:** ~~attempts table + rate-limit~~ — reverted 2026-04-23, kept simple for v1. No throttle; mismatched code just returns 400.
-2. **C-2 auto-refund:** automatic on cancel-paid. Single toast "Order cancelled + refund issued". Refund item `reason='other'`, `note=cancel_reason`.
+2. **C-2 cancel vs refund split:** (revised 2026-04-24) cancel = unpaid-only, refund = paid-only. Original auto-refund-on-paid-cancel design reverted: simpler to gate by payment status. Binary payment model (paid/unpaid, no partial) keeps the split unambiguous — partial-payment scenarios are split into two orders operationally.
 3. **C-3 admin-only refund:** `assertCanProcessPaymentOrRefund` tightened to `role==='admin'` for refund endpoint. Payment collection remains cashier+admin.
 4. **D-1 auto-close trigger:** Upstash Schedule → HTTP POST to `/admin/cron/shifts/auto-close` (internal shared-secret header). Runs at 00:05 Jakarta daily (cushion for clock drift).
 5. **E-1 photo delete:** soft delete (`deleted_at`, `deleted_by`). S3 object stays (future sweep).

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -526,8 +526,8 @@ export const ordersServicesTable = pgTable(
     check("price_non_negative_check", sql`${table.price} >= 0`),
     check("discount_valid_check", sql`${table.price} >= ${table.discount}`),
     check(
-      "order_services_pickup_event_matches_status_check",
-      sql`(${table.status} = 'picked_up') = (${table.pickup_event_id} IS NOT NULL)`
+      "order_services_pickup_event_terminal_check",
+      sql`${table.pickup_event_id} IS NULL OR ${table.status} IN ('picked_up', 'refunded')`
     ),
   ]
 );

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -191,6 +191,7 @@ export const refundReasonEnum = pgEnum("refund_reason_enum", [
   "cannot_process",
   "lost",
   "other",
+  "customer_cancelled",
 ]);
 
 export const campaignsTable = pgTable(

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { orderServiceStatusEnum } from "@/db/schema";
+import { orderServiceStatusEnum, refundReasonEnum } from "@/db/schema";
 import { MAX_PAGE_SIZE } from "@/modules/orders/order.schema";
 import { dateStringSchema } from "@/schema/common";
 import { normalizePagination } from "@/utils/pagination";
@@ -99,7 +99,7 @@ export const POSTOrderRefundSchema = z.object({
         .object({
           note: z.string().trim().optional(),
           order_service_id: z.coerce.number().int().positive(),
-          reason: z.enum(["damaged", "cannot_process", "lost", "other"]),
+          reason: z.enum(refundReasonEnum.enumValues),
         })
         .superRefine((value, ctx) => {
           if (value.reason === "other" && !value.note?.trim()) {

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -88,6 +88,10 @@ export const PATCHOrderPaymentSchema = z.object({
   payment_method_id: z.coerce.number().int().positive(),
 });
 
+export const POSTOrderCancelSchema = z.object({
+  cancel_reason: z.string().trim().min(1).max(1000),
+});
+
 export const POSTOrderRefundSchema = z.object({
   items: z
     .array(
@@ -161,6 +165,7 @@ export type PostOrderServicePhotoPresignInput = z.infer<
 export type PostOrderDropoffPhotoPresignInput = z.infer<
   typeof POSTOrderDropoffPhotoPresignSchema
 >;
+export type PostOrderCancelInput = z.infer<typeof POSTOrderCancelSchema>;
 export type PostOrderRefundInput = z.infer<typeof POSTOrderRefundSchema>;
 export type PatchOrderServiceHandlerInput = z.infer<
   typeof PATCHOrderServiceHandlerSchema

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -23,6 +23,7 @@ import type {
   PatchOrderPaymentInput,
   PatchOrderServiceHandlerInput,
   PatchOrderServiceStatusInput,
+  PostOrderCancelInput,
   PostOrderDropoffPhotoPresignInput,
   PostOrderPickupEventInput,
   PostOrderPickupEventPresignInput,
@@ -1210,7 +1211,7 @@ export async function createOrderRefund({
   body: PostOrderRefundInput;
   user: JWTPayload;
 }) {
-  assertCanProcessPaymentOrRefund(user);
+  assertIsAdmin(user);
 
   const uniqueServiceIds = [
     ...new Set(body.items.map((item) => item.order_service_id)),
@@ -1254,7 +1255,7 @@ export async function createOrderRefund({
   }
 
   for (const service of services) {
-    if (["picked_up", "refunded", "cancelled"].includes(service.status)) {
+    if (["refunded", "cancelled"].includes(service.status)) {
       throw new BadRequestException(
         `Service ${service.id} cannot be refunded from status ${service.status}`
       );
@@ -1343,5 +1344,180 @@ export async function createOrderRefund({
   return {
     refund,
     total_refund_amount: totalRefundAmount,
+  };
+}
+
+export async function cancelOrder({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PostOrderCancelInput;
+  user: JWTPayload;
+}) {
+  assertIsAdmin(user);
+
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: {
+      id: true,
+      status: true,
+      payment_status: true,
+      paid_amount: true,
+      refunded_amount: true,
+    },
+  });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  if (order.status === "cancelled") {
+    throw new BadRequestException("Order is already cancelled");
+  }
+
+  const allServices = await db.query.ordersServicesTable.findMany({
+    where: { order_id: orderId },
+    columns: { id: true, status: true },
+  });
+
+  const cancellableServices = allServices.filter(
+    (service) => !isTerminalOrderServiceStatus(service.status)
+  );
+
+  if (cancellableServices.length === 0) {
+    throw new BadRequestException("No cancellable services on this order");
+  }
+
+  const cancelReason = body.cancel_reason.trim();
+  const cancellableIds = cancellableServices.map((service) => service.id);
+  const isPaid = order.payment_status === "paid";
+
+  let refundPlan: {
+    items: ReturnType<typeof buildRefundItems>;
+    totalRefundAmount: number;
+  } | null = null;
+
+  if (isPaid) {
+    const refundCaps = await getOrderLineRefundCaps(orderId);
+    const capsByServiceId = new Map(
+      refundCaps
+        .filter(
+          (cap) =>
+            cancellableIds.includes(cap.order_service_id) &&
+            cap.maxRefundable > 0
+        )
+        .map((cap) => [cap.order_service_id, cap.maxRefundable])
+    );
+
+    if (capsByServiceId.size > 0) {
+      const items = buildRefundItems({
+        capsByServiceId,
+        items: Array.from(capsByServiceId.keys()).map((id) => ({
+          order_service_id: id,
+          reason: "other" as const,
+          note: cancelReason,
+        })),
+      });
+
+      const totalRefundAmount = items.reduce(
+        (sum, item) => sum + item.amount,
+        0
+      );
+
+      const refundablePaidAmount =
+        Number(order.paid_amount) - Number(order.refunded_amount);
+      if (totalRefundAmount > refundablePaidAmount) {
+        throw new BadRequestException(
+          "Refund exceeds remaining paid amount for this order"
+        );
+      }
+
+      refundPlan = { items, totalRefundAmount };
+    }
+  }
+
+  const cancellableStatusById = new Map(
+    cancellableServices.map((service) => [service.id, service.status])
+  );
+
+  const createdRefund = await db.transaction(async (tx) => {
+    const updatedServices = await tx
+      .update(ordersServicesTable)
+      .set({ status: "cancelled", cancel_reason: cancelReason })
+      .where(
+        and(
+          eq(ordersServicesTable.order_id, orderId),
+          inArray(ordersServicesTable.id, cancellableIds),
+          sql`${ordersServicesTable.status} NOT IN ('picked_up', 'refunded', 'cancelled')`
+        )
+      )
+      .returning({ id: ordersServicesTable.id });
+
+    if (updatedServices.length === 0) {
+      throw new BadRequestException(
+        "Services changed state before cancellation could apply. Refresh and try again."
+      );
+    }
+
+    await tx.insert(orderServiceStatusLogsTable).values(
+      updatedServices.map((row) => ({
+        order_service_id: row.id,
+        from_status: cancellableStatusById.get(row.id),
+        to_status: "cancelled" as const,
+        changed_by: user.id,
+        note: cancelReason,
+      }))
+    );
+
+    let refundRow: typeof orderRefundsTable.$inferSelect | null = null;
+
+    if (refundPlan) {
+      const [created] = await tx
+        .insert(orderRefundsTable)
+        .values({
+          order_id: orderId,
+          refunded_by: user.id,
+          total_amount: refundPlan.totalRefundAmount.toString(),
+          note: cancelReason,
+        })
+        .returning();
+      refundRow = created;
+
+      await tx.insert(orderRefundItemsTable).values(
+        refundPlan.items.map((item) => ({
+          order_refund_id: created.id,
+          order_service_id: item.order_service_id,
+          amount: item.amount.toString(),
+          reason: item.reason,
+          note: item.note,
+        }))
+      );
+    }
+
+    await tx
+      .update(ordersTable)
+      .set({
+        cancelled_at: new Date(),
+        updated_by: user.id,
+        ...(refundPlan
+          ? {
+              refunded_amount: sql`${ordersTable.refunded_amount} + ${refundPlan.totalRefundAmount}`,
+            }
+          : {}),
+      })
+      .where(eq(ordersTable.id, orderId));
+
+    await recalculateOrderStatus(tx, orderId, user.id);
+
+    return refundRow;
+  });
+
+  return {
+    cancelled_service_ids: cancellableIds,
+    order_id: orderId,
+    refund: createdRefund,
+    total_refund_amount: refundPlan?.totalRefundAmount ?? 0,
   };
 }

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -851,6 +851,18 @@ export async function updateOrderServiceStatus({
       );
     }
 
+    if (body.status === "cancelled") {
+      const parentOrder = await tx.query.ordersTable.findFirst({
+        where: { id: orderId },
+        columns: { payment_status: true },
+      });
+      if (parentOrder?.payment_status === "paid") {
+        throw new BadRequestException(
+          "Paid orders cannot cancel individual services. Refund the service instead."
+        );
+      }
+    }
+
     const isClaimTransition =
       (locked.status === "queued" || locked.status === "qc_reject") &&
       body.status === "processing";
@@ -1364,8 +1376,6 @@ export async function cancelOrder({
       id: true,
       status: true,
       payment_status: true,
-      paid_amount: true,
-      refunded_amount: true,
     },
   });
 
@@ -1375,6 +1385,12 @@ export async function cancelOrder({
 
   if (order.status === "cancelled") {
     throw new BadRequestException("Order is already cancelled");
+  }
+
+  if (order.payment_status === "paid") {
+    throw new BadRequestException(
+      "Paid orders cannot be cancelled. Issue a refund instead."
+    );
   }
 
   const allServices = await db.query.ordersServicesTable.findMany({
@@ -1392,57 +1408,12 @@ export async function cancelOrder({
 
   const cancelReason = body.cancel_reason.trim();
   const cancellableIds = cancellableServices.map((service) => service.id);
-  const isPaid = order.payment_status === "paid";
-
-  let refundPlan: {
-    items: ReturnType<typeof buildRefundItems>;
-    totalRefundAmount: number;
-  } | null = null;
-
-  if (isPaid) {
-    const refundCaps = await getOrderLineRefundCaps(orderId);
-    const capsByServiceId = new Map(
-      refundCaps
-        .filter(
-          (cap) =>
-            cancellableIds.includes(cap.order_service_id) &&
-            cap.maxRefundable > 0
-        )
-        .map((cap) => [cap.order_service_id, cap.maxRefundable])
-    );
-
-    if (capsByServiceId.size > 0) {
-      const items = buildRefundItems({
-        capsByServiceId,
-        items: Array.from(capsByServiceId.keys()).map((id) => ({
-          order_service_id: id,
-          reason: "other" as const,
-          note: cancelReason,
-        })),
-      });
-
-      const totalRefundAmount = items.reduce(
-        (sum, item) => sum + item.amount,
-        0
-      );
-
-      const refundablePaidAmount =
-        Number(order.paid_amount) - Number(order.refunded_amount);
-      if (totalRefundAmount > refundablePaidAmount) {
-        throw new BadRequestException(
-          "Refund exceeds remaining paid amount for this order"
-        );
-      }
-
-      refundPlan = { items, totalRefundAmount };
-    }
-  }
 
   const cancellableStatusById = new Map(
     cancellableServices.map((service) => [service.id, service.status])
   );
 
-  const createdRefund = await db.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     const updatedServices = await tx
       .update(ordersServicesTable)
       .set({ status: "cancelled", cancel_reason: cancelReason })
@@ -1471,53 +1442,19 @@ export async function cancelOrder({
       }))
     );
 
-    let refundRow: typeof orderRefundsTable.$inferSelect | null = null;
-
-    if (refundPlan) {
-      const [created] = await tx
-        .insert(orderRefundsTable)
-        .values({
-          order_id: orderId,
-          refunded_by: user.id,
-          total_amount: refundPlan.totalRefundAmount.toString(),
-          note: cancelReason,
-        })
-        .returning();
-      refundRow = created;
-
-      await tx.insert(orderRefundItemsTable).values(
-        refundPlan.items.map((item) => ({
-          order_refund_id: created.id,
-          order_service_id: item.order_service_id,
-          amount: item.amount.toString(),
-          reason: item.reason,
-          note: item.note,
-        }))
-      );
-    }
-
     await tx
       .update(ordersTable)
       .set({
         cancelled_at: new Date(),
         updated_by: user.id,
-        ...(refundPlan
-          ? {
-              refunded_amount: sql`${ordersTable.refunded_amount} + ${refundPlan.totalRefundAmount}`,
-            }
-          : {}),
       })
       .where(eq(ordersTable.id, orderId));
 
     await recalculateOrderStatus(tx, orderId, user.id);
-
-    return refundRow;
   });
 
   return {
     cancelled_service_ids: cancellableIds,
     order_id: orderId,
-    refund: createdRefund,
-    total_refund_amount: refundPlan?.totalRefundAmount ?? 0,
   };
 }

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -407,12 +407,7 @@ const app = new Hono()
         user,
       });
 
-      const message =
-        result.total_refund_amount > 0
-          ? "Order cancelled + refund issued"
-          : "Order cancelled";
-
-      return c.json(success(result, message));
+      return c.json(success(result, "Order cancelled"));
     }
   );
 

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -12,6 +12,7 @@ import {
   PATCHOrderPaymentSchema,
   PATCHOrderServiceHandlerSchema,
   PATCHOrderServiceStatusSchema,
+  POSTOrderCancelSchema,
   POSTOrderDropoffPhotoPresignSchema,
   POSTOrderPickupEventPresignSchema,
   POSTOrderPickupEventSchema,
@@ -21,6 +22,7 @@ import {
   PUTOrderDropoffPhotoSchema,
 } from "@/modules/orders/order-admin.schema";
 import {
+  cancelOrder,
   createOrderDropoffPhotoPresign,
   createOrderPickupEvent,
   createOrderPickupEventPresign,
@@ -386,6 +388,31 @@ const app = new Hono()
         success(result, "Order refund processed"),
         StatusCodes.CREATED
       );
+    }
+  )
+  .post(
+    "/:id/cancel",
+    idParamSchema,
+    zodValidator("json", POSTOrderCancelSchema),
+    async (c) => {
+      const user = c.get("jwtPayload") as JWTPayload;
+      const { id } = c.req.valid("param");
+      const body = c.req.valid("json");
+
+      await assertOrderAccess(user, id);
+
+      const result = await cancelOrder({
+        orderId: id,
+        body,
+        user,
+      });
+
+      const message =
+        result.total_refund_amount > 0
+          ? "Order cancelled + refund issued"
+          : "Order cancelled";
+
+      return c.json(success(result, message));
     }
   );
 


### PR DESCRIPTION
## Summary

Redefines Group C of the v1 core plan (`docs/core-implementation-plan.md`). Supersedes the original **auto-refund-on-paid-cancel** design from 12d8757.

Fresclean's payment model is **binary** (paid / unpaid — no partial). The original plan baked a paid-vs-unpaid branch inside `cancelOrder` that auto-issued a refund; this PR collapses that branching by splitting the two endpoints by payment status instead.

- **Unpaid orders** → `POST /admin/orders/:id/cancel` (status flip + `cancelled_at`, no money logic).
- **Paid orders** → `POST /admin/orders/:id/refunds` (money back + service `refunded` terminal status).

### Server

- `cancelOrder`: rejects paid orders with `"Paid orders cannot be cancelled. Issue a refund instead."`. Refund-compute block (`buildRefundItems`, `orderRefundsTable` insert, `refunded_amount` update) deleted entirely. Return shape simplified — `refund` / `total_refund_amount` fields removed.
- `updateOrderServiceStatus`: rejects `cancelled` transition on paid orders (`"Paid orders cannot cancel individual services. Refund the service instead."`).
- `createOrderRefund`: unchanged — already paid-only (line 1239 guard kept).
- `refund_reason_enum`: adds `customer_cancelled` for pre-pickup paid refunds initiated by the customer.
- `POSTOrderRefundSchema`: reason Zod enum now derived from `refundReasonEnum.enumValues` to avoid drift.

### Web

- Order detail header shows one destructive button:
  - `Cancel order` when `payment_status === "unpaid"` and something's cancellable.
  - `Refund order` when `payment_status === "paid"` and something's refundable.
  - Never both. Clear mental model.
- New `RefundOrderForm` (`apps/web/src/features/orders/components/refund-order-form.tsx`) mirrors `CancelOrderForm`: seeds all refundable services with reason `customer_cancelled`, submits via existing `refundMutation`.
- Per-line `cancelled` transition filtered out of service action buttons when paid.
- `REFUND_REASONS` + `OrderRefundReason` union extended with `customer_cancelled`.
- Cancel dialog description simplified — no more paid/unpaid conditional text.

### Docs

- `docs/core-implementation-plan.md` Group C marked done; C-2 rewritten to reflect the split. Locked decision #2 rewritten to document the revision.

## Test plan

- [x] `bun run type-check` — all packages green.
- [x] `bun x ultracite fix` — clean.
- [x] `bun run push:dev` — enum applied (`ALTER TYPE refund_reason_enum ADD VALUE 'customer_cancelled'`).
- [x] Unpaid order → `Cancel order` button → confirm → services `cancelled`, `cancelled_at` set, no `order_refunds` row.
- [x] Paid order → `Refund order` button → confirm → refund row created, services `refunded`, `refunded_amount` increases.
- [x] `POST /orders/:id/cancel` on paid order → 400 with refund-pointer message.
- [x] `PATCH /orders/:id/services/:sid/status` `{status:"cancelled"}` on paid → 400.
- [x] Paid order per-line refund (reason `damaged`) still works for single service.
- [x] Per-service card on paid orders does not show the per-line `Cancel` button.