### PR TITLE
feat(campaigns): buy N get M free discount type

### DIFF
--- a/apps/web/src/features/campaigns/components/campaign-form.tsx
+++ b/apps/web/src/features/campaigns/components/campaign-form.tsx
@@ -1,6 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon } from "@phosphor-icons/react";
-import { Controller, useForm } from "react-hook-form";
+import {
+	Controller,
+	FormProvider,
+	useForm,
+	useFormContext,
+	useWatch,
+} from "react-hook-form";
 import { z } from "zod";
 import { CurrencyInput } from "@/components/form/currency-input";
 import { Button } from "@/components/ui/button";
@@ -25,23 +31,64 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { ServicesMultiAutocomplete } from "@/features/orders/components/services-multi-autocomplete";
 import { useSheetDirtyGuard } from "@/hooks/useSheetDirtyGuard";
 import type { CampaignPayload } from "@/lib/api";
 
-const campaignFormSchema = z.object({
-	code: z.string().trim().min(1, "Code is required"),
-	name: z.string().trim().min(1, "Name is required"),
-	discount_type: z.enum(["fixed", "percentage"]),
-	discount_value: z.string().trim().min(1, "Discount value is required"),
-	min_order_total: z.string().trim().min(1, "Min order total is required"),
-	max_discount: z.string().trim().optional(),
-	starts_at: z.string().trim().optional(),
-	ends_at: z.string().trim().optional(),
-	is_active: z.boolean(),
-	store_ids: z.array(z.number().int().positive()),
-});
+const campaignFormSchema = z
+	.object({
+		code: z.string().trim().min(1, "Code is required"),
+		name: z.string().trim().min(1, "Name is required"),
+		discount_type: z.enum(["fixed", "percentage", "buy_n_get_m_free"]),
+		discount_value: z.string(),
+		min_order_total: z.string().min(1, "Min order total is required"),
+		max_discount: z.string().optional(),
+		starts_at: z.string().optional(),
+		ends_at: z.string().optional(),
+		is_active: z.boolean(),
+		store_ids: z.array(z.number().int().positive()),
+		eligible_service_ids: z.array(z.number().int().positive()),
+		buy_quantity: z.number().int().min(1).optional(),
+		free_quantity: z.number().int().min(1).optional(),
+	})
+	.superRefine((value, ctx) => {
+		if (value.discount_type === "buy_n_get_m_free") {
+			if (value.eligible_service_ids.length < 1) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["eligible_service_ids"],
+					message: "Select at least one eligible service",
+				});
+			}
+			if (!value.buy_quantity || value.buy_quantity < 1) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["buy_quantity"],
+					message: "Buy quantity is required",
+				});
+			}
+			if (!value.free_quantity || value.free_quantity < 1) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["free_quantity"],
+					message: "Free quantity is required",
+				});
+			}
+			return;
+		}
+
+		if (!value.discount_value || value.discount_value.trim().length === 0) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["discount_value"],
+				message: "Discount value is required",
+			});
+		}
+	});
 
 export type CampaignFormState = z.infer<typeof campaignFormSchema>;
+
+type CampaignDiscountType = CampaignFormState["discount_type"];
 
 type CampaignFormProps = {
 	defaultValues: CampaignFormState;
@@ -52,19 +99,224 @@ type CampaignFormProps = {
 };
 
 function toCampaignPayload(values: CampaignFormState): CampaignPayload {
-	return {
+	const base = {
 		code: values.code,
 		name: values.name,
-		discount_type: values.discount_type,
-		discount_value: values.discount_value,
 		min_order_total: values.min_order_total,
-		max_discount: values.max_discount?.trim() ? values.max_discount : null,
 		starts_at: values.starts_at ? new Date(values.starts_at) : null,
 		ends_at: values.ends_at ? new Date(values.ends_at) : null,
 		is_active: values.is_active,
 		store_ids: values.store_ids,
+		eligible_service_ids: values.eligible_service_ids,
+	};
+
+	if (values.discount_type === "buy_n_get_m_free") {
+		return {
+			...base,
+			discount_type: "buy_n_get_m_free",
+			buy_quantity: values.buy_quantity ?? 1,
+			free_quantity: values.free_quantity ?? 1,
+		};
+	}
+
+	return {
+		...base,
+		discount_type: values.discount_type,
+		discount_value: values.discount_value,
+		max_discount: values.max_discount?.trim() ? values.max_discount : null,
 	};
 }
+
+const DISCOUNT_TYPE_OPTIONS: { value: CampaignDiscountType; label: string }[] =
+	[
+		{ value: "fixed", label: "Fixed" },
+		{ value: "percentage", label: "Percentage" },
+		{ value: "buy_n_get_m_free", label: "Buy N Get M Free" },
+	];
+
+const FixedDiscountFields = () => {
+	const { control } = useFormContext<CampaignFormState>();
+
+	return (
+		<>
+			<Controller
+				name="discount_value"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-discount-value" asterisk>
+							Discount Value
+						</FieldLabel>
+						<CurrencyInput
+							id="campaign-discount-value"
+							placeholder="Rp0"
+							value={field.value}
+							onValueChange={field.onChange}
+							required
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+			<Controller
+				name="max_discount"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-max-discount">
+							Max Discount
+						</FieldLabel>
+						<CurrencyInput
+							id="campaign-max-discount"
+							placeholder="optional"
+							value={field.value ?? ""}
+							onValueChange={field.onChange}
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+		</>
+	);
+};
+
+const PercentageDiscountFields = () => {
+	const { control } = useFormContext<CampaignFormState>();
+
+	return (
+		<>
+			<Controller
+				name="discount_value"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-discount-value" asterisk>
+							Discount Value
+						</FieldLabel>
+						<Input
+							{...field}
+							id="campaign-discount-value"
+							type="number"
+							placeholder="e.g. 10"
+							min={1}
+							max={100}
+							aria-invalid={fieldState.invalid}
+							className="h-10"
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+			<Controller
+				name="max_discount"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-max-discount">
+							Max Discount
+						</FieldLabel>
+						<CurrencyInput
+							id="campaign-max-discount"
+							placeholder="optional"
+							value={field.value ?? ""}
+							onValueChange={field.onChange}
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+		</>
+	);
+};
+
+const BogoDiscountFields = () => {
+	const { control } = useFormContext<CampaignFormState>();
+
+	return (
+		<>
+			<Controller
+				name="buy_quantity"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-buy-quantity" asterisk>
+							Buy Quantity
+						</FieldLabel>
+						<Input
+							id="campaign-buy-quantity"
+							type="number"
+							min={1}
+							placeholder="e.g. 4"
+							value={field.value ?? ""}
+							onChange={(event) =>
+								field.onChange(
+									event.target.value ? Number(event.target.value) : undefined,
+								)
+							}
+							aria-invalid={fieldState.invalid}
+							className="h-10"
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+			<Controller
+				name="free_quantity"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid}>
+						<FieldLabel htmlFor="campaign-free-quantity" asterisk>
+							Free Quantity
+						</FieldLabel>
+						<Input
+							id="campaign-free-quantity"
+							type="number"
+							min={1}
+							placeholder="e.g. 1"
+							value={field.value ?? ""}
+							onChange={(event) =>
+								field.onChange(
+									event.target.value ? Number(event.target.value) : undefined,
+								)
+							}
+							aria-invalid={fieldState.invalid}
+							className="h-10"
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+			<Controller
+				name="eligible_service_ids"
+				control={control}
+				render={({ field, fieldState }) => (
+					<Field data-invalid={fieldState.invalid} className="md:col-span-2">
+						<FieldLabel htmlFor="campaign-eligible-services" asterisk>
+							Eligible Services
+						</FieldLabel>
+						<ServicesMultiAutocomplete
+							id="campaign-eligible-services"
+							placeholder="Select eligible services"
+							values={field.value}
+							onValuesChange={field.onChange}
+							error={fieldState.error}
+						/>
+						<FieldError errors={[fieldState.error]} />
+					</Field>
+				)}
+			/>
+		</>
+	);
+};
+
+const discountTypeFieldsMap: Record<
+	CampaignDiscountType,
+	() => React.JSX.Element
+> = {
+	fixed: FixedDiscountFields,
+	percentage: PercentageDiscountFields,
+	buy_n_get_m_free: BogoDiscountFields,
+};
 
 export function CampaignForm({
 	defaultValues,
@@ -79,284 +331,243 @@ export function CampaignForm({
 	});
 	const isSubmitting = form.formState.isSubmitting;
 	useSheetDirtyGuard(form.formState.isDirty);
-	const discountType = form.watch("discount_type");
+	const discountType = useWatch({
+		control: form.control,
+		name: "discount_type",
+	});
+	const DiscountFields = discountTypeFieldsMap[discountType];
 
 	return (
-		<form
-			onSubmit={form.handleSubmit(async (values) => {
-				await handleOnSubmit(toCampaignPayload(values));
-			})}
-		>
-			<FieldGroup>
-				<Controller
-					name="code"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-code" asterisk>
-								Code
-							</FieldLabel>
-							<Input
-								{...field}
-								id="campaign-code"
-								placeholder="e.g. MARCH10"
-								aria-invalid={fieldState.invalid}
-								disabled={isSubmitting}
-								className="h-10"
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
+		<FormProvider {...form}>
+			<form
+				onSubmit={form.handleSubmit(async (values) => {
+					await handleOnSubmit(toCampaignPayload(values));
+				})}
+			>
+				<FieldGroup>
+					<Controller
+						name="code"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-code" asterisk>
+									Code
+								</FieldLabel>
+								<Input
+									{...field}
+									id="campaign-code"
+									placeholder="e.g. MARCH10"
+									aria-invalid={fieldState.invalid}
+									disabled={isSubmitting}
+									className="h-10"
+								/>
+								<FieldError errors={[fieldState.error]} />
+							</Field>
+						)}
+					/>
 
-				<Controller
-					name="name"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-name" asterisk>
-								Name
-							</FieldLabel>
-							<Input
-								{...field}
-								id="campaign-name"
-								placeholder="e.g. March Promo"
-								aria-invalid={fieldState.invalid}
-								disabled={isSubmitting}
-								className="h-10"
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
+					<Controller
+						name="name"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-name" asterisk>
+									Name
+								</FieldLabel>
+								<Input
+									{...field}
+									id="campaign-name"
+									placeholder="e.g. March Promo"
+									aria-invalid={fieldState.invalid}
+									disabled={isSubmitting}
+									className="h-10"
+								/>
+								<FieldError errors={[fieldState.error]} />
+							</Field>
+						)}
+					/>
 
