### PR TITLE
feat(reports): branch × category revenue matrix

### DIFF
--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -71,6 +71,7 @@ function ChartContainer({
 				<ChartStyle id={chartId} config={config} />
 				<RechartsPrimitive.ResponsiveContainer
 					initialDimension={initialDimension}
+					minWidth={0}
 				>
 					{children}
 				</RechartsPrimitive.ResponsiveContainer>

--- a/apps/web/src/features/reports/panels/financial-panel.tsx
+++ b/apps/web/src/features/reports/panels/financial-panel.tsx
@@ -1,19 +1,36 @@
+import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { ChartCard } from "@/features/reports/components/chart-card";
+import dayjs from "dayjs";
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Sankey,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+	type ChartConfig,
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "@/components/ui/chart";
 import { ExportButton } from "@/features/reports/components/export-button";
-import { KpiCard, KpiRow } from "@/features/reports/components/kpi-card";
 import {
 	csvFilename,
 	downloadCsv,
 	escapeCsv,
 } from "@/features/reports/utils/csv";
+import { percentFormatter } from "@/features/reports/utils/format";
 import {
-	numberFormatter,
-	percentFormatter,
-} from "@/features/reports/utils/format";
-import { CHART_PALETTE } from "@/features/reports/utils/palette";
-import type { FinancialReport, ReportGranularity } from "@/lib/api";
+	bucketToLabel,
+	bucketToTooltipLabel,
+} from "@/features/reports/utils/granularity";
+import type { FinancialReport, KpiDelta, ReportGranularity } from "@/lib/api";
 import { financialQueryOptions } from "@/lib/query-options";
+import { cn } from "@/lib/utils";
 import { formatIDRCurrency } from "@/shared/utils";
 
 interface FinancialPanelProps {
@@ -23,8 +40,87 @@ interface FinancialPanelProps {
 	granularity?: ReportGranularity;
 }
 
-const OTHER_COLOR = "var(--muted-foreground)";
-const CATEGORY_PALETTE = CHART_PALETTE.slice(0, 5);
+type SummaryCurrent = FinancialReport["summary"]["current"];
+type FinancialBucket = FinancialReport["series"][number];
+
+const TONE_BY_SIGN = {
+	"-1": {
+		tone: "text-destructive",
+		stripe: "bg-destructive",
+		Icon: ArrowDownIcon,
+	},
+	"0": {
+		tone: "text-muted-foreground",
+		stripe: "bg-muted-foreground/40",
+		Icon: MinusIcon,
+	},
+	"1": {
+		tone: "text-success",
+		stripe: "bg-success",
+		Icon: ArrowUpIcon,
+	},
+} as const;
+
+const NEUTRAL_TONE = {
+	tone: "text-muted-foreground",
+	stripe: "bg-muted-foreground/40",
+	Icon: MinusIcon,
+} as const;
+
+const toneForPct = (pct: number | null | undefined, invert = false) => {
+	if (pct === null || pct === undefined) {
+		return NEUTRAL_TONE;
+	}
+	const directional = invert ? -pct : pct;
+	return TONE_BY_SIGN[Math.sign(directional).toString() as "-1" | "0" | "1"];
+};
+
+const formatDeltaPct = (pct: number | null | undefined): string => {
+	if (pct === null || pct === undefined) {
+		return "—";
+	}
+	const sign = pct > 0 ? "+" : "";
+	return `${sign}${(pct * 100).toFixed(1)}%`;
+};
+
+const formatIDRShort = (v: number): string => {
+	const abs = Math.abs(v);
+	const sign = v < 0 ? "-" : "";
+	if (abs >= 1_000_000_000) {
+		return `${sign}Rp ${(abs / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (abs >= 1_000_000) {
+		return `${sign}Rp ${(abs / 1_000_000).toFixed(1)}M`;
+	}
+	if (abs >= 1_000) {
+		return `${sign}Rp ${(abs / 1_000).toFixed(0)}k`;
+	}
+	return `${sign}Rp ${abs.toFixed(0)}`;
+};
+
+const formatAxisShort = (v: number): string => {
+	const abs = Math.abs(v);
+	const sign = v < 0 ? "-" : "";
+	if (abs >= 1_000_000_000) {
+		return `${sign}${(abs / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (abs >= 1_000_000) {
+		return `${sign}${(abs / 1_000_000).toFixed(1)}M`;
+	}
+	if (abs >= 1_000) {
+		return `${sign}${(abs / 1_000).toFixed(0)}k`;
+	}
+	return `${sign}${abs.toFixed(0)}`;
+};
+
+const formatPreviousRangeLabel = (from: string, to: string): string => {
+	const f = dayjs(from);
+	const t = dayjs(to);
+	if (f.month() === t.month() && f.year() === t.year()) {
+		return `${f.format("MMM D")}-${t.format("D")}`;
+	}
+	return `${f.format("MMM D")}-${t.format("MMM D")}`;
+};
 
 export const FinancialPanel = ({
 	from,
@@ -37,18 +133,6 @@ export const FinancialPanel = ({
 	);
 	const data = query.data;
 	const summary = data?.summary.current;
-	const deltas = data?.summary.deltas;
-
-	const categoryKeys = data?.category_keys ?? [];
-	const categorySeries = categoryKeys.map((c, idx) => ({
-		key: c.key,
-		label: c.label,
-		color:
-			c.key === "cat_other"
-				? OTHER_COLOR
-				: CATEGORY_PALETTE[idx % CATEGORY_PALETTE.length],
-	}));
-
 	const storeBreakdown = data?.store_breakdown ?? [];
 	const storeMax = storeBreakdown.reduce((m, r) => Math.max(m, r.revenue), 0);
 
@@ -93,6 +177,21 @@ export const FinancialPanel = ({
 			);
 		}
 		lines.push("");
+		const matrix = data.store_category_matrix;
+		lines.push(
+			"Branch × Category,Store code,Store name,Category,Revenue,Share within branch,Branch total",
+		);
+		for (const row of matrix.rows) {
+			for (const cell of row.cells) {
+				const col = matrix.columns.find(
+					(c) => c.category_id === cell.category_id,
+				);
+				lines.push(
+					`Branch×Category,${escapeCsv(row.store_code)},${escapeCsv(row.store_name)},${escapeCsv(col?.label ?? "")},${cell.revenue},${cell.share},${row.total}`,
+				);
+			}
+		}
+		lines.push("");
 		lines.push("Branch revenue,Store code,Store name,Revenue,Orders,Share");
 		for (const row of storeBreakdown) {
 			lines.push(
@@ -107,111 +206,662 @@ export const FinancialPanel = ({
 
 	return (
 		<div className="grid gap-6">
-			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-				<KpiRow>
-					<KpiCard
-						label="Gross revenue"
-						value={formatIDRCurrency(String(summary?.gross_revenue ?? 0))}
-						delta={deltas?.gross_revenue}
-						helper="Services + products"
-					/>
-					<KpiCard
-						label="Discount"
-						value={formatIDRCurrency(String(summary?.discount ?? 0))}
-						delta={deltas?.discount}
-						helper="Campaign + manual"
-					/>
-					<KpiCard
-						label="Net revenue"
-						value={formatIDRCurrency(String(summary?.net_revenue ?? 0))}
-						delta={deltas?.net_revenue}
-						helper="Gross - discount"
-					/>
-					<KpiCard
-						label="COGS"
-						value={formatIDRCurrency(String(summary?.cogs ?? 0))}
-						delta={deltas?.cogs}
-						helper="Product + service cost"
-					/>
-					<KpiCard
-						label="Gross profit"
-						value={formatIDRCurrency(String(summary?.gross_profit ?? 0))}
-						delta={deltas?.gross_profit}
-						helper="Net revenue - COGS"
-					/>
-					<KpiCard
-						label="Refunds"
-						value={formatIDRCurrency(String(summary?.refunds ?? 0))}
-						delta={deltas?.refunds}
-					/>
-					<KpiCard
-						label="Net income"
-						value={formatIDRCurrency(String(summary?.net_income ?? 0))}
-						delta={deltas?.net_income}
-						helper="Net revenue - COGS - refunds"
-					/>
-					<KpiCard
-						label="Net margin"
-						value={percentFormatter.format(summary?.net_margin ?? 0)}
-						delta={deltas?.net_margin}
-						helper="Net income / net revenue"
-					/>
-					<KpiCard
-						label="Services"
-						value={formatIDRCurrency(String(summary?.services_total ?? 0))}
-						delta={deltas?.services_total}
-					/>
-					<KpiCard
-						label="Products"
-						value={formatIDRCurrency(String(summary?.products_total ?? 0))}
-						delta={deltas?.products_total}
-					/>
-				</KpiRow>
-				<ExportButton disabled={!data} onClick={handleExport} />
-			</div>
-
-			<ChartCard
-				variant="area"
-				title="Revenue · services vs products"
-				description="Stacked paid revenue over time."
-				data={data?.series ?? []}
-				granularity={data?.granularity ?? "day"}
-				stacked
-				series={[
-					{ key: "services", label: "Services", color: CHART_PALETTE[0] },
-					{ key: "products", label: "Products", color: CHART_PALETTE[1] },
-				]}
-				valueFormatter={(v) => formatIDRCurrency(String(v))}
+			<RevenueBreakdownCard
+				data={data}
+				exportDisabled={!data}
+				onExport={handleExport}
 			/>
-
-			<ChartCard
-				variant="stacked-bar"
-				title="Gross revenue composition"
-				description="Net income + COGS + refunds + discount = gross revenue per bucket."
-				data={data?.series ?? []}
-				granularity={data?.granularity ?? "day"}
-				series={[
-					{ key: "net_income", label: "Net income", color: CHART_PALETTE[1] },
-					{ key: "cogs", label: "COGS", color: CHART_PALETTE[2] },
-					{ key: "refunds", label: "Refunds", color: CHART_PALETTE[3] },
-					{ key: "discount", label: "Discount", color: CHART_PALETTE[4] },
-				]}
-				valueFormatter={(v) => formatIDRCurrency(String(v))}
-			/>
-
-			<ChartCard
-				variant="area"
-				title="Service revenue by category"
-				description="Top 5 categories stacked; remainder grouped as Other."
-				data={data?.category_series ?? []}
-				granularity={data?.granularity ?? "day"}
-				stacked
-				series={categorySeries}
-				valueFormatter={(v) => formatIDRCurrency(String(v))}
-			/>
-
+			<BranchCategoryMatrix data={data} />
 			<BranchList rows={storeBreakdown} max={storeMax} />
 		</div>
+	);
+};
+
+interface RevenueBreakdownCardProps {
+	data: FinancialReport | undefined;
+	exportDisabled: boolean;
+	onExport: () => void;
+}
+
+const RevenueBreakdownCard = ({
+	data,
+	exportDisabled,
+	onExport,
+}: RevenueBreakdownCardProps) => {
+	const summary = data?.summary.current;
+	const previous = data?.summary.previous;
+	const deltas = data?.summary.deltas;
+	const heroPct = deltas?.net_revenue?.delta_pct;
+	const heroTone = toneForPct(heroPct);
+	const HeroIcon = heroTone.Icon;
+	const previousLabel = data
+		? formatPreviousRangeLabel(data.previous.from, data.previous.to)
+		: "";
+
+	return (
+		<Card className="border-border/70">
+			<CardContent className="grid gap-6 p-5 sm:p-6">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+					<div className="grid min-w-0 gap-1.5">
+						<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+							Net revenue
+						</p>
+						<p className="break-all font-mono text-2xl font-semibold tabular-nums sm:text-3xl">
+							{formatIDRCurrency(String(summary?.net_revenue ?? 0))}
+						</p>
+						<p
+							className={cn(
+								"flex flex-wrap items-center gap-1.5 font-mono text-xs tabular-nums",
+								heroTone.tone,
+							)}
+						>
+							<HeroIcon className="size-3" weight="bold" />
+							<span className="font-medium">{formatDeltaPct(heroPct)}</span>
+							{previous ? (
+								<span className="text-muted-foreground">
+									{`vs ${formatIDRCurrency(String(previous.net_revenue))} (${previousLabel})`}
+								</span>
+							) : null}
+						</p>
+						<p className="text-[11px] text-muted-foreground">
+							Gross − discount
+						</p>
+					</div>
+					<ExportButton disabled={exportDisabled} onClick={onExport} />
+				</div>
+
+				<RevenueLineChart
+					series={data?.series ?? []}
+					granularity={data?.granularity ?? "day"}
+				/>
+
+				<StatStrip
+					sectionLabel="── REVENUE TRAJECTORY ──"
+					cells={[
+						{
+							label: "Gross",
+							value: summary?.gross_revenue ?? 0,
+							delta: deltas?.gross_revenue,
+						},
+						{
+							label: "Net revenue",
+							value: summary?.net_revenue ?? 0,
+							delta: deltas?.net_revenue,
+						},
+						{
+							label: "Net income",
+							value: summary?.net_income ?? 0,
+							delta: deltas?.net_income,
+						},
+					]}
+				/>
+
+				<SankeyFlow summary={summary} />
+
+				<StatStrip
+					sectionLabel="── DEDUCTIONS & MARGIN ──"
+					cells={[
+						{
+							label: "Discount",
+							value: summary?.discount ?? 0,
+							delta: deltas?.discount,
+							invertDelta: true,
+						},
+						{
+							label: "COGS",
+							value: summary?.cogs ?? 0,
+							delta: deltas?.cogs,
+							invertDelta: true,
+						},
+						{
+							label: "Refunds",
+							value: summary?.refunds ?? 0,
+							delta: deltas?.refunds,
+							invertDelta: true,
+						},
+						{
+							label: "Net margin",
+							value: summary?.net_margin ?? 0,
+							delta: deltas?.net_margin,
+							isPercent: true,
+						},
+					]}
+				/>
+			</CardContent>
+		</Card>
+	);
+};
+
+const GROSS_COLOR = "#94A3B8";
+const NET_REVENUE_COLOR = "#3B82F6";
+const NET_INCOME_COLOR = "#22C55E";
+
+const LINE_CHART_CONFIG: ChartConfig = {
+	gross_revenue: { label: "Gross", color: GROSS_COLOR },
+	net_revenue: { label: "Net revenue", color: NET_REVENUE_COLOR },
+	net_income: { label: "Net income", color: NET_INCOME_COLOR },
+};
+
+interface RevenueLineChartProps {
+	series: FinancialBucket[];
+	granularity: ReportGranularity;
+}
+
+const RevenueLineChart = ({ series, granularity }: RevenueLineChartProps) => {
+	const isEmpty =
+		series.length === 0 ||
+		series.every(
+			(row) =>
+				row.gross_revenue === 0 &&
+				row.net_revenue === 0 &&
+				row.net_income === 0,
+		);
+	if (isEmpty) {
+		return (
+			<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+				No revenue in range.
+			</div>
+		);
+	}
+	return (
+		<div className="grid gap-2">
+			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+				<span className="flex items-center gap-1.5">
+					<span
+						className="h-0.5 w-3"
+						style={{ backgroundColor: GROSS_COLOR, opacity: 0.6 }}
+					/>
+					Gross
+				</span>
+				<span className="flex items-center gap-1.5">
+					<span
+						className="h-0.5 w-3"
+						style={{ backgroundColor: NET_REVENUE_COLOR }}
+					/>
+					Net revenue
+				</span>
+				<span className="flex items-center gap-1.5">
+					<span
+						className="h-0.5 w-3"
+						style={{ backgroundColor: NET_INCOME_COLOR }}
+					/>
+					Net income
+				</span>
+			</div>
+			<ChartContainer
+				className="aspect-auto w-full"
+				config={LINE_CHART_CONFIG}
+				style={{ height: 240 }}
+			>
+				<LineChart data={series} margin={{ left: 4, right: 8, top: 8 }}>
+					<CartesianGrid vertical={false} strokeDasharray="3 3" />
+					<XAxis
+						axisLine={false}
+						dataKey="bucket"
+						minTickGap={24}
+						tickFormatter={(value: string) => bucketToLabel(value, granularity)}
+						tickLine={false}
+						tickMargin={8}
+					/>
+					<YAxis
+						axisLine={false}
+						tickFormatter={(v: number) => formatAxisShort(v)}
+						tickLine={false}
+						tickMargin={8}
+						width={56}
+					/>
+					<ChartTooltip
+						content={
+							<ChartTooltipContent
+								formatter={(value, name) => (
+									<div className="flex flex-1 items-center justify-between gap-3">
+										<span className="text-muted-foreground">
+											{LINE_CHART_CONFIG[name as string]?.label ?? name}
+										</span>
+										<span className="font-mono font-medium text-foreground tabular-nums">
+											{formatIDRCurrency(String(Number(value)))}
+										</span>
+									</div>
+								)}
+								labelFormatter={(value) =>
+									bucketToTooltipLabel(value as string, granularity)
+								}
+							/>
+						}
+						cursor={false}
+					/>
+					<Line
+						dataKey="gross_revenue"
+						dot={false}
+						stroke={GROSS_COLOR}
+						strokeOpacity={0.6}
+						strokeWidth={1.5}
+						type="monotone"
+					/>
+					<Line
+						dataKey="net_revenue"
+						dot={false}
+						stroke={NET_REVENUE_COLOR}
+						strokeWidth={1.75}
+						type="monotone"
+					/>
+					<Line
+						dataKey="net_income"
+						dot={false}
+						stroke={NET_INCOME_COLOR}
+						strokeWidth={2}
+						type="monotone"
+					/>
+				</LineChart>
+			</ChartContainer>
+		</div>
+	);
+};
+
+interface SankeyNodeDatum {
+	name: string;
+	opacity: number;
+	displayValue: number;
+}
+
+interface SankeyFlowProps {
+	summary: SummaryCurrent | undefined;
+}
+
+const SankeyFlow = ({ summary }: SankeyFlowProps) => {
+	const sectionLabel = (
+		<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+			── FLOW ──
+		</p>
+	);
+
+	if (!summary || summary.gross_revenue <= 0) {
+		return (
+			<div className="grid gap-2">
+				{sectionLabel}
+				<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+					No revenue to flow.
+				</div>
+			</div>
+		);
+	}
+
+	const netIncomePositive = Math.max(summary.net_income, 0);
+	const nodes: SankeyNodeDatum[] = [
+		{
+			name: "Gross revenue",
+			opacity: 0.45,
+			displayValue: summary.gross_revenue,
+		},
+		{ name: "Discount", opacity: 0.3, displayValue: summary.discount },
+		{ name: "Net revenue", opacity: 0.7, displayValue: summary.net_revenue },
+		{ name: "COGS", opacity: 0.3, displayValue: summary.cogs },
+		{ name: "Refunds", opacity: 0.3, displayValue: summary.refunds },
+		{ name: "Net income", opacity: 1, displayValue: netIncomePositive },
+	];
+
+	const linkCandidates = [
+		{ source: 0, target: 1, value: summary.discount },
+		{ source: 0, target: 2, value: summary.net_revenue },
+		{ source: 2, target: 3, value: summary.cogs },
+		{ source: 2, target: 4, value: summary.refunds },
+		{ source: 2, target: 5, value: netIncomePositive },
+	];
+	const links = linkCandidates.filter((l) => l.value > 0);
+
+	if (links.length === 0) {
+		return (
+			<div className="grid gap-2">
+				{sectionLabel}
+				<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+					No revenue to flow.
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid gap-2">
+			{sectionLabel}
+			<div className="w-full" style={{ height: 280 }}>
+				<ResponsiveContainer height="100%" width="100%">
+					<Sankey
+						data={{ nodes, links }}
+						link={{
+							fillOpacity: 1,
+							stroke: "var(--foreground)",
+						}}
+						margin={{ bottom: 8, left: 8, right: 110, top: 8 }}
+						node={(props) => <SankeyNode {...props} />}
+						nodePadding={28}
+						nodeWidth={6}
+					/>
+				</ResponsiveContainer>
+			</div>
+		</div>
+	);
+};
+
+interface SankeyNodeRenderProps {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	payload: unknown;
+}
+
+const SankeyNode = ({
+	x,
+	y,
+	width,
+	height,
+	payload,
+}: SankeyNodeRenderProps) => {
+	const datum = payload as SankeyNodeDatum;
+	const labelX = x + width + 6;
+	const labelY = y + height / 2;
+	return (
+		<g>
+			<rect
+				fill="var(--foreground)"
+				fillOpacity={datum.opacity}
+				height={height}
+				width={width}
+				x={x}
+				y={y}
+			/>
+			<text fontSize={10} x={labelX} y={labelY - 1}>
+				<tspan
+					fill="var(--muted-foreground)"
+					fontFamily="ui-monospace, SFMono-Regular, monospace"
+				>
+					{datum.name}
+				</tspan>
+			</text>
+			<text fontSize={10} fontWeight={600} x={labelX} y={labelY + 11}>
+				<tspan
+					fill="var(--foreground)"
+					fontFamily="ui-monospace, SFMono-Regular, monospace"
+				>
+					{formatIDRShort(datum.displayValue)}
+				</tspan>
+			</text>
+		</g>
+	);
+};
+
+interface StatCell {
+	label: string;
+	value: number;
+	delta?: Pick<KpiDelta, "delta_pct"> | null;
+	invertDelta?: boolean;
+	isPercent?: boolean;
+}
+
+interface StatStripProps {
+	sectionLabel: string;
+	cells: StatCell[];
+}
+
+const StatStrip = ({ sectionLabel, cells }: StatStripProps) => (
+	<div className="grid gap-3">
+		<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+			{sectionLabel}
+		</p>
+		<div
+			className={cn(
+				"grid grid-cols-2",
+				cells.length === 3 ? "lg:grid-cols-3" : "lg:grid-cols-4",
+			)}
+		>
+			{cells.map((cell, idx) => {
+				const pct = cell.delta?.delta_pct;
+				const tone = toneForPct(pct, cell.invertDelta);
+				const Icon = tone.Icon;
+				return (
+					<div
+						className={cn(
+							"grid gap-1 px-3 py-2 sm:px-4",
+							idx > 0 && "lg:border-l lg:border-border/40",
+						)}
+						key={cell.label}
+					>
+						<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+							{cell.label}
+						</p>
+						<p className="break-all font-mono text-sm font-semibold tabular-nums">
+							{cell.isPercent
+								? percentFormatter.format(cell.value)
+								: formatIDRCurrency(String(cell.value))}
+						</p>
+						<p
+							className={cn(
+								"flex items-center gap-1 font-mono text-[11px] tabular-nums",
+								tone.tone,
+							)}
+						>
+							{pct === null || pct === undefined ? null : (
+								<Icon className="size-2.5" weight="bold" />
+							)}
+							{formatDeltaPct(pct)}
+						</p>
+					</div>
+				);
+			})}
+		</div>
+	</div>
+);
+
+type StoreCategoryMatrix = FinancialReport["store_category_matrix"];
+type MatrixColumn = StoreCategoryMatrix["columns"][number];
+type MatrixRow = StoreCategoryMatrix["rows"][number];
+
+interface BranchCategoryMatrixProps {
+	data: FinancialReport | undefined;
+}
+
+const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
+	const matrix = data?.store_category_matrix;
+	const columns = matrix?.columns ?? [];
+	const rows = matrix?.rows ?? [];
+	const omittedStores = matrix?.omitted_stores ?? 0;
+
+	const grandTotal = rows.reduce((s, r) => s + r.total, 0);
+	const columnTotals = columns.map((col) =>
+		rows.reduce((s, r) => {
+			const cell = r.cells.find((c) => c.category_id === col.category_id);
+			return s + (cell?.revenue ?? 0);
+		}, 0),
+	);
+
+	const isEmpty = rows.length === 0 || grandTotal === 0;
+
+	return (
+		<Card className="border-border/70">
+			<CardContent className="grid gap-3 p-5 sm:p-6">
+				<div className="grid gap-1">
+					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+						Branch × Category
+					</p>
+					<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+						{`// share within branch · top ${columns.length} categor${columns.length === 1 ? "y" : "ies"}`}
+					</p>
+				</div>
+
+				{isEmpty ? (
+					<p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+						{"// no category revenue in range"}
+					</p>
+				) : (
+					<div className="overflow-x-auto">
+						<table className="w-full border-separate border-spacing-0 font-mono text-[11px] tabular-nums">
+							<thead>
+								<tr>
+									<th
+										className="sticky left-0 z-10 bg-card px-2 py-1.5 text-left text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										scope="col"
+									>
+										Branch
+									</th>
+									{columns.map((col) => (
+										<MatrixHeaderCell column={col} key={col.category_id} />
+									))}
+									<th
+										className="border-l border-border/40 px-2 py-1.5 text-right text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										scope="col"
+									>
+										Total
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{rows.map((row) => (
+									<MatrixBranchRow
+										columns={columns}
+										grandTotal={grandTotal}
+										key={row.store_id}
+										row={row}
+									/>
+								))}
+							</tbody>
+							<tfoot>
+								<tr>
+									<th
+										className="sticky left-0 z-10 border-t border-border/40 bg-card px-2 py-2 text-left text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										scope="row"
+									>
+										Total
+									</th>
+									{columns.map((col, idx) => (
+										<td
+											className="border-t border-border/40 px-2 py-2 text-center text-muted-foreground"
+											key={col.category_id}
+										>
+											{formatIDRShort(columnTotals[idx] ?? 0)}
+										</td>
+									))}
+									<td className="border-l border-t border-border/40 px-2 py-2 text-right font-semibold">
+										{formatIDRShort(grandTotal)}
+									</td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+				)}
+
+				{omittedStores > 0 ? (
+					<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+						{`(+${omittedStores} branch${omittedStores === 1 ? "" : "es"} not shown)`}
+					</p>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+};
+
+interface MatrixHeaderCellProps {
+	column: MatrixColumn;
+}
+
+const MatrixHeaderCell = ({ column }: MatrixHeaderCellProps) => (
+	<th
+		className="px-2 py-1.5 text-center text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+		scope="col"
+		title={column.label}
+	>
+		<span className="block max-w-[88px] truncate">{column.label}</span>
+	</th>
+);
+
+interface MatrixBranchRowProps {
+	row: MatrixRow;
+	columns: MatrixColumn[];
+	grandTotal: number;
+}
+
+const MatrixBranchRow = ({
+	row,
+	columns,
+	grandTotal,
+}: MatrixBranchRowProps) => (
+	<tr className="group">
+		<th
+			className="sticky left-0 z-10 border-t border-border/40 bg-card px-2 py-2 text-left align-top group-hover:bg-muted/40"
+			scope="row"
+		>
+			<span className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+				{row.store_code}
+			</span>
+			<span className="block max-w-[140px] truncate text-foreground">
+				{row.store_name}
+			</span>
+		</th>
+		{columns.map((col) => {
+			const cell = row.cells.find((c) => c.category_id === col.category_id);
+			return (
+				<MatrixCell
+					branchTotal={row.total}
+					cellRevenue={cell?.revenue ?? 0}
+					cellShare={cell?.share ?? 0}
+					columnLabel={col.label}
+					grandTotal={grandTotal}
+					key={col.category_id}
+					storeCode={row.store_code}
+					storeName={row.store_name}
+				/>
+			);
+		})}
+		<td className="border-l border-t border-border/40 px-2 py-2 text-right font-semibold group-hover:bg-muted/40">
+			{formatIDRShort(row.total)}
+		</td>
+	</tr>
+);
+
+interface MatrixCellProps {
+	cellShare: number;
+	cellRevenue: number;
+	branchTotal: number;
+	grandTotal: number;
+	columnLabel: string;
+	storeCode: string;
+	storeName: string;
+}
+
+const MatrixCell = ({
+	cellShare,
+	cellRevenue,
+	branchTotal,
+	grandTotal,
+	columnLabel,
+	storeCode,
+	storeName,
+}: MatrixCellProps) => {
+	const opacity = cellRevenue === 0 ? 0 : Math.max(0.05, cellShare ** 0.7);
+	const isInverted = opacity > 0.5;
+	const branchSharePct = branchTotal > 0 ? cellShare * 100 : 0;
+	const grandSharePct = grandTotal > 0 ? (cellRevenue / grandTotal) * 100 : 0;
+	const tooltip = `${storeCode} ${storeName} · ${columnLabel}\nRp ${cellRevenue.toLocaleString("id-ID")} · ${branchSharePct.toFixed(1)}% of branch · ${grandSharePct.toFixed(1)}% of total`;
+
+	return (
+		<td
+			className="relative border-t border-border/40 px-2 py-2 text-center align-middle"
+			title={tooltip}
+		>
+			<div
+				aria-hidden
+				className="absolute inset-0"
+				style={{ backgroundColor: "var(--foreground)", opacity }}
+			/>
+			<span
+				className={cn(
+					"relative",
+					isInverted ? "text-background" : "text-foreground",
+					cellRevenue === 0 && "text-muted-foreground",
+				)}
+			>
+				{cellRevenue === 0 ? "·" : `${Math.round(cellShare * 100)}%`}
+			</span>
+		</td>
 	);
 };
 
@@ -227,41 +877,43 @@ const BranchList = ({ rows, max }: BranchListProps) => {
 		return null;
 	}
 	return (
-		<div className="grid gap-3">
-			<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-				Branch leaderboard
-			</p>
-			<div className="grid gap-3">
-				{rows.map((row) => {
-					const pct = max === 0 ? 0 : (row.revenue / max) * 100;
-					return (
-						<div key={row.store_id} className="grid gap-1">
-							<div className="flex items-center justify-between gap-2">
-								<span className="flex items-center gap-2 truncate text-sm font-medium">
-									<span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-										{row.store_code}
+		<Card className="border-border/70">
+			<CardContent className="grid gap-4 p-5 sm:p-6">
+				<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+					Branch leaderboard
+				</p>
+				<div className="grid gap-3">
+					{rows.map((row) => {
+						const widthPct = max === 0 ? 0 : (row.revenue / max) * 100;
+						return (
+							<div className="grid gap-1" key={row.store_id}>
+								<div className="flex items-center justify-between gap-2">
+									<span className="flex min-w-0 items-center gap-2 truncate text-sm font-medium">
+										<span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+											{row.store_code}
+										</span>
+										<span className="truncate">{row.store_name}</span>
 									</span>
-									<span className="truncate">{row.store_name}</span>
-								</span>
-								<span className="font-mono text-sm tabular-nums">
-									{formatIDRCurrency(String(row.revenue))}
-								</span>
+									<span className="font-mono text-sm tabular-nums">
+										{formatIDRCurrency(String(row.revenue))}
+									</span>
+								</div>
+								<div className="h-1.5 w-full bg-muted">
+									<div
+										className="h-full bg-foreground"
+										style={{ width: `${widthPct}%` }}
+									/>
+								</div>
+								<div className="flex items-center justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
+									<span>{`${row.orders} orders`}</span>
+									<span>{percentFormatter.format(row.share)}</span>
+								</div>
 							</div>
-							<div className="h-1.5 w-full bg-muted">
-								<div
-									className="h-full bg-foreground"
-									style={{ width: `${pct}%` }}
-								/>
-							</div>
-							<div className="flex items-center justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
-								<span>{`${numberFormatter.format(row.orders)} orders`}</span>
-								<span>{percentFormatter.format(row.share)}</span>
-							</div>
-						</div>
-					);
-				})}
-			</div>
-		</div>
+						);
+					})}
+				</div>
+			</CardContent>
+		</Card>
 	);
 };
 

--- a/apps/web/src/features/reports/panels/financial-panel.tsx
+++ b/apps/web/src/features/reports/panels/financial-panel.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
+import { useMemo, useState } from "react";
 import {
 	CartesianGrid,
 	Line,
@@ -83,17 +84,26 @@ const formatDeltaPct = (pct: number | null | undefined): string => {
 	return `${sign}${(pct * 100).toFixed(1)}%`;
 };
 
+const formatDeltaPp = (curr: number, prev: number): string => {
+	const diff = (curr - prev) * 100;
+	const sign = diff > 0 ? "+" : "";
+	return `${sign}${diff.toFixed(1)}pp`;
+};
+
+const safeRatio = (num: number, denom: number): number =>
+	denom > 0 ? num / denom : 0;
+
 const formatIDRShort = (v: number): string => {
 	const abs = Math.abs(v);
 	const sign = v < 0 ? "-" : "";
 	if (abs >= 1_000_000_000) {
-		return `${sign}Rp ${(abs / 1_000_000_000).toFixed(1)}B`;
+		return `${sign}Rp ${(abs / 1_000_000_000).toFixed(2)}B`;
 	}
 	if (abs >= 1_000_000) {
-		return `${sign}Rp ${(abs / 1_000_000).toFixed(1)}M`;
+		return `${sign}Rp ${(abs / 1_000_000).toFixed(2)}M`;
 	}
 	if (abs >= 1_000) {
-		return `${sign}Rp ${(abs / 1_000).toFixed(0)}k`;
+		return `${sign}Rp ${(abs / 1_000).toFixed(0)}K`;
 	}
 	return `${sign}Rp ${abs.toFixed(0)}`;
 };
@@ -108,7 +118,7 @@ const formatAxisShort = (v: number): string => {
 		return `${sign}${(abs / 1_000_000).toFixed(1)}M`;
 	}
 	if (abs >= 1_000) {
-		return `${sign}${(abs / 1_000).toFixed(0)}k`;
+		return `${sign}${(abs / 1_000).toFixed(0)}K`;
 	}
 	return `${sign}${abs.toFixed(0)}`;
 };
@@ -132,7 +142,6 @@ export const FinancialPanel = ({
 		financialQueryOptions({ from, to, store_id: storeId, granularity }),
 	);
 	const data = query.data;
-	const summary = data?.summary.current;
 	const storeBreakdown = data?.store_breakdown ?? [];
 	const storeMax = storeBreakdown.reduce((m, r) => Math.max(m, r.revenue), 0);
 
@@ -140,33 +149,28 @@ export const FinancialPanel = ({
 		if (!data) {
 			return;
 		}
-		const lines: string[] = [];
+		const summary = data.summary.current;
 		const prev = data.summary.previous;
+		const lines: string[] = [];
 		lines.push("Financial totals,Metric,Current,Previous");
 		lines.push(
-			`Totals,Gross revenue,${summary?.gross_revenue ?? 0},${prev.gross_revenue}`,
+			`Totals,Gross revenue,${summary.gross_revenue},${prev.gross_revenue}`,
 		);
 		lines.push(
-			`Totals,Services,${summary?.services_total ?? 0},${prev.services_total}`,
+			`Totals,Services,${summary.services_total},${prev.services_total}`,
 		);
 		lines.push(
-			`Totals,Products,${summary?.products_total ?? 0},${prev.products_total}`,
+			`Totals,Products,${summary.products_total},${prev.products_total}`,
 		);
-		lines.push(`Totals,Discount,${summary?.discount ?? 0},${prev.discount}`);
+		lines.push(`Totals,Discount,${summary.discount},${prev.discount}`);
+		lines.push(`Totals,Net revenue,${summary.net_revenue},${prev.net_revenue}`);
+		lines.push(`Totals,COGS,${summary.cogs},${prev.cogs}`);
 		lines.push(
-			`Totals,Net revenue,${summary?.net_revenue ?? 0},${prev.net_revenue}`,
+			`Totals,Gross profit,${summary.gross_profit},${prev.gross_profit}`,
 		);
-		lines.push(`Totals,COGS,${summary?.cogs ?? 0},${prev.cogs}`);
-		lines.push(
-			`Totals,Gross profit,${summary?.gross_profit ?? 0},${prev.gross_profit}`,
-		);
-		lines.push(`Totals,Refunds,${summary?.refunds ?? 0},${prev.refunds}`);
-		lines.push(
-			`Totals,Net income,${summary?.net_income ?? 0},${prev.net_income}`,
-		);
-		lines.push(
-			`Totals,Net margin,${summary?.net_margin ?? 0},${prev.net_margin}`,
-		);
+		lines.push(`Totals,Refunds,${summary.refunds},${prev.refunds}`);
+		lines.push(`Totals,Net income,${summary.net_income},${prev.net_income}`);
+		lines.push(`Totals,Net margin,${summary.net_margin},${prev.net_margin}`);
 		lines.push("");
 		lines.push(
 			"Financial series,Bucket,Services,Products,Gross,Discount,Net revenue,COGS,Gross profit,Refunds,Net income",
@@ -206,6 +210,7 @@ export const FinancialPanel = ({
 
 	return (
 		<div className="grid gap-6">
+			<KpiStrip data={data} storeId={storeId} />
 			<RevenueBreakdownCard
 				data={data}
 				exportDisabled={!data}
@@ -223,50 +228,40 @@ interface RevenueBreakdownCardProps {
 	onExport: () => void;
 }
 
+interface PanelSectionTitleProps {
+	title: string;
+	meta?: string;
+}
+
+const PanelSectionTitle = ({ title, meta }: PanelSectionTitleProps) => (
+	<div className="flex min-w-0 items-start gap-2">
+		<span className="mt-0.5 h-4 w-1 shrink-0 bg-foreground" aria-hidden />
+		<div className="grid min-w-0 gap-0.5">
+			<p className="text-sm font-semibold leading-none text-foreground">
+				{title}
+			</p>
+			{meta ? (
+				<p className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+					{meta}
+				</p>
+			) : null}
+		</div>
+	</div>
+);
+
 const RevenueBreakdownCard = ({
 	data,
 	exportDisabled,
 	onExport,
 }: RevenueBreakdownCardProps) => {
 	const summary = data?.summary.current;
-	const previous = data?.summary.previous;
 	const deltas = data?.summary.deltas;
-	const heroPct = deltas?.net_revenue?.delta_pct;
-	const heroTone = toneForPct(heroPct);
-	const HeroIcon = heroTone.Icon;
-	const previousLabel = data
-		? formatPreviousRangeLabel(data.previous.from, data.previous.to)
-		: "";
 
 	return (
 		<Card className="border-border/70">
-			<CardContent className="grid gap-6 p-5 sm:p-6">
-				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-					<div className="grid min-w-0 gap-1.5">
-						<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-							Net revenue
-						</p>
-						<p className="break-all font-mono text-2xl font-semibold tabular-nums sm:text-3xl">
-							{formatIDRCurrency(String(summary?.net_revenue ?? 0))}
-						</p>
-						<p
-							className={cn(
-								"flex flex-wrap items-center gap-1.5 font-mono text-xs tabular-nums",
-								heroTone.tone,
-							)}
-						>
-							<HeroIcon className="size-3" weight="bold" />
-							<span className="font-medium">{formatDeltaPct(heroPct)}</span>
-							{previous ? (
-								<span className="text-muted-foreground">
-									{`vs ${formatIDRCurrency(String(previous.net_revenue))} (${previousLabel})`}
-								</span>
-							) : null}
-						</p>
-						<p className="text-[11px] text-muted-foreground">
-							Gross − discount
-						</p>
-					</div>
+			<CardContent className="grid gap-5 p-5 sm:p-6">
+				<div className="flex items-center justify-between">
+					<PanelSectionTitle title="Revenue" />
 					<ExportButton disabled={exportDisabled} onClick={onExport} />
 				</div>
 
@@ -276,7 +271,7 @@ const RevenueBreakdownCard = ({
 				/>
 
 				<StatStrip
-					sectionLabel="── REVENUE TRAJECTORY ──"
+					title="Revenue trajectory"
 					cells={[
 						{
 							label: "Gross",
@@ -299,7 +294,7 @@ const RevenueBreakdownCard = ({
 				<SankeyFlow summary={summary} />
 
 				<StatStrip
-					sectionLabel="── DEDUCTIONS & MARGIN ──"
+					title="Deductions & margin"
 					cells={[
 						{
 							label: "Discount",
@@ -358,14 +353,14 @@ const RevenueLineChart = ({ series, granularity }: RevenueLineChartProps) => {
 		);
 	if (isEmpty) {
 		return (
-			<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+			<div className="flex h-60 items-center justify-center border border-border/40 text-sm text-muted-foreground">
 				No revenue in range.
 			</div>
 		);
 	}
 	return (
 		<div className="grid gap-2">
-			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[11px] uppercase tracking-widest text-foreground/70">
 				<span className="flex items-center gap-1.5">
 					<span
 						className="h-0.5 w-3"
@@ -389,9 +384,9 @@ const RevenueLineChart = ({ series, granularity }: RevenueLineChartProps) => {
 				</span>
 			</div>
 			<ChartContainer
-				className="aspect-auto w-full"
+				className="h-60 min-h-60 min-w-0 w-full aspect-auto"
 				config={LINE_CHART_CONFIG}
-				style={{ height: 240 }}
+				style={{ height: 240, minHeight: 240, minWidth: 0 }}
 			>
 				<LineChart data={series} margin={{ left: 4, right: 8, top: 8 }}>
 					<CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -460,26 +455,44 @@ const RevenueLineChart = ({ series, granularity }: RevenueLineChartProps) => {
 
 interface SankeyNodeDatum {
 	name: string;
-	opacity: number;
 	displayValue: number;
+	color: string;
+	labelTone: string;
 }
 
 interface SankeyFlowProps {
 	summary: SummaryCurrent | undefined;
 }
 
+interface SankeyLinkDatum {
+	source: number;
+	target: number;
+	value: number;
+	color: string;
+	opacity: number;
+}
+
+interface SankeyLinkRenderProps {
+	sourceX: number;
+	targetX: number;
+	sourceY: number;
+	targetY: number;
+	sourceControlX: number;
+	targetControlX: number;
+	linkWidth: number;
+	payload: unknown;
+}
+
 const SankeyFlow = ({ summary }: SankeyFlowProps) => {
 	const sectionLabel = (
-		<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-			── FLOW ──
-		</p>
+		<PanelSectionTitle meta="green retained · red deductions" title="Flow" />
 	);
 
 	if (!summary || summary.gross_revenue <= 0) {
 		return (
 			<div className="grid gap-2">
 				{sectionLabel}
-				<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+				<div className="flex h-60 items-center justify-center border border-border/40 text-sm text-muted-foreground">
 					No revenue to flow.
 				</div>
 			</div>
@@ -490,22 +503,78 @@ const SankeyFlow = ({ summary }: SankeyFlowProps) => {
 	const nodes: SankeyNodeDatum[] = [
 		{
 			name: "Gross revenue",
-			opacity: 0.45,
 			displayValue: summary.gross_revenue,
+			color: "var(--muted-foreground)",
+			labelTone: "var(--muted-foreground)",
 		},
-		{ name: "Discount", opacity: 0.3, displayValue: summary.discount },
-		{ name: "Net revenue", opacity: 0.7, displayValue: summary.net_revenue },
-		{ name: "COGS", opacity: 0.3, displayValue: summary.cogs },
-		{ name: "Refunds", opacity: 0.3, displayValue: summary.refunds },
-		{ name: "Net income", opacity: 1, displayValue: netIncomePositive },
+		{
+			name: "Discount",
+			displayValue: summary.discount,
+			color: "var(--destructive)",
+			labelTone: "var(--destructive)",
+		},
+		{
+			name: "Net revenue",
+			displayValue: summary.net_revenue,
+			color: "var(--success)",
+			labelTone: "var(--success)",
+		},
+		{
+			name: "COGS",
+			displayValue: summary.cogs,
+			color: "var(--destructive)",
+			labelTone: "var(--destructive)",
+		},
+		{
+			name: "Refunds",
+			displayValue: summary.refunds,
+			color: "var(--destructive)",
+			labelTone: "var(--destructive)",
+		},
+		{
+			name: "Net income",
+			displayValue: netIncomePositive,
+			color: "var(--success)",
+			labelTone: "var(--success)",
+		},
 	];
 
-	const linkCandidates = [
-		{ source: 0, target: 1, value: summary.discount },
-		{ source: 0, target: 2, value: summary.net_revenue },
-		{ source: 2, target: 3, value: summary.cogs },
-		{ source: 2, target: 4, value: summary.refunds },
-		{ source: 2, target: 5, value: netIncomePositive },
+	const linkCandidates: SankeyLinkDatum[] = [
+		{
+			source: 0,
+			target: 1,
+			value: summary.discount,
+			color: "var(--destructive)",
+			opacity: 0.28,
+		},
+		{
+			source: 0,
+			target: 2,
+			value: summary.net_revenue,
+			color: "var(--success)",
+			opacity: 0.24,
+		},
+		{
+			source: 2,
+			target: 3,
+			value: summary.cogs,
+			color: "var(--destructive)",
+			opacity: 0.28,
+		},
+		{
+			source: 2,
+			target: 4,
+			value: summary.refunds,
+			color: "var(--destructive)",
+			opacity: 0.34,
+		},
+		{
+			source: 2,
+			target: 5,
+			value: netIncomePositive,
+			color: "var(--success)",
+			opacity: 0.34,
+		},
 	];
 	const links = linkCandidates.filter((l) => l.value > 0);
 
@@ -513,7 +582,7 @@ const SankeyFlow = ({ summary }: SankeyFlowProps) => {
 		return (
 			<div className="grid gap-2">
 				{sectionLabel}
-				<div className="flex h-[240px] items-center justify-center border border-border/40 text-sm text-muted-foreground">
+				<div className="flex h-60 items-center justify-center border border-border/40 text-sm text-muted-foreground">
 					No revenue to flow.
 				</div>
 			</div>
@@ -523,22 +592,49 @@ const SankeyFlow = ({ summary }: SankeyFlowProps) => {
 	return (
 		<div className="grid gap-2">
 			{sectionLabel}
-			<div className="w-full" style={{ height: 280 }}>
-				<ResponsiveContainer height="100%" width="100%">
+			<div className="h-80 min-h-80 min-w-0 w-full overflow-visible">
+				<ResponsiveContainer
+					height={320}
+					initialDimension={{ height: 320, width: 720 }}
+					minWidth={0}
+					width="100%"
+				>
 					<Sankey
 						data={{ nodes, links }}
-						link={{
-							fillOpacity: 1,
-							stroke: "var(--foreground)",
-						}}
-						margin={{ bottom: 8, left: 8, right: 110, top: 8 }}
+						link={(props) => <SankeyLink {...props} />}
+						margin={{ bottom: 32, left: 8, right: 156, top: 12 }}
 						node={(props) => <SankeyNode {...props} />}
-						nodePadding={28}
+						nodePadding={24}
 						nodeWidth={6}
 					/>
 				</ResponsiveContainer>
 			</div>
 		</div>
+	);
+};
+
+const SankeyLink = ({
+	sourceX,
+	targetX,
+	sourceY,
+	targetY,
+	sourceControlX,
+	targetControlX,
+	linkWidth,
+	payload,
+}: SankeyLinkRenderProps) => {
+	const datum = payload as SankeyLinkDatum;
+	const path = `M${sourceX},${sourceY}C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`;
+
+	return (
+		<path
+			d={path}
+			fill="none"
+			stroke={datum.color}
+			strokeLinecap="butt"
+			strokeOpacity={datum.opacity}
+			strokeWidth={Math.max(linkWidth, 1)}
+		/>
 	);
 };
 
@@ -563,22 +659,22 @@ const SankeyNode = ({
 	return (
 		<g>
 			<rect
-				fill="var(--foreground)"
-				fillOpacity={datum.opacity}
+				fill={datum.color}
 				height={height}
+				opacity={0.95}
 				width={width}
 				x={x}
 				y={y}
 			/>
-			<text fontSize={10} x={labelX} y={labelY - 1}>
+			<text fontSize={11} x={labelX} y={labelY - 1}>
 				<tspan
-					fill="var(--muted-foreground)"
+					fill={datum.labelTone}
 					fontFamily="ui-monospace, SFMono-Regular, monospace"
 				>
 					{datum.name}
 				</tspan>
 			</text>
-			<text fontSize={10} fontWeight={600} x={labelX} y={labelY + 11}>
+			<text fontSize={11} fontWeight={600} x={labelX} y={labelY + 12}>
 				<tspan
 					fill="var(--foreground)"
 					fontFamily="ui-monospace, SFMono-Regular, monospace"
@@ -599,15 +695,13 @@ interface StatCell {
 }
 
 interface StatStripProps {
-	sectionLabel: string;
+	title: string;
 	cells: StatCell[];
 }
 
-const StatStrip = ({ sectionLabel, cells }: StatStripProps) => (
+const StatStrip = ({ title, cells }: StatStripProps) => (
 	<div className="grid gap-3">
-		<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-			{sectionLabel}
-		</p>
+		<PanelSectionTitle title={title} />
 		<div
 			className={cn(
 				"grid grid-cols-2",
@@ -626,13 +720,13 @@ const StatStrip = ({ sectionLabel, cells }: StatStripProps) => (
 						)}
 						key={cell.label}
 					>
-						<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+						<p className="font-mono text-[10px] uppercase tracking-widest text-foreground/70">
 							{cell.label}
 						</p>
-						<p className="break-all font-mono text-sm font-semibold tabular-nums">
+						<p className="break-all font-mono text-base font-semibold tabular-nums">
 							{cell.isPercent
 								? percentFormatter.format(cell.value)
-								: formatIDRCurrency(String(cell.value))}
+								: formatIDRShort(cell.value)}
 						</p>
 						<p
 							className={cn(
@@ -652,6 +746,142 @@ const StatStrip = ({ sectionLabel, cells }: StatStripProps) => (
 	</div>
 );
 
+interface KpiStripProps {
+	data: FinancialReport | undefined;
+	storeId?: number;
+}
+
+type ToneSpec = ReturnType<typeof toneForPct>;
+
+interface KpiCellModel {
+	label: string;
+	value: string;
+	delta: string;
+	tone: ToneSpec;
+}
+
+const KpiStrip = ({ data, storeId }: KpiStripProps) => {
+	const cells = useMemo<KpiCellModel[]>(() => {
+		if (!data) {
+			return [];
+		}
+		const summary = data.summary.current;
+		const prev = data.summary.previous;
+		const deltas = data.summary.deltas;
+		const totalOrders = storeId
+			? (data.store_breakdown.find((r) => r.store_id === storeId)?.orders ?? 0)
+			: data.store_breakdown.reduce((s, r) => s + r.orders, 0);
+		const aov = safeRatio(summary.gross_revenue, totalOrders);
+		const refundRate = safeRatio(summary.refunds, summary.gross_revenue);
+		const prevRefundRate = safeRatio(prev.refunds, prev.gross_revenue);
+		const marginPp = summary.net_margin - prev.net_margin;
+		const refundRateDiff = refundRate - prevRefundRate;
+
+		return [
+			{
+				label: "Net revenue",
+				value: formatIDRShort(summary.net_revenue),
+				delta: formatDeltaPct(deltas.net_revenue?.delta_pct),
+				tone: toneForPct(deltas.net_revenue?.delta_pct),
+			},
+			{
+				label: "Net income",
+				value: formatIDRShort(summary.net_income),
+				delta: formatDeltaPct(deltas.net_income?.delta_pct),
+				tone: toneForPct(deltas.net_income?.delta_pct),
+			},
+			{
+				label: "Margin",
+				value: percentFormatter.format(summary.net_margin),
+				delta: formatDeltaPp(summary.net_margin, prev.net_margin),
+				tone: toneForPct(marginPp),
+			},
+			{
+				label: "Orders",
+				value: totalOrders.toLocaleString("id-ID"),
+				delta: "—",
+				tone: NEUTRAL_TONE,
+			},
+			{
+				label: "AOV",
+				value: formatIDRShort(aov),
+				delta: "—",
+				tone: NEUTRAL_TONE,
+			},
+			{
+				label: "COGS",
+				value: formatIDRShort(summary.cogs),
+				delta: formatDeltaPct(deltas.cogs?.delta_pct),
+				tone: toneForPct(deltas.cogs?.delta_pct, true),
+			},
+			{
+				label: "Refund rate",
+				value: percentFormatter.format(refundRate),
+				delta: formatDeltaPp(refundRate, prevRefundRate),
+				tone: toneForPct(refundRateDiff, true),
+			},
+		];
+	}, [data, storeId]);
+
+	const previousLabel = data
+		? formatPreviousRangeLabel(data.previous.from, data.previous.to)
+		: "";
+
+	if (!data) {
+		return (
+			<Card className="border-border/70">
+				<CardContent className="grid h-30 place-items-center p-5 sm:p-6">
+					<p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+						Loading totals…
+					</p>
+				</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<Card className="border-border/70">
+			<CardContent className="grid gap-0 p-0">
+				<div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
+					<PanelSectionTitle meta={`vs ${previousLabel}`} title="Totals" />
+				</div>
+				<div className="grid grid-cols-2 sm:grid-cols-4 xl:grid-cols-7">
+					{cells.map((cell, idx) => {
+						const Icon = cell.tone.Icon;
+						return (
+							<div
+								className={cn(
+									"grid gap-1 px-4 py-4",
+									idx > 0 && "xl:border-l xl:border-border/40",
+								)}
+								key={cell.label}
+							>
+								<p className="font-mono text-[10px] uppercase tracking-widest text-foreground/70">
+									{cell.label}
+								</p>
+								<p className="break-all font-mono text-base font-semibold tabular-nums">
+									{cell.value}
+								</p>
+								<p
+									className={cn(
+										"flex items-center gap-1 font-mono text-[11px] tabular-nums",
+										cell.tone.tone,
+									)}
+								>
+									{cell.delta === "—" ? null : (
+										<Icon className="size-2.5" weight="bold" />
+									)}
+									{cell.delta}
+								</p>
+							</div>
+						);
+					})}
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
 type StoreCategoryMatrix = FinancialReport["store_category_matrix"];
 type MatrixColumn = StoreCategoryMatrix["columns"][number];
 type MatrixRow = StoreCategoryMatrix["rows"][number];
@@ -660,7 +890,10 @@ interface BranchCategoryMatrixProps {
 	data: FinancialReport | undefined;
 }
 
+type MatrixDisplayMode = "share" | "amount";
+
 const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
+	const [mode, setMode] = useState<MatrixDisplayMode>("share");
 	const matrix = data?.store_category_matrix;
 	const columns = matrix?.columns ?? [];
 	const rows = matrix?.rows ?? [];
@@ -679,17 +912,16 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 	return (
 		<Card className="border-border/70">
 			<CardContent className="grid gap-3 p-5 sm:p-6">
-				<div className="grid gap-1">
-					<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-						Branch × Category
-					</p>
-					<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-						{`// share within branch · top ${columns.length} categor${columns.length === 1 ? "y" : "ies"}`}
-					</p>
+				<div className="flex items-start justify-between gap-3">
+					<PanelSectionTitle
+						meta={`${mode === "share" ? "share within branch" : "revenue (Rp)"} · top ${columns.length} categor${columns.length === 1 ? "y" : "ies"}`}
+						title="Branch × Category"
+					/>
+					<MatrixModeToggle mode={mode} onChange={setMode} />
 				</div>
 
 				{isEmpty ? (
-					<p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+					<p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
 						{"// no category revenue in range"}
 					</p>
 				) : (
@@ -698,7 +930,7 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 							<thead>
 								<tr>
 									<th
-										className="sticky left-0 z-10 bg-card px-2 py-1.5 text-left text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										className="sticky left-0 z-10 bg-card px-2 py-1.5 text-left text-[11px] uppercase tracking-widest text-foreground/70"
 										scope="col"
 									>
 										Branch
@@ -707,7 +939,7 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 										<MatrixHeaderCell column={col} key={col.category_id} />
 									))}
 									<th
-										className="border-l border-border/40 px-2 py-1.5 text-right text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										className="border-l border-border/40 px-2 py-1.5 text-right text-[11px] uppercase tracking-widest text-foreground/70"
 										scope="col"
 									>
 										Total
@@ -720,6 +952,7 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 										columns={columns}
 										grandTotal={grandTotal}
 										key={row.store_id}
+										mode={mode}
 										row={row}
 									/>
 								))}
@@ -727,14 +960,14 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 							<tfoot>
 								<tr>
 									<th
-										className="sticky left-0 z-10 border-t border-border/40 bg-card px-2 py-2 text-left text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+										className="sticky left-0 z-10 border-t border-border/40 bg-card px-2 py-2 text-left text-[11px] uppercase tracking-widest text-foreground/70"
 										scope="row"
 									>
 										Total
 									</th>
 									{columns.map((col, idx) => (
 										<td
-											className="border-t border-border/40 px-2 py-2 text-center text-muted-foreground"
+											className="border-t border-border/40 px-2 py-2 text-center font-semibold"
 											key={col.category_id}
 										>
 											{formatIDRShort(columnTotals[idx] ?? 0)}
@@ -750,7 +983,7 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 				)}
 
 				{omittedStores > 0 ? (
-					<p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+					<p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
 						{`(+${omittedStores} branch${omittedStores === 1 ? "" : "es"} not shown)`}
 					</p>
 				) : null}
@@ -759,17 +992,55 @@ const BranchCategoryMatrix = ({ data }: BranchCategoryMatrixProps) => {
 	);
 };
 
+interface MatrixModeToggleProps {
+	mode: MatrixDisplayMode;
+	onChange: (mode: MatrixDisplayMode) => void;
+}
+
+const MatrixModeToggle = ({ mode, onChange }: MatrixModeToggleProps) => (
+	<div className="inline-flex shrink-0 border border-border/60 font-mono text-[11px]">
+		<button
+			aria-pressed={mode === "share"}
+			className={cn(
+				"px-2.5 py-1",
+				mode === "share"
+					? "bg-foreground text-background"
+					: "text-muted-foreground hover:text-foreground",
+			)}
+			onClick={() => onChange("share")}
+			type="button"
+		>
+			%
+		</button>
+		<button
+			aria-pressed={mode === "amount"}
+			className={cn(
+				"border-l border-border/60 px-2.5 py-1",
+				mode === "amount"
+					? "bg-foreground text-background"
+					: "text-muted-foreground hover:text-foreground",
+			)}
+			onClick={() => onChange("amount")}
+			type="button"
+		>
+			Rp
+		</button>
+	</div>
+);
+
 interface MatrixHeaderCellProps {
 	column: MatrixColumn;
 }
 
 const MatrixHeaderCell = ({ column }: MatrixHeaderCellProps) => (
 	<th
-		className="px-2 py-1.5 text-center text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+		className="min-w-28 px-3 py-2 text-center align-bottom text-[11px] uppercase tracking-wide text-foreground/70"
 		scope="col"
 		title={column.label}
 	>
-		<span className="block max-w-[88px] truncate">{column.label}</span>
+		<span className="block max-w-36 whitespace-normal break-words leading-tight">
+			{column.label}
+		</span>
 	</th>
 );
 
@@ -777,22 +1048,24 @@ interface MatrixBranchRowProps {
 	row: MatrixRow;
 	columns: MatrixColumn[];
 	grandTotal: number;
+	mode: MatrixDisplayMode;
 }
 
 const MatrixBranchRow = ({
 	row,
 	columns,
 	grandTotal,
+	mode,
 }: MatrixBranchRowProps) => (
 	<tr className="group">
 		<th
 			className="sticky left-0 z-10 border-t border-border/40 bg-card px-2 py-2 text-left align-top group-hover:bg-muted/40"
 			scope="row"
 		>
-			<span className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+			<span className="block text-[10px] uppercase tracking-widest text-muted-foreground">
 				{row.store_code}
 			</span>
-			<span className="block max-w-[140px] truncate text-foreground">
+			<span className="block max-w-35 truncate text-foreground">
 				{row.store_name}
 			</span>
 		</th>
@@ -806,6 +1079,7 @@ const MatrixBranchRow = ({
 					columnLabel={col.label}
 					grandTotal={grandTotal}
 					key={col.category_id}
+					mode={mode}
 					storeCode={row.store_code}
 					storeName={row.store_name}
 				/>
@@ -825,6 +1099,7 @@ interface MatrixCellProps {
 	columnLabel: string;
 	storeCode: string;
 	storeName: string;
+	mode: MatrixDisplayMode;
 }
 
 const MatrixCell = ({
@@ -835,12 +1110,20 @@ const MatrixCell = ({
 	columnLabel,
 	storeCode,
 	storeName,
+	mode,
 }: MatrixCellProps) => {
 	const opacity = cellRevenue === 0 ? 0 : Math.max(0.05, cellShare ** 0.7);
-	const isInverted = opacity > 0.5;
+	const isInverted = opacity > 0.35;
 	const branchSharePct = branchTotal > 0 ? cellShare * 100 : 0;
 	const grandSharePct = grandTotal > 0 ? (cellRevenue / grandTotal) * 100 : 0;
 	const tooltip = `${storeCode} ${storeName} · ${columnLabel}\nRp ${cellRevenue.toLocaleString("id-ID")} · ${branchSharePct.toFixed(1)}% of branch · ${grandSharePct.toFixed(1)}% of total`;
+
+	const display =
+		cellRevenue === 0
+			? "·"
+			: mode === "share"
+				? `${Math.round(cellShare * 100)}%`
+				: formatIDRShort(cellRevenue);
 
 	return (
 		<td
@@ -859,7 +1142,7 @@ const MatrixCell = ({
 					cellRevenue === 0 && "text-muted-foreground",
 				)}
 			>
-				{cellRevenue === 0 ? "·" : `${Math.round(cellShare * 100)}%`}
+				{display}
 			</span>
 		</td>
 	);
@@ -879,23 +1162,22 @@ const BranchList = ({ rows, max }: BranchListProps) => {
 	return (
 		<Card className="border-border/70">
 			<CardContent className="grid gap-4 p-5 sm:p-6">
-				<p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-					Branch leaderboard
-				</p>
+				<PanelSectionTitle title="Branch leaderboard" />
 				<div className="grid gap-3">
 					{rows.map((row) => {
 						const widthPct = max === 0 ? 0 : (row.revenue / max) * 100;
+						const aov = safeRatio(row.revenue, row.orders);
 						return (
 							<div className="grid gap-1" key={row.store_id}>
 								<div className="flex items-center justify-between gap-2">
 									<span className="flex min-w-0 items-center gap-2 truncate text-sm font-medium">
-										<span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+										<span className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
 											{row.store_code}
 										</span>
 										<span className="truncate">{row.store_name}</span>
 									</span>
 									<span className="font-mono text-sm tabular-nums">
-										{formatIDRCurrency(String(row.revenue))}
+										{formatIDRShort(row.revenue)}
 									</span>
 								</div>
 								<div className="h-1.5 w-full bg-muted">
@@ -904,9 +1186,12 @@ const BranchList = ({ rows, max }: BranchListProps) => {
 										style={{ width: `${widthPct}%` }}
 									/>
 								</div>
-								<div className="flex items-center justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
-									<span>{`${row.orders} orders`}</span>
-									<span>{percentFormatter.format(row.share)}</span>
+								<div className="flex flex-wrap items-center gap-x-3 font-mono text-[11px] tabular-nums text-muted-foreground">
+									<span>{`${row.orders.toLocaleString("id-ID")} orders`}</span>
+									<span aria-hidden>·</span>
+									<span>{`AOV ${formatIDRShort(aov)}`}</span>
+									<span aria-hidden>·</span>
+									<span>{`${percentFormatter.format(row.share)} share`}</span>
 								</div>
 							</div>
 						);

--- a/docs/deferred-actions.md
+++ b/docs/deferred-actions.md
@@ -165,6 +165,21 @@ Items skipped for first production launch. Each entry: **what**, **why deferred*
 
 ---
 
+## Reports
+
+### D-20. Financial panel — Iteration 2 (manual two-range compare + per-bucket/per-category previous)
+- **What:**
+  1. Manual two-range pickers + compare-mode toggle on financial panel (`apps/web/src/features/reports/panels/financial-panel.tsx`).
+  2. Server endpoint `/admin/reports/financial` accepts `compare_from` / `compare_to` query params.
+  3. Server returns per-category previous totals → enable per-category deltas in Branch×Category matrix and category bars.
+  4. Server returns per-bucket previous series → overlay ghost line on revenue line chart.
+- **Current:** Iteration 1 ships only auto-compare against equivalent prior range (`summary.previous` + `summary.deltas`). Hero KPI + stat strips show deltas; matrix + line chart do not.
+- **Why deferred:** Iteration 1 design freeze; manual picker UX + server schema change need their own pass.
+- **Revisit when:** Stakeholder requests YoY/MoM compare OR per-category trend signal.
+- **Effort:** Medium. UI picker + Zod query schema + range util + repository per-category/per-bucket previous queries.
+
+---
+
 ## Index
 
 | ID | Area | Effort | Trigger |
@@ -188,3 +203,4 @@ Items skipped for first production launch. Each entry: **what**, **why deferred*
 | D-17 | DR backup | M | Compliance |
 | D-18 | Secrets management | LM | Compliance |
 | D-19 | Cancel→refund note link | L | Audit request |
+| D-20 | Financial panel Iteration 2 (manual compare + per-bucket/per-category previous) | M | YoY/MoM ask or category trend signal |

--- a/packages/server/src/modules/reports/report-range.repository.ts
+++ b/packages/server/src/modules/reports/report-range.repository.ts
@@ -279,6 +279,63 @@ export async function listCategoryRevenueSeries({
   }));
 }
 
+// ───────────────────────── Branch × Category revenue ─────────────────────────
+
+export async function listStoreCategoryRevenueRows({
+  range,
+  storeId,
+}: {
+  range: DateRange;
+  storeId?: number;
+}) {
+  const conditions = [
+    gte(ordersTable.paid_at, range.start),
+    lt(ordersTable.paid_at, range.end),
+    isNotNull(ordersTable.paid_at),
+  ];
+  if (storeId !== undefined) {
+    conditions.push(eq(ordersTable.store_id, storeId));
+  }
+
+  const rows = await db
+    .select({
+      store_id: ordersTable.store_id,
+      store_name: storesTable.name,
+      store_code: storesTable.code,
+      category_id: categoriesTable.id,
+      category_name: categoriesTable.name,
+      revenue: sql<string>`COALESCE(SUM(${ordersServicesTable.subtotal}), 0)`,
+    })
+    .from(ordersServicesTable)
+    .innerJoin(ordersTable, eq(ordersServicesTable.order_id, ordersTable.id))
+    .innerJoin(storesTable, eq(ordersTable.store_id, storesTable.id))
+    .innerJoin(
+      servicesTable,
+      eq(ordersServicesTable.service_id, servicesTable.id)
+    )
+    .innerJoin(
+      categoriesTable,
+      eq(servicesTable.category_id, categoriesTable.id)
+    )
+    .where(and(...conditions))
+    .groupBy(
+      ordersTable.store_id,
+      storesTable.name,
+      storesTable.code,
+      categoriesTable.id,
+      categoriesTable.name
+    );
+
+  return rows.map((row) => ({
+    store_id: row.store_id,
+    store_name: row.store_name,
+    store_code: row.store_code,
+    category_id: row.category_id,
+    category_name: row.category_name,
+    revenue: Number(row.revenue),
+  }));
+}
+
 // ───────────────────────── Orders flow (R2) ─────────────────────────
 
 export async function listOrdersInSeries({

--- a/packages/server/src/modules/reports/report-range.service.ts
+++ b/packages/server/src/modules/reports/report-range.service.ts
@@ -21,6 +21,7 @@ import {
   listReturningCustomerOrdersSeries,
   listServicesCogsSeries,
   listServicesRevenueSeries,
+  listStoreCategoryRevenueRows,
   listStoreRevenueRows,
   listTopCustomers,
   listWorkerProductivityRows,
@@ -143,16 +144,22 @@ export async function getFinancialReport(query: GetReportRangeQuery) {
   const range = getJakartaRange(ctx.from, ctx.to);
   const storeId = ctx.store_id ?? undefined;
 
-  const [current, previous, categories, storeRevenue] = await Promise.all([
-    financialSummaryFor({ range, storeId, granularity: ctx.granularity }),
-    financialSummaryFor({
-      range: ctx.previous.range,
-      storeId,
-      granularity: ctx.granularity,
-    }),
-    listCategoryRevenueSeries({ range, storeId, granularity: ctx.granularity }),
-    listStoreRevenueRows({ range }),
-  ]);
+  const [current, previous, categories, storeRevenue, storeCategoryRows] =
+    await Promise.all([
+      financialSummaryFor({ range, storeId, granularity: ctx.granularity }),
+      financialSummaryFor({
+        range: ctx.previous.range,
+        storeId,
+        granularity: ctx.granularity,
+      }),
+      listCategoryRevenueSeries({
+        range,
+        storeId,
+        granularity: ctx.granularity,
+      }),
+      listStoreRevenueRows({ range }),
+      listStoreCategoryRevenueRows({ range, storeId }),
+    ]);
 
   const servicesMap = indexBy(current.services);
   const productsMap = indexBy(current.products);
@@ -248,6 +255,115 @@ export async function getFinancialReport(query: GetReportRangeQuery) {
     }))
     .sort((a, b) => b.revenue - a.revenue);
 
+  // Branch × Category matrix: global top N columns, "Other" collapses rest
+  const STORE_CATEGORY_TOP_N = 6;
+  const STORE_CATEGORY_MAX_STORES = 12;
+  const OTHER_CATEGORY_ID = -1;
+
+  const globalCategoryTotals = new Map<
+    number,
+    { label: string; revenue: number }
+  >();
+  for (const row of storeCategoryRows) {
+    const entry = globalCategoryTotals.get(row.category_id);
+    globalCategoryTotals.set(row.category_id, {
+      label: row.category_name,
+      revenue: (entry?.revenue ?? 0) + row.revenue,
+    });
+  }
+
+  const globalSorted = Array.from(globalCategoryTotals.entries())
+    .map(([id, c]) => ({
+      category_id: id,
+      label: c.label,
+      revenue: c.revenue,
+    }))
+    .sort((a, b) => b.revenue - a.revenue || a.category_id - b.category_id);
+
+  const topCategoryEntries = globalSorted.slice(0, STORE_CATEGORY_TOP_N);
+  const hasOtherStoreCategory = globalSorted.length > STORE_CATEGORY_TOP_N;
+  const topCategoryIdSet = new Set(
+    topCategoryEntries.map((c) => c.category_id)
+  );
+
+  const storeCategoryColumns: {
+    category_id: number;
+    label: string;
+    revenue: number;
+  }[] = topCategoryEntries.map((c) => ({
+    category_id: c.category_id,
+    label: c.label,
+    revenue: c.revenue,
+  }));
+  if (hasOtherStoreCategory) {
+    const otherTotal = globalSorted
+      .slice(STORE_CATEGORY_TOP_N)
+      .reduce((s, c) => s + c.revenue, 0);
+    storeCategoryColumns.push({
+      category_id: OTHER_CATEGORY_ID,
+      label: "Other",
+      revenue: otherTotal,
+    });
+  }
+
+  interface StoreBucket {
+    store_id: number;
+    store_code: string;
+    store_name: string;
+    total: number;
+    byCategory: Map<number, number>;
+  }
+
+  const storeBuckets = new Map<number, StoreBucket>();
+  for (const row of storeCategoryRows) {
+    const bucket = storeBuckets.get(row.store_id) ?? {
+      store_id: row.store_id,
+      store_code: row.store_code,
+      store_name: row.store_name,
+      total: 0,
+      byCategory: new Map<number, number>(),
+    };
+    const colId = topCategoryIdSet.has(row.category_id)
+      ? row.category_id
+      : OTHER_CATEGORY_ID;
+    bucket.byCategory.set(
+      colId,
+      (bucket.byCategory.get(colId) ?? 0) + row.revenue
+    );
+    bucket.total += row.revenue;
+    storeBuckets.set(row.store_id, bucket);
+  }
+
+  const sortedStoreBuckets = Array.from(storeBuckets.values()).sort(
+    (a, b) => b.total - a.total
+  );
+  const omittedStoreCount = Math.max(
+    0,
+    sortedStoreBuckets.length - STORE_CATEGORY_MAX_STORES
+  );
+  const visibleStoreBuckets = sortedStoreBuckets.slice(
+    0,
+    STORE_CATEGORY_MAX_STORES
+  );
+
+  const storeCategoryRowsOut = visibleStoreBuckets.map((bucket) => {
+    const cells = storeCategoryColumns.map((col) => {
+      const revenue = bucket.byCategory.get(col.category_id) ?? 0;
+      return {
+        category_id: col.category_id,
+        revenue,
+        share: bucket.total > 0 ? revenue / bucket.total : 0,
+      };
+    });
+    return {
+      store_id: bucket.store_id,
+      store_code: bucket.store_code,
+      store_name: bucket.store_name,
+      total: bucket.total,
+      cells,
+    };
+  });
+
   return {
     from: ctx.from,
     to: ctx.to,
@@ -259,6 +375,11 @@ export async function getFinancialReport(query: GetReportRangeQuery) {
     category_keys: categoryKeys,
     category_treemap: categoryTreemap,
     store_breakdown: storeBreakdown,
+    store_category_matrix: {
+      columns: storeCategoryColumns,
+      rows: storeCategoryRowsOut,
+      omitted_stores: omittedStoreCount,
+    },
     summary: {
       current: summary,
       previous: prevSummary,


### PR DESCRIPTION
## Summary
- Add `store_category_matrix` to financial report (per-branch revenue across global top 6 categories + Other, cap 12 stores)
- Replace global category card with `BranchCategoryMatrix` heatmap (opacity shading by share-within-branch)
- Update CSV export with branch×category block

## Test plan
- [x] `/reports` financial tab — heatmap renders with opacity gradient
- [x] Filter by store → single-row matrix, totals match
- [x] Empty range → "// no category revenue in range"
- [x] >12 branches → "(+N branches not shown)" footer
- [x] CSV export contains Branch × Category block
- [x] Cell tooltip shows branch + category + revenue + branch/grand share