-				<Controller
-					name="discount_type"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-discount-type" asterisk>
-								Discount Type
-							</FieldLabel>
-							<Select
-								value={field.value}
-								onValueChange={(value) =>
-									field.onChange((value ?? "fixed") as "fixed" | "percentage")
-								}
-								disabled={isSubmitting}
-							>
-								<SelectTrigger id="campaign-discount-type" size="md">
-									<SelectValue placeholder="Select discount type" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="fixed">Fixed</SelectItem>
-									<SelectItem value="percentage">Percentage</SelectItem>
-								</SelectContent>
-							</Select>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
+					<Controller
+						name="discount_type"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-discount-type" asterisk>
+									Discount Type
+								</FieldLabel>
+								<Select
+									value={field.value}
+									onValueChange={(value) =>
+										field.onChange((value ?? "fixed") as CampaignDiscountType)
+									}
+									disabled={isSubmitting}
+								>
+									<SelectTrigger id="campaign-discount-type" size="md">
+										<SelectValue placeholder="Select discount type" />
+									</SelectTrigger>
+									<SelectContent>
+										{DISCOUNT_TYPE_OPTIONS.map((option) => (
+											<SelectItem key={option.value} value={option.value}>
+												{option.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FieldError errors={[fieldState.error]} />
+							</Field>
+						)}
+					/>
 
-				<Controller
-					name="discount_value"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-discount-value" asterisk>
-								Discount Value
-							</FieldLabel>
-							{discountType === "fixed" ? (
+					<DiscountFields />
+
+					<Controller
+						name="min_order_total"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-min-order" asterisk>
+									Min Order Total
+								</FieldLabel>
 								<CurrencyInput
-									id="campaign-discount-value"
+									id="campaign-min-order"
 									placeholder="Rp0"
 									value={field.value}
 									onValueChange={field.onChange}
 									disabled={isSubmitting}
 									required
 								/>
-							) : (
+								<FieldError errors={[fieldState.error]} />
+							</Field>
+						)}
+					/>
+
+					<Controller
+						name="starts_at"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-starts-at">Starts At</FieldLabel>
 								<Input
 									{...field}
-									id="campaign-discount-value"
-									type="number"
-									placeholder="e.g. 10"
-									min={1}
+									id="campaign-starts-at"
+									type="datetime-local"
 									aria-invalid={fieldState.invalid}
 									disabled={isSubmitting}
 									className="h-10"
 								/>
-							)}
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
-
-				<Controller
-					name="min_order_total"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-min-order" asterisk>
-								Min Order Total
-							</FieldLabel>
-							<CurrencyInput
-								id="campaign-min-order"
-								placeholder="Rp0"
-								value={field.value}
-								onValueChange={field.onChange}
-								disabled={isSubmitting}
-								required
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
-
-				<Controller
-					name="max_discount"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-max-discount">
-								Max Discount
-							</FieldLabel>
-							<CurrencyInput
-								id="campaign-max-discount"
-								placeholder="optional"
-								value={field.value ?? ""}
-								onValueChange={field.onChange}
-								disabled={isSubmitting}
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
-
-				<Controller
-					name="starts_at"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-starts-at">Starts At</FieldLabel>
-							<Input
-								{...field}
-								id="campaign-starts-at"
-								type="datetime-local"
-								aria-invalid={fieldState.invalid}
-								disabled={isSubmitting}
-								className="h-10"
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
-
-				<Controller
-					name="ends_at"
-					control={form.control}
-					render={({ field, fieldState }) => (
-						<Field data-invalid={fieldState.invalid}>
-							<FieldLabel htmlFor="campaign-ends-at">Ends At</FieldLabel>
-							<Input
-								{...field}
-								id="campaign-ends-at"
-								type="datetime-local"
-								aria-invalid={fieldState.invalid}
-								disabled={isSubmitting}
-								className="h-10"
-							/>
-							<FieldError errors={[fieldState.error]} />
-						</Field>
-					)}
-				/>
-
-				<Controller
-					name="store_ids"
-					control={form.control}
-					render={({ field }) => (
-						<FieldSet className="border p-2">
-							<FieldLegend variant="label">
-								Stores (empty = all stores)
-							</FieldLegend>
-							<FieldGroup>
-								{stores.map((store) => {
-									const checked = field.value.includes(store.id);
-									return (
-										<Field
-											orientation="horizontal"
-											key={store.id}
-											className="flex items-center gap-2 text-sm"
-										>
-											<Checkbox
-												id={`campaign-store-${store.id}`}
-												checked={checked}
-												onCheckedChange={(value) => {
-													if (value) {
-														field.onChange([...field.value, store.id]);
-														return;
-													}
-
-													field.onChange(
-														field.value.filter((id: number) => id !== store.id),
-													);
-												}}
-												disabled={isSubmitting}
-											/>
-											<FieldLabel htmlFor={`campaign-store-${store.id}`}>
-												{store.name}
-											</FieldLabel>
-										</Field>
-									);
-								})}
-							</FieldGroup>
-						</FieldSet>
-					)}
-				/>
-
-				<Controller
-					name="is_active"
-					control={form.control}
-					render={({ field }) => (
-						<FieldLabel htmlFor="campaign-active" className="md:col-span-2">
-							<Field orientation="horizontal">
-								<FieldContent>
-									<FieldTitle>Active</FieldTitle>
-									<FieldDescription>
-										Active campaigns can be applied during checkout.
-									</FieldDescription>
-								</FieldContent>
-								<Switch
-									id="campaign-active"
-									checked={field.value}
-									onCheckedChange={(checked) => field.onChange(!!checked)}
-									disabled={isSubmitting}
-								/>
+								<FieldError errors={[fieldState.error]} />
 							</Field>
-						</FieldLabel>
-					)}
-				/>
+						)}
+					/>
 
-				<div className="flex flex-wrap gap-2 md:col-span-2 md:justify-end">
-					{isEditing ? (
+					<Controller
+						name="ends_at"
+						control={form.control}
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel htmlFor="campaign-ends-at">Ends At</FieldLabel>
+								<Input
+									{...field}
+									id="campaign-ends-at"
+									type="datetime-local"
+									aria-invalid={fieldState.invalid}
+									disabled={isSubmitting}
+									className="h-10"
+								/>
+								<FieldError errors={[fieldState.error]} />
+							</Field>
+						)}
+					/>
+
+					<Controller
+						name="store_ids"
+						control={form.control}
+						render={({ field }) => (
+							<FieldSet className="border p-2">
+								<FieldLegend variant="label">
+									Stores (empty = all stores)
+								</FieldLegend>
+								<FieldGroup>
+									{stores.map((store) => {
+										const checked = field.value.includes(store.id);
+										return (
+											<Field
+												orientation="horizontal"
+												key={store.id}
+												className="flex items-center gap-2 text-sm"
+											>
+												<Checkbox
+													id={`campaign-store-${store.id}`}
+													checked={checked}
+													onCheckedChange={(value) => {
+														if (value) {
+															field.onChange([...field.value, store.id]);
+															return;
+														}
+
+														field.onChange(
+															field.value.filter(
+																(id: number) => id !== store.id,
+															),
+														);
+													}}
+													disabled={isSubmitting}
+												/>
+												<FieldLabel htmlFor={`campaign-store-${store.id}`}>
+													{store.name}
+												</FieldLabel>
+											</Field>
+										);
+									})}
+								</FieldGroup>
+							</FieldSet>
+						)}
+					/>
+
+					<Controller
+						name="is_active"
+						control={form.control}
+						render={({ field }) => (
+							<FieldLabel htmlFor="campaign-active" className="md:col-span-2">
+								<Field orientation="horizontal">
+									<FieldContent>
+										<FieldTitle>Active</FieldTitle>
+										<FieldDescription>
+											Active campaigns can be applied during checkout.
+										</FieldDescription>
+									</FieldContent>
+									<Switch
+										id="campaign-active"
+										checked={field.value}
+										onCheckedChange={(checked) => field.onChange(!!checked)}
+										disabled={isSubmitting}
+									/>
+								</Field>
+							</FieldLabel>
+						)}
+					/>
+
+					<div className="flex flex-wrap gap-2 md:col-span-2 md:justify-end">
+						{isEditing ? (
+							<Button
+								type="button"
+								variant="outline"
+								onClick={onReset}
+								disabled={isSubmitting}
+							>
+								Cancel edit
+							</Button>
+						) : null}
 						<Button
-							type="button"
-							variant="outline"
-							onClick={onReset}
-							disabled={isSubmitting}
+							type="submit"
+							loading={isSubmitting}
+							icon={<PlusIcon className="size-4" />}
 						>
-							Cancel edit
+							{isEditing ? "Update Campaign" : "Create Campaign"}
 						</Button>
-					) : null}
-					<Button
-						type="submit"
-						loading={isSubmitting}
-						icon={<PlusIcon className="size-4" />}
-					>
-						{isEditing ? "Update Campaign" : "Create Campaign"}
-					</Button>
-				</div>
-			</FieldGroup>
-		</form>
+					</div>
+				</FieldGroup>
+			</form>
+		</FormProvider>
 	);
 }

--- a/apps/web/src/features/orders/components/services-multi-autocomplete.tsx
+++ b/apps/web/src/features/orders/components/services-multi-autocomplete.tsx
@@ -1,0 +1,168 @@
+import { CaretDownIcon, XIcon } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { servicesQueryOptions } from "@/lib/query-options";
+import { cn } from "@/lib/utils";
+
+interface ServicesMultiAutocompleteProps {
+	id?: string;
+	label?: string;
+	placeholder?: string;
+	values: number[];
+	onValuesChange: (values: number[]) => void;
+	disabled?: boolean;
+	error?: { message?: string };
+}
+
+export const ServicesMultiAutocomplete = ({
+	id = "services-multi",
+	label,
+	placeholder = "Select services",
+	values,
+	onValuesChange,
+	disabled,
+	error,
+}: ServicesMultiAutocompleteProps) => {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const servicesQuery = useQuery(servicesQueryOptions());
+
+	const services = servicesQuery.data ?? [];
+
+	const valueSet = useMemo(() => new Set(values), [values]);
+
+	const selectableServices = useMemo(
+		() => services.filter((service) => service.is_active),
+		[services],
+	);
+
+	const selectedServices = useMemo(
+		() => selectableServices.filter((service) => valueSet.has(service.id)),
+		[selectableServices, valueSet],
+	);
+
+	const handleToggle = useCallback(
+		(serviceId: number) => {
+			if (valueSet.has(serviceId)) {
+				onValuesChange(values.filter((id) => id !== serviceId));
+				return;
+			}
+			onValuesChange([...values, serviceId]);
+		},
+		[values, valueSet, onValuesChange],
+	);
+
+	const handleRemove = useCallback(
+		(serviceId: number) => {
+			onValuesChange(values.filter((id) => id !== serviceId));
+		},
+		[values, onValuesChange],
+	);
+
+	const hasSelection = selectedServices.length > 0;
+
+	return (
+		<Field data-invalid={!!error}>
+			{label ? <FieldLabel htmlFor={id}>{label}</FieldLabel> : null}
+			<Popover open={isOpen} onOpenChange={setIsOpen}>
+				<PopoverTrigger
+					nativeButton={false}
+					render={
+						<div
+							id={id}
+							role="combobox"
+							aria-haspopup="listbox"
+							aria-expanded={isOpen}
+							tabIndex={disabled ? -1 : 0}
+							aria-disabled={disabled}
+							className={cn(
+								"flex h-auto min-h-10 w-full cursor-pointer items-center justify-between gap-2 border border-input bg-background px-3 py-2 text-left text-sm",
+								"aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+							)}
+						/>
+					}
+				>
+					<div className="flex flex-1 flex-wrap items-center gap-1.5">
+						{hasSelection ? (
+							selectedServices.map((service) => (
+								<Badge
+									key={service.id}
+									variant="secondary"
+									className="gap-1 pr-1"
+								>
+									{service.code}
+									{!disabled ? (
+										<button
+											type="button"
+											onClick={(event) => {
+												event.stopPropagation();
+												handleRemove(service.id);
+											}}
+											className="hover:text-destructive"
+											aria-label={`Remove ${service.code}`}
+										>
+											<XIcon className="size-3" />
+										</button>
+									) : null}
+								</Badge>
+							))
+						) : (
+							<span className="text-muted-foreground">{placeholder}</span>
+						)}
+					</div>
+					<CaretDownIcon className="size-4 shrink-0 opacity-50" />
+				</PopoverTrigger>
+				<PopoverContent
+					align="start"
+					className="w-(--radix-popover-trigger-width) max-h-72 overflow-y-auto p-0"
+				>
+					{selectableServices.length === 0 ? (
+						<p className="p-3 text-muted-foreground text-sm">
+							No services available
+						</p>
+					) : (
+						<ul className="divide-y">
+							{selectableServices.map((service) => {
+								const isChecked = valueSet.has(service.id);
+								return (
+									<li key={service.id}>
+										<Button
+											type="button"
+											variant="ghost"
+											className="h-auto w-full justify-start gap-2 rounded-none px-3 py-2 text-left"
+											onClick={() => handleToggle(service.id)}
+										>
+											<Checkbox
+												checked={isChecked}
+												className="pointer-events-none"
+												tabIndex={-1}
+											/>
+											<div className="flex flex-col">
+												<span className="text-sm font-medium">
+													{service.code}
+												</span>
+												<span className="text-muted-foreground text-xs">
+													{service.name}
+												</span>
+											</div>
+										</Button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</PopoverContent>
+			</Popover>
+			<FieldError errors={[error]} />
+		</Field>
+	);
+};

--- a/apps/web/src/features/reports/panels/financial-panel.tsx
+++ b/apps/web/src/features/reports/panels/financial-panel.tsx
@@ -68,6 +68,10 @@ export const FinancialPanel = ({
 		lines.push(
 			`Totals,Products,${summary?.products_total ?? 0},${prev.products_total}`,
 		);
+		lines.push(`Totals,Discount,${summary?.discount ?? 0},${prev.discount}`);
+		lines.push(
+			`Totals,Net revenue,${summary?.net_revenue ?? 0},${prev.net_revenue}`,
+		);
 		lines.push(`Totals,COGS,${summary?.cogs ?? 0},${prev.cogs}`);
 		lines.push(
 			`Totals,Gross profit,${summary?.gross_profit ?? 0},${prev.gross_profit}`,
@@ -81,11 +85,11 @@ export const FinancialPanel = ({
 		);
 		lines.push("");
 		lines.push(
-			"Financial series,Bucket,Services,Products,Gross,COGS,Gross profit,Refunds,Net income",
+			"Financial series,Bucket,Services,Products,Gross,Discount,Net revenue,COGS,Gross profit,Refunds,Net income",
 		);
 		for (const row of data.series) {
 			lines.push(
-				`Series,${escapeCsv(row.bucket)},${row.services},${row.products},${row.gross_revenue},${row.cogs},${row.gross_profit},${row.refunds},${row.net_income}`,
+				`Series,${escapeCsv(row.bucket)},${row.services},${row.products},${row.gross_revenue},${row.discount},${row.net_revenue},${row.cogs},${row.gross_profit},${row.refunds},${row.net_income}`,
 			);
 		}
 		lines.push("");
@@ -112,6 +116,18 @@ export const FinancialPanel = ({
 						helper="Services + products"
 					/>
 					<KpiCard
+						label="Discount"
+						value={formatIDRCurrency(String(summary?.discount ?? 0))}
+						delta={deltas?.discount}
+						helper="Campaign + manual"
+					/>
+					<KpiCard
+						label="Net revenue"
+						value={formatIDRCurrency(String(summary?.net_revenue ?? 0))}
+						delta={deltas?.net_revenue}
+						helper="Gross - discount"
+					/>
+					<KpiCard
 						label="COGS"
 						value={formatIDRCurrency(String(summary?.cogs ?? 0))}
 						delta={deltas?.cogs}
@@ -121,7 +137,7 @@ export const FinancialPanel = ({
 						label="Gross profit"
 						value={formatIDRCurrency(String(summary?.gross_profit ?? 0))}
 						delta={deltas?.gross_profit}
-						helper="Before refunds"
+						helper="Net revenue - COGS"
 					/>
 					<KpiCard
 						label="Refunds"
@@ -132,13 +148,13 @@ export const FinancialPanel = ({
 						label="Net income"
 						value={formatIDRCurrency(String(summary?.net_income ?? 0))}
 						delta={deltas?.net_income}
-						helper="Gross - COGS - refunds"
+						helper="Net revenue - COGS - refunds"
 					/>
 					<KpiCard
 						label="Net margin"
 						value={percentFormatter.format(summary?.net_margin ?? 0)}
 						delta={deltas?.net_margin}
-						helper="Net income / gross"
+						helper="Net income / net revenue"
 					/>
 					<KpiCard
 						label="Services"
@@ -171,13 +187,14 @@ export const FinancialPanel = ({
 			<ChartCard
 				variant="stacked-bar"
 				title="Gross revenue composition"
-				description="Net income + COGS + refunds = gross revenue per bucket."
+				description="Net income + COGS + refunds + discount = gross revenue per bucket."
 				data={data?.series ?? []}
 				granularity={data?.granularity ?? "day"}
 				series={[
 					{ key: "net_income", label: "Net income", color: CHART_PALETTE[1] },
 					{ key: "cogs", label: "COGS", color: CHART_PALETTE[2] },
 					{ key: "refunds", label: "Refunds", color: CHART_PALETTE[3] },
+					{ key: "discount", label: "Discount", color: CHART_PALETTE[4] },
 				]}
 				valueFormatter={(v) => formatIDRCurrency(String(v))}
 			/>

--- a/apps/web/src/features/reports/panels/overview-panel.tsx
+++ b/apps/web/src/features/reports/panels/overview-panel.tsx
@@ -157,7 +157,7 @@ export const OverviewPanel = ({ date, storeId }: OverviewPanelProps) => {
 
 			<KpiRow>
 				<KpiCard
-					label="Revenue"
+					label="Net revenue"
 					value={formatIDRCurrency(String(overview?.daily.revenue ?? 0))}
 					helper="Paid minus refunded"
 				/>

--- a/apps/web/src/features/transactions/components/campaign-summary-card.tsx
+++ b/apps/web/src/features/transactions/components/campaign-summary-card.tsx
@@ -1,0 +1,81 @@
+import { memo } from "react";
+import { Badge } from "@/components/ui/badge";
+import type { Campaign } from "@/lib/api";
+import { formatIDRCurrency } from "@/shared/utils";
+
+interface CampaignSummaryProps {
+	campaign: Campaign;
+}
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<div className="flex items-center justify-between gap-3 border border-emerald-300/60 bg-emerald-50/70 p-3 text-sm dark:border-emerald-800 dark:bg-emerald-950/30">
+		{children}
+	</div>
+);
+
+const Body = ({
+	campaign,
+	subtitle,
+}: {
+	campaign: Campaign;
+	subtitle: string;
+}) => (
+	<div>
+		<p className="font-medium">{campaign.name}</p>
+		<p className="text-xs text-muted-foreground">
+			{campaign.code} · {subtitle}
+		</p>
+	</div>
+);
+
+const FixedCampaignSummary = ({ campaign }: CampaignSummaryProps) => (
+	<Container>
+		<Body campaign={campaign} subtitle="Fixed discount" />
+		<Badge variant="success">
+			{formatIDRCurrency(String(campaign.discount_value))}
+		</Badge>
+	</Container>
+);
+
+const PercentageCampaignSummary = ({ campaign }: CampaignSummaryProps) => (
+	<Container>
+		<Body campaign={campaign} subtitle="Percentage discount" />
+		<Badge variant="success">{campaign.discount_value}%</Badge>
+	</Container>
+);
+
+const BogoCampaignSummary = ({ campaign }: CampaignSummaryProps) => {
+	const buy = campaign.buy_quantity ?? 0;
+	const free = campaign.free_quantity ?? 0;
+	const eligibleCodes =
+		campaign.eligibleServices
+			?.map((entry) => entry.service?.code ?? `#${entry.service_id}`)
+			.join(", ") ?? "";
+
+	return (
+		<Container>
+			<Body
+				campaign={campaign}
+				subtitle={`Eligible: ${eligibleCodes || "—"}`}
+			/>
+			<Badge variant="success">
+				Buy {buy} Get {free} Free
+			</Badge>
+		</Container>
+	);
+};
+
+const summaryByType = {
+	fixed: FixedCampaignSummary,
+	percentage: PercentageCampaignSummary,
+	buy_n_get_m_free: BogoCampaignSummary,
+} as const;
+
+export const CampaignSummaryCard = memo(
+	({ campaign }: CampaignSummaryProps) => {
+		const Component = summaryByType[campaign.discount_type];
+		return <Component campaign={campaign} />;
+	},
+);
+
+CampaignSummaryCard.displayName = "CampaignSummaryCard";

--- a/apps/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/apps/web/src/features/transactions/components/transactions-checkout.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { CampaignAutocomplete } from "@/features/orders/components/campaign-autocomplete";
 import { CustomerAutocomplete } from "@/features/orders/components/customer-autocomplete";
+import { CampaignSummaryCard } from "@/features/transactions/components/campaign-summary-card";
 import { useCartTotals } from "@/features/transactions/hooks/use-cart-totals";
 import { useTransactionsCart } from "@/features/transactions/hooks/use-transactions-cart";
 import {
@@ -156,9 +157,17 @@ export function TransactionsCheckout() {
 		[paymentMethodOptions, selectedPaymentMethodId],
 	);
 
+	const lines = useMemo(
+		() =>
+			cartServiceRows.map((row) => ({
+				price: Number(row.service.price),
+				service_id: row.service.id,
+			})),
+		[cartServiceRows],
+	);
 	const stackedDiscount = useMemo(
-		() => getStackedDiscount(subtotal, selectedCampaigns),
-		[subtotal, selectedCampaigns],
+		() => getStackedDiscount(subtotal, selectedCampaigns, lines),
+		[subtotal, selectedCampaigns, lines],
 	);
 	const campaignDiscount = stackedDiscount.total;
 	const discountValue = Number(manualDiscount || 0);
@@ -256,22 +265,7 @@ export function TransactionsCheckout() {
 			{selectedCampaigns.length > 0 ? (
 				<div className="grid gap-2">
 					{selectedCampaigns.map((campaign) => (
-						<div
-							key={campaign.id}
-							className="flex items-center justify-between gap-3 border border-emerald-300/60 bg-emerald-50/70 p-3 text-sm dark:border-emerald-800 dark:bg-emerald-950/30"
-						>
-							<div>
-								<p className="font-medium">{campaign.name}</p>
-								<p className="text-xs text-muted-foreground">
-									{campaign.code} active on this store
-								</p>
-							</div>
-							<Badge variant="success">
-								{campaign.discount_type === "percentage"
-									? `${campaign.discount_value}%`
-									: formatIDRCurrency(String(campaign.discount_value))}
-							</Badge>
-						</div>
+						<CampaignSummaryCard key={campaign.id} campaign={campaign} />
 					))}
 				</div>
 			) : null}

--- a/apps/web/src/features/transactions/lib/transactions.ts
+++ b/apps/web/src/features/transactions/lib/transactions.ts
@@ -1,5 +1,6 @@
 import {
 	type CampaignContribution,
+	type DiscountLine,
 	stackCampaignDiscounts,
 } from "@fresclean/api/schema";
 import type {
@@ -113,8 +114,17 @@ export function isCampaignAvailable(campaign: Campaign, now: Date) {
 
 export type CampaignBreakdown = CampaignContribution<Campaign>;
 
-export function getStackedDiscount(subtotal: number, campaigns: Campaign[]) {
-	return stackCampaignDiscounts(subtotal, campaigns);
+export function getStackedDiscount(
+	subtotal: number,
+	campaigns: Campaign[],
+	lines: DiscountLine[] = [],
+) {
+	const stackInput = campaigns.map((campaign) => ({
+		...campaign,
+		eligible_service_ids:
+			campaign.eligibleServices?.map((entry) => entry.service_id) ?? [],
+	}));
+	return stackCampaignDiscounts(subtotal, stackInput, lines);
 }
 
 export function toTransactionPayload({

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -312,18 +312,39 @@ export type FetchCampaignsQuery = {
 	is_active?: boolean;
 };
 
-export type CampaignPayload = {
+export type CampaignBasePayload = {
 	code: string;
 	name: string;
-	discount_type: "fixed" | "percentage";
-	discount_value: string;
 	min_order_total: string;
-	max_discount?: string | null;
 	starts_at?: Date | null;
 	ends_at?: Date | null;
 	is_active: boolean;
 	store_ids: number[];
+	eligible_service_ids: number[];
 };
+
+export type CampaignFixedPayload = CampaignBasePayload & {
+	discount_type: "fixed";
+	discount_value: string;
+	max_discount?: string | null;
+};
+
+export type CampaignPercentagePayload = CampaignBasePayload & {
+	discount_type: "percentage";
+	discount_value: string;
+	max_discount?: string | null;
+};
+
+export type CampaignBogoPayload = CampaignBasePayload & {
+	discount_type: "buy_n_get_m_free";
+	buy_quantity: number;
+	free_quantity: number;
+};
+
+export type CampaignPayload =
+	| CampaignFixedPayload
+	| CampaignPercentagePayload
+	| CampaignBogoPayload;
 
 export type OrderCancelReason =
 	| "customer_request"
@@ -686,9 +707,25 @@ export async function createCampaign(payload: CampaignPayload) {
 	);
 }
 
+export type UpdateCampaignPayload = {
+	code?: string;
+	name?: string;
+	discount_type?: "fixed" | "percentage" | "buy_n_get_m_free";
+	discount_value?: string;
+	min_order_total?: string;
+	max_discount?: string | null;
+	starts_at?: Date | null;
+	ends_at?: Date | null;
+	is_active?: boolean;
+	store_ids?: number[];
+	eligible_service_ids?: number[];
+	buy_quantity?: number | null;
+	free_quantity?: number | null;
+};
+
 export async function updateCampaign(
 	id: number,
-	payload: Partial<CampaignPayload>,
+	payload: UpdateCampaignPayload,
 ) {
 	return parseResponse(
 		rpcWithAuth().api.admin.campaigns[":id"].$put({

--- a/apps/web/src/routes/_admin/campaigns.tsx
+++ b/apps/web/src/routes/_admin/campaigns.tsx
@@ -27,9 +27,9 @@ import {
 } from "@/features/campaigns/components/campaign-form";
 import {
 	type Campaign,
-	type CampaignPayload,
 	createCampaign,
 	queryKeys,
+	type UpdateCampaignPayload,
 	updateCampaign,
 } from "@/lib/api";
 import { campaignsQueryOptions, storesQueryOptions } from "@/lib/query-options";
@@ -84,6 +84,9 @@ const defaultCampaignForm: CampaignFormState = {
 	ends_at: "",
 	is_active: true,
 	store_ids: [],
+	eligible_service_ids: [],
+	buy_quantity: undefined,
+	free_quantity: undefined,
 };
 
 function toDateTimeLocal(value: Date | string | null | undefined) {
@@ -99,6 +102,12 @@ function toDateTimeLocal(value: Date | string | null | undefined) {
 function formatCampaignDiscount(campaign: Campaign) {
 	if (campaign.discount_type === "percentage") {
 		return `${campaign.discount_value}%`;
+	}
+
+	if (campaign.discount_type === "buy_n_get_m_free") {
+		return `Buy ${campaign.buy_quantity ?? "?"} Get ${
+			campaign.free_quantity ?? "?"
+		} Free`;
 	}
 
 	return formatIDRCurrency(String(campaign.discount_value));
@@ -205,7 +214,7 @@ function CampaignsPage() {
 			payload,
 		}: {
 			id: number;
-			payload: Partial<CampaignPayload>;
+			payload: UpdateCampaignPayload;
 		}) => updateCampaign(id, payload),
 		onSuccess: async () => {
 			await queryClient.invalidateQueries({ queryKey: ["campaigns"] });
@@ -259,6 +268,10 @@ function CampaignsPage() {
 							ends_at: toDateTimeLocal(campaign.ends_at),
 							is_active: campaign.is_active,
 							store_ids: campaign.stores.map((item) => item.store_id),
+							eligible_service_ids:
+								campaign.eligibleServices?.map((item) => item.service_id) ?? [],
+							buy_quantity: campaign.buy_quantity ?? undefined,
+							free_quantity: campaign.free_quantity ?? undefined,
 						}}
 						isEditing
 						onReset={closeSheet}

--- a/packages/server/src/db/relations.ts
+++ b/packages/server/src/db/relations.ts
@@ -79,6 +79,7 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   servicesTable: {
+    campaignEligibilities: r.many.campaignEligibleServicesTable(),
     category: r.one.categoriesTable({
       from: r.servicesTable.category_id,
       to: r.categoriesTable.id,
@@ -98,6 +99,7 @@ export const relations = defineRelations(schema, (r) => ({
       alias: "campaign_created_by",
       optional: false,
     }),
+    eligibleServices: r.many.campaignEligibleServicesTable(),
     orderCampaigns: r.many.orderCampaignsTable(),
     stores: r.many.campaignStoresTable(),
     updatedBy: r.one.usersTable({
@@ -117,6 +119,19 @@ export const relations = defineRelations(schema, (r) => ({
     store: r.one.storesTable({
       from: r.campaignStoresTable.store_id,
       to: r.storesTable.id,
+      optional: false,
+    }),
+  },
+
+  campaignEligibleServicesTable: {
+    campaign: r.one.campaignsTable({
+      from: r.campaignEligibleServicesTable.campaign_id,
+      to: r.campaignsTable.id,
+      optional: false,
+    }),
+    service: r.one.servicesTable({
+      from: r.campaignEligibleServicesTable.service_id,
+      to: r.servicesTable.id,
       optional: false,
     }),
   },

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -175,6 +175,7 @@ export const discountSourceEnum = pgEnum("discount_source_enum", [
 export const campaignDiscountTypeEnum = pgEnum("campaign_discount_type_enum", [
   "fixed",
   "percentage",
+  "buy_n_get_m_free",
 ]);
 export const orderServiceStatusEnum = pgEnum("order_service_status_enum", [
   "queued",
@@ -213,6 +214,8 @@ export const campaignsTable = pgTable(
     discount_value: decimal("discount_value", { precision: 12 })
       .default("0")
       .notNull(),
+    buy_quantity: integer("buy_quantity"),
+    free_quantity: integer("free_quantity"),
     ends_at: timestamp("ends_at"),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
     is_active: boolean("is_active").default(true).notNull(),
@@ -254,6 +257,16 @@ export const campaignsTable = pgTable(
       "campaign_percentage_discount_limit_check",
       sql`${table.discount_type} != 'percentage' OR (${table.discount_value} >= 0 AND ${table.discount_value} <= 100)`
     ),
+    check(
+      "campaign_bogo_valid_check",
+      sql`${table.discount_type} != 'buy_n_get_m_free'
+          OR (
+            ${table.buy_quantity} IS NOT NULL
+            AND ${table.free_quantity} IS NOT NULL
+            AND ${table.buy_quantity} >= 1
+            AND ${table.free_quantity} >= 1
+          )`
+    ),
   ]
 );
 
@@ -275,6 +288,28 @@ export const campaignStoresTable = pgTable(
     uniqueIndex("campaign_stores_campaign_store_uidx").on(
       table.campaign_id,
       table.store_id
+    ),
+  ]
+);
+
+export const campaignEligibleServicesTable = pgTable(
+  "campaign_eligible_services",
+  {
+    campaign_id: integer("campaign_id")
+      .references(() => campaignsTable.id, { onDelete: "cascade" })
+      .notNull(),
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    service_id: integer("service_id")
+      .references(() => servicesTable.id, { onDelete: "cascade" })
+      .notNull(),
+  },
+  (table) => [
+    index("campaign_eligible_services_campaign_idx").on(table.campaign_id),
+    index("campaign_eligible_services_service_idx").on(table.service_id),
+    uniqueIndex("campaign_eligible_services_campaign_service_uidx").on(
+      table.campaign_id,
+      table.service_id
     ),
   ]
 );
@@ -445,6 +480,7 @@ export const orderCampaignsTable = pgTable(
     applied_amount: decimal("applied_amount", { precision: 12 })
       .default("0")
       .notNull(),
+    buy_quantity: integer("buy_quantity"),
     campaign_id: integer("campaign_id")
       .references(() => campaignsTable.id, { onDelete: "restrict" })
       .notNull(),
@@ -453,6 +489,7 @@ export const orderCampaignsTable = pgTable(
     discount_value: decimal("discount_value", { precision: 12 })
       .default("0")
       .notNull(),
+    free_quantity: integer("free_quantity"),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
     max_discount: decimal("max_discount", { precision: 12 }),
     order_id: integer("order_id")

--- a/packages/server/src/db/seed/run-seed.ts
+++ b/packages/server/src/db/seed/run-seed.ts
@@ -65,23 +65,324 @@ const STORE_PRESETS = [
 ] as const;
 
 const CATEGORY_PRESETS = [
-  { key: "core", name: "Core Cleaning" },
-  { key: "restoration", name: "Restoration" },
-  { key: "protection", name: "Protection & Finishing" },
+  { key: "deep_clean", name: "Deep Clean" },
+  { key: "leather", name: "Leather Care" },
+  { key: "suede", name: "Suede Care" },
+  { key: "helmet", name: "Helmet" },
+  { key: "sole_protector", name: "Sole Protector" },
+  { key: "repaint", name: "Repaint" },
+  { key: "repair", name: "Repair" },
+  { key: "addons", name: "Add-Ons" },
+  { key: "express", name: "Express" },
   { key: "retail", name: "Retail Product" },
 ] as const;
 
+// Prices in IDR (rupiah). COGS approximated per service type.
 const SERVICE_PRESETS = [
-  { code: "DCB", name: "Deep Clean Basic", categoryKey: "core" },
-  { code: "DCP", name: "Deep Clean Premium", categoryKey: "core" },
-  { code: "EXP", name: "Express Cleaning", categoryKey: "core" },
-  { code: "RPT", name: "Repaint Touch-up", categoryKey: "restoration" },
-  { code: "RPF", name: "Repaint Full", categoryKey: "restoration" },
-  { code: "GLU", name: "Reglue Service", categoryKey: "restoration" },
-  { code: "WPR", name: "Water Repellent Coating", categoryKey: "protection" },
-  { code: "UVT", name: "Unyellowing Treatment", categoryKey: "protection" },
-  { code: "DST", name: "Deodorizing Sterilization", categoryKey: "protection" },
-  { code: "LCE", name: "Lace Replacement", categoryKey: "restoration" },
+  // Deep Clean
+  {
+    code: "DCS",
+    name: "Deep Clean Standard (Shoes / Hat)",
+    categoryKey: "deep_clean",
+    price: 60_000,
+    cogs: 11_000,
+  },
+  {
+    code: "DCE",
+    name: "Deep Clean Express (6h to 24h)",
+    categoryKey: "deep_clean",
+    price: 90_000,
+    cogs: 16_000,
+  },
+  {
+    code: "DCB",
+    name: "Deep Clean Baby (up to EU 24)",
+    categoryKey: "deep_clean",
+    price: 30_000,
+    cogs: 6000,
+  },
+  {
+    code: "DCW",
+    name: "Deep Clean Waist / Sling / Hand Bag",
+    categoryKey: "deep_clean",
+    price: 60_000,
+    cogs: 11_000,
+  },
+  {
+    code: "DCP",
+    name: "Deep Clean Backpack / Tote Bag",
+    categoryKey: "deep_clean",
+    price: 80_000,
+    cogs: 14_000,
+  },
+  {
+    code: "DCL",
+    name: "Deep Clean Luggage / Golf / Gym Bag",
+    categoryKey: "deep_clean",
+    price: 100_000,
+    cogs: 18_000,
+  },
+  {
+    code: "DCT",
+    name: "Deep Clean Stroller",
+    categoryKey: "deep_clean",
+    price: 150_000,
+    cogs: 27_000,
+  },
+
+  // Leather Care
+  {
+    code: "LCS",
+    name: "Leather Care Standard",
+    categoryKey: "leather",
+    price: 125_000,
+    cogs: 25_000,
+  },
+  {
+    code: "LCB",
+    name: "Leather Care Bag",
+    categoryKey: "leather",
+    price: 200_000,
+    cogs: 40_000,
+  },
+  {
+    code: "LCC",
+    name: "Leather Care Complete (with Outsole Cleaning)",
+    categoryKey: "leather",
+    price: 150_000,
+    cogs: 30_000,
+  },
+
+  // Suede Care
+  {
+    code: "SCC",
+    name: "Suede Care Complete (Suede / Nubuck)",
+    categoryKey: "suede",
+    price: 150_000,
+    cogs: 30_000,
+  },
+
+  // Helmet
+  {
+    code: "HLM",
+    name: "Helmet Half / Full Face",
+    categoryKey: "helmet",
+    price: 80_000,
+    cogs: 16_000,
+  },
+
+  // Sole Protector
+  {
+    code: "SPI",
+    name: "Sole Protector Items Only",
+    categoryKey: "sole_protector",
+    price: 150_000,
+    cogs: 60_000,
+  },
+  {
+    code: "SPN",
+    name: "Sole Protector Installation (6 Mo. Warranty)",
+    categoryKey: "sole_protector",
+    price: 275_000,
+    cogs: 90_000,
+  },
+
+  // Repaint
+  {
+    code: "RPB",
+    name: "Repaint Full Body",
+    categoryKey: "repaint",
+    price: 175_000,
+    cogs: 35_000,
+  },
+  {
+    code: "RPM",
+    name: "Repaint Mid Sole",
+    categoryKey: "repaint",
+    price: 130_000,
+    cogs: 26_000,
+  },
+  {
+    code: "RPU",
+    name: "Repaint Upper Sole",
+    categoryKey: "repaint",
+    price: 150_000,
+    cogs: 30_000,
+  },
+  {
+    code: "RP2",
+    name: "Repaint Add Two Tone (2 Color)",
+    categoryKey: "repaint",
+    price: 50_000,
+    cogs: 12_000,
+  },
+  {
+    code: "RPC",
+    name: "Repaint Add Checkerboard",
+    categoryKey: "repaint",
+    price: 100_000,
+    cogs: 22_000,
+  },
+  {
+    code: "RPG",
+    name: "Repaint Bag",
+    categoryKey: "repaint",
+    price: 250_000,
+    cogs: 50_000,
+  },
+
+  // Repair (6 Mo. Warranty)
+  {
+    code: "RGM",
+    name: "Repair Minor Reglue",
+    categoryKey: "repair",
+    price: 35_000,
+    cogs: 8000,
+  },
+  {
+    code: "RGF",
+    name: "Repair Full Sole Reglue",
+    categoryKey: "repair",
+    price: 150_000,
+    cogs: 35_000,
+  },
+  {
+    code: "RST",
+    name: "Repair Restitch",
+    categoryKey: "repair",
+    price: 80_000,
+    cogs: 18_000,
+  },
+  {
+    code: "RLR",
+    name: "Repair Leather Replacement",
+    categoryKey: "repair",
+    price: 120_000,
+    cogs: 35_000,
+  },
+  {
+    code: "RZP",
+    name: "Repair Zipper Replacement",
+    categoryKey: "repair",
+    price: 90_000,
+    cogs: 25_000,
+  },
+  {
+    code: "RSS",
+    name: "Repair Slide Swap",
+    categoryKey: "repair",
+    price: 500_000,
+    cogs: 175_000,
+  },
+  {
+    code: "RSO",
+    name: "Repair Sole Swap",
+    categoryKey: "repair",
+    price: 200_000,
+    cogs: 70_000,
+  },
+  {
+    code: "RSY",
+    name: "Repair Sole Swap Yeezy",
+    categoryKey: "repair",
+    price: 700_000,
+    cogs: 280_000,
+  },
+  {
+    code: "RSB",
+    name: "Repair Sole Swap Balenciaga",
+    categoryKey: "repair",
+    price: 1_100_000,
+    cogs: 440_000,
+  },
+  {
+    code: "RSL",
+    name: "Repair Sole Swap Louboutin",
+    categoryKey: "repair",
+    price: 1_110_000,
+    cogs: 440_000,
+  },
+  {
+    code: "RSN",
+    name: "Repair Sole Swap Yonex SHB",
+    categoryKey: "repair",
+    price: 325_000,
+    cogs: 110_000,
+  },
+  {
+    code: "RHT",
+    name: "Repair Heels Tip",
+    categoryKey: "repair",
+    price: 100_000,
+    cogs: 28_000,
+  },
+  {
+    code: "RLW",
+    name: "Repair Luggage Wheels",
+    categoryKey: "repair",
+    price: 150_000,
+    cogs: 50_000,
+  },
+  {
+    code: "ROT",
+    name: "Repair Others",
+    categoryKey: "repair",
+    price: 250_000,
+    cogs: 80_000,
+  },
+
+  // Add-Ons
+  {
+    code: "AWT",
+    name: "Add-On Whitening (Canvas)",
+    categoryKey: "addons",
+    price: 90_000,
+    cogs: 14_000,
+  },
+  {
+    code: "AHS",
+    name: "Add-On Hard Stain (Mesh, Knit)",
+    categoryKey: "addons",
+    price: 40_000,
+    cogs: 7000,
+  },
+  {
+    code: "AUY",
+    name: "Add-On Unyellow (Hard Rubber)",
+    categoryKey: "addons",
+    price: 50_000,
+    cogs: 9000,
+  },
+  {
+    code: "AUW",
+    name: "Add-On Unwrinkle (Remove Creasing)",
+    categoryKey: "addons",
+    price: 50_000,
+    cogs: 9000,
+  },
+  {
+    code: "AHR",
+    name: "Add-On Hat Reshape",
+    categoryKey: "addons",
+    price: 60_000,
+    cogs: 10_000,
+  },
+  {
+    code: "AWP",
+    name: "Add-On Waterproof",
+    categoryKey: "addons",
+    price: 50_000,
+    cogs: 12_000,
+  },
+
+  // Express
+  {
+    code: "EXP",
+    name: "Express Skip the Line",
+    categoryKey: "express",
+    price: 30_000,
+    cogs: 5000,
+  },
 ] as const;
 
 const PAYMENT_METHODS = [
@@ -156,7 +457,7 @@ interface StoreRow {
 interface CampaignRow {
   id: number;
   code: string;
-  discount_type: "fixed" | "percentage";
+  discount_type: "fixed" | "percentage" | "buy_n_get_m_free";
   discount_value: number;
   min_order_total: number;
   max_discount: number | null;
@@ -694,8 +995,8 @@ async function seedCatalog(adminId: number) {
         code: service.code,
         name: service.name,
         description: faker.lorem.sentence(),
-        cogs: asMoney(randInt(14_000, 65_000)),
-        price: asMoney(randInt(40_000, 180_000)),
+        cogs: asMoney(service.cogs),
+        price: asMoney(service.price),
         is_active: true,
       }))
     )

--- a/packages/server/src/modules/campaigns/campaign.repository.ts
+++ b/packages/server/src/modules/campaigns/campaign.repository.ts
@@ -1,10 +1,30 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { campaignStoresTable, campaignsTable } from "@/db/schema";
+import {
+  campaignEligibleServicesTable,
+  campaignStoresTable,
+  campaignsTable,
+} from "@/db/schema";
 
 interface CampaignFilters {
   is_active?: boolean;
   store_id?: number;
+}
+
+type CampaignDiscountType = "fixed" | "percentage" | "buy_n_get_m_free";
+
+interface CampaignWritePayload {
+  code: string;
+  name: string;
+  discount_type: CampaignDiscountType;
+  discount_value: string;
+  max_discount?: string | null;
+  min_order_total: string;
+  starts_at?: Date | null;
+  ends_at?: Date | null;
+  is_active: boolean;
+  buy_quantity?: number | null;
+  free_quantity?: number | null;
 }
 
 export function listCampaigns(filters: CampaignFilters) {
@@ -34,6 +54,18 @@ export function listCampaigns(filters: CampaignFilters) {
           },
         },
       },
+      eligibleServices: {
+        columns: { service_id: true },
+        with: {
+          service: {
+            columns: {
+              id: true,
+              code: true,
+              name: true,
+            },
+          },
+        },
+      },
     },
   });
 }
@@ -54,6 +86,18 @@ export function findCampaignById(id: number) {
           },
         },
       },
+      eligibleServices: {
+        columns: { id: true, service_id: true },
+        with: {
+          service: {
+            columns: {
+              id: true,
+              code: true,
+              name: true,
+            },
+          },
+        },
+      },
     },
   });
 }
@@ -65,24 +109,23 @@ export function findStoresByIds(storeIds: number[]) {
   });
 }
 
+export function findServicesByIds(serviceIds: number[]) {
+  return db.query.servicesTable.findMany({
+    where: { id: { in: serviceIds } },
+    columns: { id: true },
+  });
+}
+
 export function insertCampaignWithStores({
   payload,
   actorId,
   storeIds,
+  serviceIds,
 }: {
-  payload: {
-    code: string;
-    name: string;
-    discount_type: "fixed" | "percentage";
-    discount_value: string;
-    max_discount?: string | null;
-    min_order_total: string;
-    starts_at?: Date | null;
-    ends_at?: Date | null;
-    is_active: boolean;
-  };
+  payload: CampaignWritePayload;
   actorId: number;
   storeIds: number[];
+  serviceIds: number[];
 }) {
   return db.transaction(async (tx) => {
     const [campaign] = await tx
@@ -103,6 +146,15 @@ export function insertCampaignWithStores({
       );
     }
 
+    if (serviceIds.length > 0) {
+      await tx.insert(campaignEligibleServicesTable).values(
+        serviceIds.map((serviceId) => ({
+          campaign_id: campaign.id,
+          service_id: serviceId,
+        }))
+      );
+    }
+
     return campaign;
   });
 }
@@ -112,21 +164,13 @@ export function updateCampaignWithStores({
   payload,
   actorId,
   storeIds,
+  serviceIds,
 }: {
   id: number;
-  payload: Partial<{
-    code: string;
-    name: string;
-    discount_type: "fixed" | "percentage";
-    discount_value: string;
-    max_discount?: string | null;
-    min_order_total: string;
-    starts_at?: Date | null;
-    ends_at?: Date | null;
-    is_active: boolean;
-  }>;
+  payload: Partial<CampaignWritePayload>;
   actorId: number;
   storeIds?: number[];
+  serviceIds?: number[];
 }) {
   return db.transaction(async (tx) => {
     const rows = await tx
@@ -153,6 +197,21 @@ export function updateCampaignWithStores({
       }
     }
 
+    if (serviceIds) {
+      await tx
+        .delete(campaignEligibleServicesTable)
+        .where(eq(campaignEligibleServicesTable.campaign_id, id));
+
+      if (serviceIds.length > 0) {
+        await tx.insert(campaignEligibleServicesTable).values(
+          serviceIds.map((serviceId) => ({
+            campaign_id: id,
+            service_id: serviceId,
+          }))
+        );
+      }
+    }
+
     return rows[0] ?? null;
   });
 }
@@ -163,4 +222,23 @@ export function deleteCampaignById(id: number) {
     .where(eq(campaignsTable.id, id))
     .returning({ id: campaignsTable.id })
     .then((rows) => rows[0] ?? null);
+}
+
+export function findCampaignsByIdsWithEligibility(ids: number[]) {
+  if (ids.length === 0) {
+    return Promise.resolve(
+      [] as Awaited<ReturnType<typeof queryCampaignsWithEligibility>>
+    );
+  }
+  return queryCampaignsWithEligibility(ids);
+}
+
+function queryCampaignsWithEligibility(ids: number[]) {
+  return db.query.campaignsTable.findMany({
+    where: { id: { in: ids } },
+    with: {
+      stores: { columns: { store_id: true } },
+      eligibleServices: { columns: { service_id: true } },
+    },
+  });
 }

--- a/packages/server/src/modules/campaigns/campaign.schema.ts
+++ b/packages/server/src/modules/campaigns/campaign.schema.ts
@@ -1,22 +1,74 @@
 import { z } from "zod";
-import { campaignDiscountTypeEnum } from "@/db/schema";
 
 const campaignStoreIdsSchema = z
   .array(z.coerce.number().int().positive())
   .default([]);
 
-export const CampaignPayloadSchema = z.object({
+const campaignServiceIdsSchema = z.array(z.coerce.number().int().positive());
+
+const baseCampaignSchema = z.object({
   code: z.string().trim().min(1).max(32),
-  discount_type: z.enum(campaignDiscountTypeEnum.enumValues),
-  discount_value: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(255),
   ends_at: z.coerce.date().nullish(),
   is_active: z.coerce.boolean().default(true),
-  max_discount: z.string().trim().min(1).nullish(),
   min_order_total: z.string().trim().min(1).default("0"),
-  name: z.string().trim().min(1).max(255),
   starts_at: z.coerce.date().nullish(),
   store_ids: campaignStoreIdsSchema,
 });
+
+const fixedCampaignSchema = baseCampaignSchema.extend({
+  discount_type: z.literal("fixed"),
+  discount_value: z.string().trim().min(1),
+  max_discount: z.string().trim().min(1).nullish(),
+  eligible_service_ids: campaignServiceIdsSchema.default([]),
+});
+
+const percentageCampaignSchema = baseCampaignSchema.extend({
+  discount_type: z.literal("percentage"),
+  discount_value: z.string().trim().min(1),
+  max_discount: z.string().trim().min(1).nullish(),
+  eligible_service_ids: campaignServiceIdsSchema.default([]),
+});
+
+const bogoCampaignSchema = baseCampaignSchema.extend({
+  discount_type: z.literal("buy_n_get_m_free"),
+  discount_value: z.string().trim().default("0"),
+  max_discount: z.string().trim().nullish().default(null),
+  buy_quantity: z.coerce.number().int().min(1),
+  free_quantity: z.coerce.number().int().min(1),
+  eligible_service_ids: campaignServiceIdsSchema.min(
+    1,
+    "Eligible services required for buy N get M free"
+  ),
+});
+
+export const CampaignPayloadSchema = z.discriminatedUnion("discount_type", [
+  fixedCampaignSchema,
+  percentageCampaignSchema,
+  bogoCampaignSchema,
+]);
+
+export const CampaignUpdatePayloadSchema = z
+  .object({
+    code: z.string().trim().min(1).max(32).optional(),
+    name: z.string().trim().min(1).max(255).optional(),
+    discount_type: z
+      .enum(["fixed", "percentage", "buy_n_get_m_free"])
+      .optional(),
+    discount_value: z.string().trim().optional(),
+    max_discount: z.string().trim().nullable().optional(),
+    min_order_total: z.string().trim().min(1).optional(),
+    starts_at: z.coerce.date().nullable().optional(),
+    ends_at: z.coerce.date().nullable().optional(),
+    is_active: z.coerce.boolean().optional(),
+    store_ids: z.array(z.coerce.number().int().positive()).optional(),
+    eligible_service_ids: z
+      .array(z.coerce.number().int().positive())
+      .optional(),
+    buy_quantity: z.coerce.number().int().min(1).nullable().optional(),
+    free_quantity: z.coerce.number().int().min(1).nullable().optional(),
+  })
+  .strict();
 
 export const GETCampaignsQuerySchema = z
   .object({
@@ -26,4 +78,5 @@ export const GETCampaignsQuerySchema = z
   .optional();
 
 export type CampaignPayload = z.infer<typeof CampaignPayloadSchema>;
+export type CampaignUpdatePayload = z.infer<typeof CampaignUpdatePayloadSchema>;
 export type GetCampaignsQuery = z.infer<typeof GETCampaignsQuerySchema>;

--- a/packages/server/src/modules/campaigns/campaign.service.ts
+++ b/packages/server/src/modules/campaigns/campaign.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException } from "@/errors";
 import {
   deleteCampaignById,
   findCampaignById,
+  findServicesByIds,
   findStoresByIds,
   insertCampaignWithStores,
   listCampaigns,
@@ -9,6 +10,7 @@ import {
 } from "@/modules/campaigns/campaign.repository";
 import type {
   CampaignPayload,
+  CampaignUpdatePayload,
   GetCampaignsQuery,
 } from "@/modules/campaigns/campaign.schema";
 import type { JWTPayload } from "@/types";
@@ -28,6 +30,20 @@ async function ensureStoresExist(storeIds: number[]) {
 
   if (stores.length !== storeIds.length) {
     throw new BadRequestException("One or more store_ids are invalid");
+  }
+}
+
+async function ensureServicesExist(serviceIds: number[]) {
+  if (serviceIds.length === 0) {
+    return;
+  }
+
+  const services = await findServicesByIds(serviceIds);
+
+  if (services.length !== serviceIds.length) {
+    throw new BadRequestException(
+      "One or more eligible_service_ids are invalid"
+    );
   }
 }
 
@@ -59,6 +75,93 @@ export async function getCampaignById(id: number) {
   return markExpired(campaign, new Date());
 }
 
+function buildCreatePayload(payload: CampaignPayload) {
+  if (payload.discount_type === "buy_n_get_m_free") {
+    return {
+      code: payload.code,
+      name: payload.name,
+      discount_type: payload.discount_type,
+      discount_value: "0",
+      max_discount: null,
+      buy_quantity: payload.buy_quantity,
+      free_quantity: payload.free_quantity,
+      min_order_total: payload.min_order_total,
+      starts_at: payload.starts_at ?? null,
+      ends_at: payload.ends_at ?? null,
+      is_active: payload.is_active,
+    };
+  }
+
+  return {
+    code: payload.code,
+    name: payload.name,
+    discount_type: payload.discount_type,
+    discount_value: payload.discount_value,
+    max_discount: payload.max_discount ?? null,
+    buy_quantity: null,
+    free_quantity: null,
+    min_order_total: payload.min_order_total,
+    starts_at: payload.starts_at ?? null,
+    ends_at: payload.ends_at ?? null,
+    is_active: payload.is_active,
+  };
+}
+
+interface UpdateWritePayload {
+  code?: string;
+  name?: string;
+  discount_type?: "fixed" | "percentage" | "buy_n_get_m_free";
+  discount_value?: string;
+  max_discount?: string | null;
+  min_order_total?: string;
+  starts_at?: Date | null;
+  ends_at?: Date | null;
+  is_active?: boolean;
+  buy_quantity?: number | null;
+  free_quantity?: number | null;
+}
+
+const UPDATE_FIELDS = [
+  "code",
+  "name",
+  "discount_type",
+  "discount_value",
+  "max_discount",
+  "min_order_total",
+  "starts_at",
+  "ends_at",
+  "is_active",
+  "buy_quantity",
+  "free_quantity",
+] as const satisfies ReadonlyArray<keyof UpdateWritePayload>;
+
+function buildUpdatePayload(
+  payload: CampaignUpdatePayload
+): UpdateWritePayload {
+  const out: UpdateWritePayload = {};
+  for (const key of UPDATE_FIELDS) {
+    const value = payload[key];
+    if (value !== undefined) {
+      (out[key] as unknown) = value;
+    }
+  }
+
+  if (payload.discount_type === "buy_n_get_m_free") {
+    out.discount_value = "0";
+    if (out.max_discount === undefined) {
+      out.max_discount = null;
+    }
+  } else if (
+    payload.discount_type === "fixed" ||
+    payload.discount_type === "percentage"
+  ) {
+    out.buy_quantity = null;
+    out.free_quantity = null;
+  }
+
+  return out;
+}
+
 export async function createCampaign({
   user,
   payload,
@@ -69,22 +172,18 @@ export async function createCampaign({
   assertIsAdmin(user);
 
   const storeIds = [...new Set(payload.store_ids)];
-  await ensureStoresExist(storeIds);
+  const serviceIds = [...new Set(payload.eligible_service_ids)];
+
+  await Promise.all([
+    ensureStoresExist(storeIds),
+    ensureServicesExist(serviceIds),
+  ]);
 
   return insertCampaignWithStores({
-    payload: {
-      code: payload.code,
-      name: payload.name,
-      discount_type: payload.discount_type,
-      discount_value: payload.discount_value,
-      max_discount: payload.max_discount ?? null,
-      min_order_total: payload.min_order_total,
-      starts_at: payload.starts_at ?? null,
-      ends_at: payload.ends_at ?? null,
-      is_active: payload.is_active,
-    },
+    payload: buildCreatePayload(payload),
     actorId: user.id,
     storeIds,
+    serviceIds,
   });
 }
 
@@ -95,32 +194,28 @@ export async function updateCampaign({
 }: {
   user: JWTPayload;
   id: number;
-  payload: Partial<CampaignPayload>;
+  payload: CampaignUpdatePayload;
 }) {
   assertIsAdmin(user);
 
   const storeIds = payload.store_ids
     ? [...new Set(payload.store_ids)]
     : undefined;
-  if (storeIds) {
-    await ensureStoresExist(storeIds);
-  }
+  const serviceIds = payload.eligible_service_ids
+    ? [...new Set(payload.eligible_service_ids)]
+    : undefined;
+
+  await Promise.all([
+    storeIds ? ensureStoresExist(storeIds) : Promise.resolve(),
+    serviceIds ? ensureServicesExist(serviceIds) : Promise.resolve(),
+  ]);
 
   return updateCampaignWithStores({
     id,
-    payload: {
-      code: payload.code,
-      name: payload.name,
-      discount_type: payload.discount_type,
-      discount_value: payload.discount_value,
-      max_discount: payload.max_discount,
-      min_order_total: payload.min_order_total,
-      starts_at: payload.starts_at,
-      ends_at: payload.ends_at,
-      is_active: payload.is_active,
-    },
+    payload: buildUpdatePayload(payload),
     actorId: user.id,
     storeIds,
+    serviceIds,
   });
 }
 

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -50,9 +50,11 @@ interface ExpandedServiceItem {
 interface ResolvedCampaignRow {
   applied_amount: string;
   campaign_id: number;
-  discount_type: "fixed" | "percentage";
+  discount_type: "fixed" | "percentage" | "buy_n_get_m_free";
   discount_value: string;
   max_discount: string | null;
+  buy_quantity: number | null;
+  free_quantity: number | null;
 }
 
 interface ResolvedDiscount {
@@ -132,6 +134,7 @@ async function loadAndValidateCampaigns({
     where: { id: { in: campaignIds } },
     with: {
       stores: { columns: { store_id: true } },
+      eligibleServices: { columns: { service_id: true } },
     },
   });
 
@@ -196,6 +199,7 @@ async function resolveDiscount({
   manualDiscount,
   storeId,
   storeCode,
+  lines,
 }: {
   tx: OrderTx;
   campaignIds: number[];
@@ -203,6 +207,7 @@ async function resolveDiscount({
   manualDiscount: number;
   storeId: number;
   storeCode: string;
+  lines: { price: number; service_id: number }[];
 }): Promise<ResolvedDiscount> {
   const manual = Math.max(0, manualDiscount);
 
@@ -222,9 +227,17 @@ async function resolveDiscount({
     storeCode,
   });
 
+  const stackInput = campaigns.map((campaign) => ({
+    ...campaign,
+    eligible_service_ids: campaign.eligibleServices.map(
+      (entry) => entry.service_id
+    ),
+  }));
+
   const { total: campaignDiscount, breakdown } = stackCampaignDiscounts(
     grossTotal,
-    campaigns
+    stackInput,
+    lines
   );
 
   const campaignRows: ResolvedCampaignRow[] = breakdown.map(
@@ -234,6 +247,8 @@ async function resolveDiscount({
       discount_type: campaign.discount_type,
       discount_value: campaign.discount_value,
       max_discount: campaign.max_discount,
+      buy_quantity: campaign.buy_quantity,
+      free_quantity: campaign.free_quantity,
     })
   );
 
@@ -397,6 +412,14 @@ export async function createOrder(
     ]);
 
     const grossTotal = serviceSubtotal + productSubtotal;
+    const lines = expandedServices.map((item) => {
+      const service = serviceMap.get(item.id);
+      return {
+        price: Number(service?.price ?? 0),
+        service_id: item.id,
+      };
+    });
+
     const { discountAmount, discountSource, campaignRows } =
       await resolveDiscount({
         tx,
@@ -405,6 +428,7 @@ export async function createOrder(
         manualDiscount: Number(orderPayload.discount),
         storeId: store.id,
         storeCode: store.code,
+        lines,
       });
 
     if (discountAmount > grossTotal) {
@@ -420,6 +444,8 @@ export async function createOrder(
           discount_value: row.discount_value,
           max_discount: row.max_discount,
           applied_amount: row.applied_amount,
+          buy_quantity: row.buy_quantity,
+          free_quantity: row.free_quantity,
         }))
       );
     }

--- a/packages/server/src/modules/reports/report-range.repository.ts
+++ b/packages/server/src/modules/reports/report-range.repository.ts
@@ -170,6 +170,38 @@ export async function listProductsCogsSeries({
   }));
 }
 
+// ───────────────────────── Discount (Financial) ─────────────────────────
+
+export async function listOrderDiscountSeries({
+  range,
+  storeId,
+  granularity,
+}: BaseRangeArgs) {
+  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
+  const conditions = [
+    gte(ordersTable.paid_at, range.start),
+    lt(ordersTable.paid_at, range.end),
+    isNotNull(ordersTable.paid_at),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const rows = await db
+    .select({
+      bucket,
+      discount: sql<string>`COALESCE(SUM(${ordersTable.discount}), 0)`,
+    })
+    .from(ordersTable)
+    .where(and(...conditions))
+    .groupBy(bucket);
+
+  return rows.map((row) => ({
+    bucket: row.bucket,
+    discount: Number(row.discount),
+  }));
+}
+
 // ───────────────────────── Store revenue (branch donut) ─────────────────────────
 
 export async function listStoreRevenueRows({ range }: { range: DateRange }) {

--- a/packages/server/src/modules/reports/report-range.service.ts
+++ b/packages/server/src/modules/reports/report-range.service.ts
@@ -10,6 +10,7 @@ import {
   listCampaignEffectivenessRows,
   listCategoryRevenueSeries,
   listNewCustomersSeries,
+  listOrderDiscountSeries,
   listOrdersInSeries,
   listOrdersOutSeries,
   listPaymentMixSeries,
@@ -100,6 +101,8 @@ interface FinancialSummary {
   gross_revenue: number;
   services_total: number;
   products_total: number;
+  discount: number;
+  net_revenue: number;
   cogs: number;
   gross_profit: number;
   refunds: number;
@@ -116,12 +119,13 @@ async function financialSummaryFor({
   storeId?: number;
   granularity: Granularity;
 }) {
-  const [services, products, servicesCogs, productsCogs, refunds] =
+  const [services, products, servicesCogs, productsCogs, discount, refunds] =
     await Promise.all([
       listServicesRevenueSeries({ range, storeId, granularity }),
       listProductsRevenueSeries({ range, storeId, granularity }),
       listServicesCogsSeries({ range, storeId, granularity }),
       listProductsCogsSeries({ range, storeId, granularity }),
+      listOrderDiscountSeries({ range, storeId, granularity }),
       listRefundAmountSeries({ range, storeId, granularity }),
     ]);
   return {
@@ -129,6 +133,7 @@ async function financialSummaryFor({
     products,
     servicesCogs,
     productsCogs,
+    discount,
     refunds,
   };
 }
@@ -153,6 +158,7 @@ export async function getFinancialReport(query: GetReportRangeQuery) {
   const productsMap = indexBy(current.products);
   const servicesCogsMap = indexBy(current.servicesCogs);
   const productsCogsMap = indexBy(current.productsCogs);
+  const discountMap = indexBy(current.discount);
   const refundsMap = indexBy(current.refunds);
 
   const series = ctx.buckets.map((bucket) => {
@@ -160,18 +166,22 @@ export async function getFinancialReport(query: GetReportRangeQuery) {
     const p = productsMap.get(bucket)?.revenue ?? 0;
     const sc = servicesCogsMap.get(bucket)?.cogs ?? 0;
     const pc = productsCogsMap.get(bucket)?.cogs ?? 0;
+    const d = discountMap.get(bucket)?.discount ?? 0;
     const r = refundsMap.get(bucket)?.amount ?? 0;
     const gross = s + p;
     const cogs = sc + pc;
+    const netRevenue = gross - d;
     return {
       bucket,
       services: s,
       products: p,
       gross_revenue: gross,
+      discount: d,
+      net_revenue: netRevenue,
       cogs,
-      gross_profit: gross - cogs,
+      gross_profit: netRevenue - cogs,
       refunds: r,
-      net_income: gross - cogs - r,
+      net_income: netRevenue - cogs - r,
     };
   });
 
@@ -262,6 +272,7 @@ function summariseFinancial(raw: {
   products: { revenue: number }[];
   servicesCogs: { cogs: number }[];
   productsCogs: { cogs: number }[];
+  discount: { discount: number }[];
   refunds: { amount: number }[];
 }): FinancialSummary {
   const servicesTotal = raw.services.reduce((s, r) => s + r.revenue, 0);
@@ -269,15 +280,19 @@ function summariseFinancial(raw: {
   const cogs =
     raw.servicesCogs.reduce((s, r) => s + r.cogs, 0) +
     raw.productsCogs.reduce((s, r) => s + r.cogs, 0);
+  const discount = raw.discount.reduce((s, r) => s + r.discount, 0);
   const refunds = raw.refunds.reduce((s, r) => s + r.amount, 0);
   const gross = servicesTotal + productsTotal;
-  const grossProfit = gross - cogs;
-  const netIncome = gross - cogs - refunds;
-  const netMargin = gross > 0 ? netIncome / gross : 0;
+  const netRevenue = gross - discount;
+  const grossProfit = netRevenue - cogs;
+  const netIncome = netRevenue - cogs - refunds;
+  const netMargin = netRevenue > 0 ? netIncome / netRevenue : 0;
   return {
     gross_revenue: gross,
     services_total: servicesTotal,
     products_total: productsTotal,
+    discount,
+    net_revenue: netRevenue,
     cogs,
     gross_profit: grossProfit,
     refunds,

--- a/packages/server/src/routes/admin/campaigns.ts
+++ b/packages/server/src/routes/admin/campaigns.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import {
   CampaignPayloadSchema,
+  CampaignUpdatePayloadSchema,
   GETCampaignsQuerySchema,
 } from "@/modules/campaigns/campaign.schema";
 import {
@@ -52,7 +53,7 @@ const app = new Hono()
   .put(
     "/:id",
     idParamSchema,
-    zodValidator("json", CampaignPayloadSchema.partial()),
+    zodValidator("json", CampaignUpdatePayloadSchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
       const { id } = c.req.valid("param");

--- a/packages/server/src/schema/discount.ts
+++ b/packages/server/src/schema/discount.ts
@@ -1,8 +1,16 @@
 export interface CampaignDiscountInput {
-  discount_type: "fixed" | "percentage";
+  discount_type: "fixed" | "percentage" | "buy_n_get_m_free";
   discount_value: string;
   max_discount: string | null;
   min_order_total?: string | null;
+  buy_quantity?: number | null;
+  free_quantity?: number | null;
+  eligible_service_ids?: number[];
+}
+
+export interface DiscountLine {
+  price: number;
+  service_id: number;
 }
 
 export interface CampaignContribution<T extends CampaignDiscountInput> {
@@ -15,10 +23,44 @@ export interface StackedDiscount<T extends CampaignDiscountInput> {
   breakdown: CampaignContribution<T>[];
 }
 
+function computeBogoContribution(
+  campaign: CampaignDiscountInput,
+  lines: DiscountLine[]
+): number {
+  const buy = campaign.buy_quantity ?? 0;
+  const free = campaign.free_quantity ?? 0;
+  if (buy < 1 || free < 1) {
+    return 0;
+  }
+
+  const eligibleIds = new Set(campaign.eligible_service_ids ?? []);
+  if (eligibleIds.size === 0) {
+    return 0;
+  }
+
+  const eligiblePrices = lines
+    .filter((line) => eligibleIds.has(line.service_id))
+    .map((line) => line.price)
+    .sort((a, b) => a - b);
+
+  const groupSize = buy + free;
+  const freeCount = Math.floor(eligiblePrices.length / groupSize) * free;
+  if (freeCount === 0) {
+    return 0;
+  }
+
+  let total = 0;
+  for (let i = 0; i < freeCount; i++) {
+    total += eligiblePrices[i] ?? 0;
+  }
+  return total;
+}
+
 export function computeCampaignContribution(
   campaign: CampaignDiscountInput,
   grossTotal: number,
-  remaining: number
+  remaining: number,
+  lines: DiscountLine[] = []
 ): number {
   if (remaining <= 0) {
     return 0;
@@ -29,10 +71,14 @@ export function computeCampaignContribution(
     return 0;
   }
 
-  let contribution =
-    campaign.discount_type === "percentage"
-      ? (remaining * Number(campaign.discount_value)) / 100
-      : Number(campaign.discount_value);
+  let contribution: number;
+  if (campaign.discount_type === "buy_n_get_m_free") {
+    contribution = computeBogoContribution(campaign, lines);
+  } else if (campaign.discount_type === "percentage") {
+    contribution = (remaining * Number(campaign.discount_value)) / 100;
+  } else {
+    contribution = Number(campaign.discount_value);
+  }
 
   const maxDiscount =
     campaign.max_discount !== null && campaign.max_discount !== undefined
@@ -47,22 +93,30 @@ export function computeCampaignContribution(
 
 export function stackCampaignDiscounts<T extends CampaignDiscountInput>(
   grossTotal: number,
-  campaigns: T[]
+  campaigns: T[],
+  lines: DiscountLine[] = []
 ): StackedDiscount<T> {
-  const ordered = [...campaigns].sort(
-    (a, b) =>
-      computeCampaignContribution(b, grossTotal, grossTotal) -
-      computeCampaignContribution(a, grossTotal, grossTotal)
-  );
+  const ordered = campaigns
+    .map((campaign) => ({
+      campaign,
+      priority: computeCampaignContribution(
+        campaign,
+        grossTotal,
+        grossTotal,
+        lines
+      ),
+    }))
+    .sort((a, b) => b.priority - a.priority);
 
   let running = 0;
   const breakdown: CampaignContribution<T>[] = [];
 
-  for (const campaign of ordered) {
+  for (const { campaign } of ordered) {
     const amount = computeCampaignContribution(
       campaign,
       grossTotal,
-      grossTotal - running
+      grossTotal - running,
+      lines
     );
     running += amount;
     breakdown.push({ campaign, amount });

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -3,7 +3,7 @@ import parsePhoneNumberFromString, {
 } from "libphonenumber-js";
 import z from "zod";
 import { orderPaymentStatusEnum } from "@/db/schema";
-
+import { CampaignPayloadSchema as _CampaignPayloadSchema } from "@/modules/campaigns/campaign.schema";
 import {
   ORDER_STATUS_TRANSITIONS as _ORDER_STATUS_TRANSITIONS,
   POSTOrderPickupEventPresignSchema as _POSTOrderPickupEventPresignSchema,
@@ -14,11 +14,13 @@ export const ORDER_STATUS_TRANSITIONS = _ORDER_STATUS_TRANSITIONS;
 export const POSTOrderPickupEventPresignSchema =
   _POSTOrderPickupEventPresignSchema;
 export const POSTOrderPickupEventSchema = _POSTOrderPickupEventSchema;
+export const CampaignPayloadSchema = _CampaignPayloadSchema;
 
 import {
   type CampaignContribution as _CampaignContribution,
   type CampaignDiscountInput as _CampaignDiscountInput,
   computeCampaignContribution as _computeCampaignContribution,
+  type DiscountLine as _DiscountLine,
   type StackedDiscount as _StackedDiscount,
   stackCampaignDiscounts as _stackCampaignDiscounts,
 } from "@/schema/discount";
@@ -26,6 +28,7 @@ import {
 export type CampaignContribution<T extends _CampaignDiscountInput> =
   _CampaignContribution<T>;
 export type CampaignDiscountInput = _CampaignDiscountInput;
+export type DiscountLine = _DiscountLine;
 export type StackedDiscount<T extends _CampaignDiscountInput> =
   _StackedDiscount<T>;
 export const computeCampaignContribution = _computeCampaignContribution;


### PR DESCRIPTION
## Summary

- New \`buy_n_get_m_free\` campaign discount type with per-service eligibility
- Compute extended in \`@fresclean/api/schema\` (cheapest-N-free, line-aware) and stacks with fixed/percentage
- Admin form gets explicit fixed/percentage/BOGO field variants + services multi-select; POS renders per-type summary cards

## Test plan

- [ ] Admin → Campaigns → New: create BOGO (buy=4, free=1, eligible=[DCS, DCE]); save persists row + eligibility join
- [ ] POS: 4×DCS + 1×DCE + BOGO selected → discount = -60,000
- [ ] POS: 5×DCE + BOGO → discount = -90,000
- [ ] POS: 3×DCS + 1×DCE + BOGO → discount = 0 (under threshold)
- [ ] POS: 10×DCS + BOGO → discount = -120,000 (two groups)
- [ ] Stacking: BOGO + 10% campaign on same order, both rows in \`order_campaigns\`
- [ ] Negative: BOGO with empty \`eligible_service_ids\` → 400
- [ ] Negative: BOGO with \`buy_quantity=0\` → 400
- [ ] Edit existing BOGO campaign, archive toggles \`is_active\`
- [ ] Refund line from BOGO order — order-level discount unchanged