### PR TITLE
refactor(orders): extract pickup module + enforce picked_up CHECK

### DIFF
--- a/docs/adr/0005-pickup-code-authentication.md
+++ b/docs/adr/0005-pickup-code-authentication.md
@@ -62,29 +62,28 @@ Estimated wrong-handovers from this path: very low single digits per year worst 
 
 Accepted residual risk: cashier may, in rare birthday-collision cases combined with row-misclick, complete pickup against the wrong Order. Mitigated operationally (cashier confirms customer name on dialog) rather than schema-enforced.
 
-## Outstanding fix
+## Resolved fix
 
-One gap from the original drafting **remains real** and is independent of the two declined items:
+The one real gap from the original drafting (independent of the two declined items) is now closed.
 
-### Missing CHECK implication
+### Missing CHECK implication — fixed
 
-The schema currently enforces *if `pickup_event_id` is set, status must be `picked_up`/`refunded`*, but **not** the reverse — *if status is `picked_up`, `pickup_event_id` must be set*. A row claiming pickup happened without the dialog flow is therefore allowed by the database; only application code prevents it today.
+The schema previously enforced *if `pickup_event_id` is set, status must be `picked_up`/`refunded`*, but **not** the reverse. A row claiming pickup without the dialog flow was therefore allowed by the database; only application code prevented it.
 
-Target combined constraint:
+Two named CHECK constraints on `orders_services` now enforce both directions:
 
 ```sql
-CHECK (
-  (pickup_event_id IS NULL OR status IN ('picked_up', 'refunded'))
-  AND
-  (status != 'picked_up' OR pickup_event_id IS NOT NULL)
-)
+-- pre-existing
+CHECK (pickup_event_id IS NULL OR status IN ('picked_up', 'refunded'))
+-- added (architecture-deepening §5)
+CHECK (status != 'picked_up' OR pickup_event_id IS NOT NULL)
 ```
 
-This is a data-integrity invariant, not an authentication concern — it belongs in the schema regardless of how the code is generated or whether it is UNIQUE. Fix on its own; no coupling to the declined items.
+A data-integrity invariant, not an authentication concern — it belongs in the schema regardless of how the code is generated or whether it is UNIQUE. Landed independently of the declined items, applied to dev via `push:dev` after a data-safety query confirmed zero violating rows.
 
 ## Consequences
 
-- The picked-up transition must never be settable via a generic status dropdown — only through the pickup dialog. Today this is an **application-layer invariant**, not a schema-enforced one (see gap 3).
+- The picked-up transition must never be settable via a generic status dropdown — only through the pickup dialog. The application layer enforces the dialog path; the CHECK above (`status != 'picked_up' OR pickup_event_id IS NOT NULL`) now backstops it — a dropdown write that sets `picked_up` without a pickup event is rejected by the database.
 - `pickup_code` must never leak to admin/cashier UI for Orders not yet `ready_for_pickup` (would let an internal actor bypass the customer-presence check).
 - The public `/track` page is the only surface that exposes the code, and only after the status check.
 - Replacing the scheme later (e.g. with QR) means deprecating the dialog input path and migrating the generation column, not editing application code alone.

--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -34,7 +34,7 @@ Suggested order:
 | 2 | Split `order-admin.service.ts` by lifecycle     | ⬜ Pending   | Partially eased by #1; depends on #5 + #6 |
 | 3 | Permissions module (ADR-0004 capability table)  | ✅ Done      | See §3 + ADR-0006 |
 | 4 | Campaign eligibility → Campaigns module         | ⬜ Pending   | Independent |
-| 5 | Pickup module (ADR-0005 invariants)             | ⬜ Pending   | Uses #1's `completePickup` seam |
+| 5 | Pickup module (ADR-0005 invariants)             | ✅ Done      | See §5 |
 | 6 | Reversal off-ramps (cancel + refund)            | ⬜ Pending   | Uses #1's `transitionOrderService` + `applyRefundTransition` seams |
 | 7 | Collapse shallow CRUD services                  | ⬜ Pending   | Policy call, defer |
 | 8 | Product refunds + `refund_status` fix           | ⬜ Pending   | Bug; independent, schema change |
@@ -118,16 +118,16 @@ Web consumers updated:
 
 ## §2 — Split `order-admin.service.ts` ⬜
 
-**Problem**: 1282 lines (down from 1506 after #1) still spanning queue + handler
-+ pickup + refund + cancel + photo + payment. After #5 and #6 land, residual
-is queue + photo + payment.
+**Problem**: 1106 lines (down from 1506; −#1 then −#5) still spanning queue +
+handler + refund + cancel + photo + payment. After #6 lands, residual is queue +
+photo + payment.
 
 **Plan**: extract `order-queue.service.ts` and `order-photo.service.ts`.
 Maybe collapse `updateOrderPayment` into a small `order-payment.service.ts`
 or leave it.
 
-**Wait for**: #5 and #6 to land first — those carve out pickup and reversal
-naturally.
+**Wait for**: #6 to land first — carves out reversal naturally. (#5 done — pickup
+already carved into `order-pickup.service.ts`.)
 
 ---
 
@@ -220,30 +220,62 @@ Returns ready-to-apply Campaigns or typed validation error.
 
 ---
 
-## §5 — Pickup module ⬜ (uses #1's `completePickup`)
+## §5 — Pickup module ✅
 
-**Problem**: ADR-0005 invariants scattered across `createOrderPickupEvent` +
-pickup-photo presign + dropoff-photo handler (misleadingly-named in current
-file). Reader has to scan three handlers to verify ADR-0005 holds.
+**Goal**: gather every pickup-code / pickup-event invariant (ADR-0005) into one
+module so the picked-up transition reads end-to-end in one place, instead of
+living inside the giant `order-admin.service.ts`.
 
-**Sketch**: `packages/server/src/modules/orders/order-pickup.service.ts`
-owns:
-- `validatePickupCode(order, code)` — code matches this Order, status check
-- `recordPickupEvent({ orderId, serviceIds, photo, by })` — full flow
-  including the existing compensating-rollback for partial flips
-- pickup-photo presign
+**Home**: `packages/server/src/modules/orders/order-pickup.service.ts`. Single file.
 
-State machine's `completePickup` is the seam this module crosses for the
-status flip.
+**Scope correction**: the original sketch listed the drop-off photo handler as a
+third pickup site ("misleadingly-named"). It is **not** pickup — drop-off photo is
+an **intake** concern (writes `orders.dropoff_photo_*`, no ADR-0005 logic). It
+stayed in `order-admin.service.ts`. The Pickup module owns only the two genuinely
+pickup handlers. `saveOrderDropoffPhoto`'s name was accurate all along.
 
-**Bonus**: surface the schema CHECK gap noted in ADR-0005's "Outstanding fix"
-section — add the reverse-direction CHECK in a migration.
+**Exports**
 
-**Design questions**
-- Use real `db.transaction` instead of compensating rollback? (Neon driver
-  is `neon-serverless` Pool — supports tx. The compensating-rollback comment
-  in current code is outdated.)
-- Photo-handler naming cleanup (`saveOrderDropoffPhoto` is misleading).
+| Symbol                          | Role |
+|---------------------------------|------|
+| `createOrderPickupEvent`        | Full pickup flow: code-validate → readiness check → (tx) insert `order_pickup_events` + `completePickup`. |
+| `createOrderPickupEventPresign` | Pickup-photo upload URL (gated by `assertCanProcessPickup`). |
+
+Private `assertPickupCodeMatches(order, code)` names the ADR-0005 per-Order code rule.
+
+**Behavior changes vs pre-refactor**
+
+- Pickup writes now run inside a real `db.transaction`. The hand-rolled
+  compensating rollback (manual event-delete + service-reset on partial flip / error)
+  is deleted — the transaction rolls back automatically. No external behavior change:
+  same validations, same error messages, same concurrency guard (a concurrent pickup
+  leaves a short flip from `completePickup` → throw → rollback).
+- Names kept (`createOrderPickupEvent` / `createOrderPickupEventPresign`) — accurate,
+  no rename churn into routes.
+
+**Ported call sites**
+
+| Handler / Route | What changed |
+|-----------------|--------------|
+| `routes/admin/orders.ts` | The two pickup imports repointed from `order-admin.service` to `order-pickup.service`. Route bodies unchanged. |
+| `orders/order-admin.service.ts` | Both pickup functions removed; orphaned imports (`orderPickupEventsTable`, `completePickup`, `assertCanProcessPickup`, the two pickup input types) cleaned. 1249 → 1106 lines (−11%). |
+
+**Schema (ADR-0005 "Outstanding fix" landed)**
+
+- Added CHECK `order_services_picked_up_requires_event_check`:
+  `status != 'picked_up' OR pickup_event_id IS NOT NULL`. The picked-up transition is
+  now DB-enforced, not just application-enforced. Applied to dev via `push:dev` (this
+  repo uses the push workflow — `drizzle/dev` has no migration journal, only a pulled
+  snapshot). A read-only data-safety query confirmed **0** violating rows before apply.
+- ADR-0005 updated to mark the gap resolved.
+
+**Tests**: existing suite 42/42 pass; server type-check + biome clean. Pickup-flow
+integration tests deferred (needs a test-DB strategy, same as #1).
+
+**Outcomes**
+- `order-admin.service.ts` shrinks; pickup logic readable in one 145-line file.
+- ADR-0005 invariant promoted from code-only to schema-enforced.
+- Manual compensating-rollback retired in favor of a transaction.
 
 ---
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -575,6 +575,12 @@ export const ordersServicesTable = pgTable(
       "order_services_pickup_event_terminal_check",
       sql`${table.pickup_event_id} IS NULL OR ${table.status} IN ('picked_up', 'refunded')`
     ),
+    // ADR-0005: reverse direction — a picked_up row must point at a real pickup
+    // event, so the picked_up transition can only come from the pickup dialog.
+    check(
+      "order_services_picked_up_requires_event_check",
+      sql`${table.status} != 'picked_up' OR ${table.pickup_event_id} IS NOT NULL`
+    ),
   ]
 );
 

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -1,7 +1,6 @@
 import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
-  orderPickupEventsTable,
   orderRefundItemsTable,
   orderRefundsTable,
   orderServiceHandlerLogsTable,
@@ -22,8 +21,6 @@ import type {
   PatchOrderServiceStatusInput,
   PostOrderCancelInput,
   PostOrderDropoffPhotoPresignInput,
-  PostOrderPickupEventInput,
-  PostOrderPickupEventPresignInput,
   PostOrderRefundInput,
   PostOrderServicePhotoInput,
   PostOrderServicePhotoPresignInput,
@@ -33,7 +30,6 @@ import { normalizeOrderServiceQueueQuery } from "@/modules/orders/order-admin.sc
 import { deriveOrderRefundStatus } from "@/modules/orders/order-refund-status";
 import {
   applyRefundTransition,
-  completePickup,
   isTerminalOrderServiceStatus,
   summarizeOrderFulfillment,
   transitionOrderService,
@@ -41,7 +37,6 @@ import {
 import {
   assertCanCancelOrderService,
   assertCanProcessPayment,
-  assertCanProcessPickup,
   assertCanReassignHandler,
   assertCanRefundOrderService,
 } from "@/modules/permissions/permissions";
@@ -829,33 +824,6 @@ export async function createOrderDropoffPhotoPresign({
   });
 }
 
-export async function createOrderPickupEventPresign({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PostOrderPickupEventPresignInput;
-  user: JWTPayload;
-}) {
-  assertCanProcessPickup(user);
-
-  const order = await db.query.ordersTable.findFirst({
-    where: { id: orderId },
-    columns: { id: true },
-  });
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  const key = `orders/${orderId}/pickup/${crypto.randomUUID()}`;
-  return createPresignedUploadUrl({
-    contentType: body.content_type,
-    key,
-  });
-}
-
 export async function saveOrderServicePhoto({
   orderId,
   serviceId,
@@ -957,117 +925,6 @@ export async function saveOrderDropoffPhoto({
     id: order.id,
     dropoff_photo_uploaded_at: order.dropoff_photo_uploaded_at,
     dropoff_photo_url: buildMediaUrl(order.dropoff_photo_path),
-  };
-}
-
-export async function createOrderPickupEvent({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PostOrderPickupEventInput;
-  user: JWTPayload;
-}) {
-  assertCanProcessPickup(user);
-
-  const uniqueServiceIds = Array.from(new Set(body.service_ids));
-  if (uniqueServiceIds.length === 0) {
-    throw new BadRequestException("At least one service must be picked up");
-  }
-
-  const [order, candidateServices] = await Promise.all([
-    db.query.ordersTable.findFirst({
-      where: { id: orderId },
-      columns: { id: true, pickup_code: true },
-    }),
-    db.query.ordersServicesTable.findMany({
-      where: {
-        order_id: orderId,
-        id: { in: uniqueServiceIds },
-      },
-      columns: {
-        id: true,
-        item_code: true,
-        status: true,
-      },
-    }),
-  ]);
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  if (body.pickup_code !== order.pickup_code) {
-    throw new BadRequestException("Invalid pickup code");
-  }
-
-  if (candidateServices.length !== uniqueServiceIds.length) {
-    throw new BadRequestException(
-      "One or more services do not belong to this order"
-    );
-  }
-
-  const notReady = candidateServices.filter(
-    (service) => service.status !== "ready_for_pickup"
-  );
-  if (notReady.length > 0) {
-    throw new BadRequestException(
-      `Services not ready for pickup: ${notReady
-        .map((service) => service.item_code ?? String(service.id))
-        .join(", ")}`
-    );
-  }
-
-  const [pickupEvent] = await db
-    .insert(orderPickupEventsTable)
-    .values({
-      order_id: orderId,
-      image_path: body.image_path,
-      picked_up_by: user.id,
-    })
-    .returning({
-      id: orderPickupEventsTable.id,
-      picked_up_at: orderPickupEventsTable.picked_up_at,
-    });
-
-  let pickupResult: { flippedIds: number[] };
-  try {
-    pickupResult = await completePickup(db, {
-      orderId,
-      serviceIds: uniqueServiceIds,
-      pickupEventId: pickupEvent.id,
-      by: user.id,
-      note: "Completed from order pickup desk",
-    });
-  } catch (error) {
-    await db
-      .delete(orderPickupEventsTable)
-      .where(eq(orderPickupEventsTable.id, pickupEvent.id));
-    throw error;
-  }
-
-  if (pickupResult.flippedIds.length !== uniqueServiceIds.length) {
-    if (pickupResult.flippedIds.length > 0) {
-      await db
-        .update(ordersServicesTable)
-        .set({ status: "ready_for_pickup", pickup_event_id: null })
-        .where(eq(ordersServicesTable.pickup_event_id, pickupEvent.id));
-    }
-    await db
-      .delete(orderPickupEventsTable)
-      .where(eq(orderPickupEventsTable.id, pickupEvent.id));
-    throw new BadRequestException(
-      "Another cashier already processed one of the selected items. Refresh and try again."
-    );
-  }
-
-  return {
-    id: pickupEvent.id,
-    image_url: buildMediaUrl(body.image_path),
-    order_id: orderId,
-    picked_up_at: pickupEvent.picked_up_at,
-    service_ids: uniqueServiceIds,
   };
 }
 

--- a/packages/server/src/modules/orders/order-pickup.service.ts
+++ b/packages/server/src/modules/orders/order-pickup.service.ts
@@ -1,0 +1,145 @@
+import { db } from "@/db";
+import { orderPickupEventsTable } from "@/db/schema";
+import { BadRequestException } from "@/errors";
+import type {
+  PostOrderPickupEventInput,
+  PostOrderPickupEventPresignInput,
+} from "@/modules/orders/order-admin.schema";
+import { completePickup } from "@/modules/orders/order-status-machine";
+import { assertCanProcessPickup } from "@/modules/permissions/permissions";
+import type { JWTPayload } from "@/types";
+import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
+
+// ADR-0005: the pickup code proves the customer in front of the cashier placed
+// this Order. It is a per-Order check, never a cross-Order lookup.
+function assertPickupCodeMatches(order: { pickup_code: string }, code: string) {
+  if (code !== order.pickup_code) {
+    throw new BadRequestException("Invalid pickup code");
+  }
+}
+
+export async function createOrderPickupEventPresign({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PostOrderPickupEventPresignInput;
+  user: JWTPayload;
+}) {
+  assertCanProcessPickup(user);
+
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: { id: true },
+  });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  const key = `orders/${orderId}/pickup/${crypto.randomUUID()}`;
+  return createPresignedUploadUrl({
+    contentType: body.content_type,
+    key,
+  });
+}
+
+export async function createOrderPickupEvent({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PostOrderPickupEventInput;
+  user: JWTPayload;
+}) {
+  assertCanProcessPickup(user);
+
+  const uniqueServiceIds = Array.from(new Set(body.service_ids));
+  if (uniqueServiceIds.length === 0) {
+    throw new BadRequestException("At least one service must be picked up");
+  }
+
+  const [order, candidateServices] = await Promise.all([
+    db.query.ordersTable.findFirst({
+      where: { id: orderId },
+      columns: { id: true, pickup_code: true },
+    }),
+    db.query.ordersServicesTable.findMany({
+      where: {
+        order_id: orderId,
+        id: { in: uniqueServiceIds },
+      },
+      columns: {
+        id: true,
+        item_code: true,
+        status: true,
+      },
+    }),
+  ]);
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  assertPickupCodeMatches(order, body.pickup_code);
+
+  if (candidateServices.length !== uniqueServiceIds.length) {
+    throw new BadRequestException(
+      "One or more services do not belong to this order"
+    );
+  }
+
+  const notReady = candidateServices.filter(
+    (service) => service.status !== "ready_for_pickup"
+  );
+  if (notReady.length > 0) {
+    throw new BadRequestException(
+      `Services not ready for pickup: ${notReady
+        .map((service) => service.item_code ?? String(service.id))
+        .join(", ")}`
+    );
+  }
+
+  // One transaction: insert the pickup event + flip the services together. A
+  // concurrent pickup of the same items leaves fewer rows ready, so completePickup
+  // returns a short flip — we throw and the transaction rolls the insert back.
+  const pickupEvent = await db.transaction(async (tx) => {
+    const [event] = await tx
+      .insert(orderPickupEventsTable)
+      .values({
+        order_id: orderId,
+        image_path: body.image_path,
+        picked_up_by: user.id,
+      })
+      .returning({
+        id: orderPickupEventsTable.id,
+        picked_up_at: orderPickupEventsTable.picked_up_at,
+      });
+
+    const { flippedIds } = await completePickup(tx, {
+      orderId,
+      serviceIds: uniqueServiceIds,
+      pickupEventId: event.id,
+      by: user.id,
+      note: "Completed from order pickup desk",
+    });
+
+    if (flippedIds.length !== uniqueServiceIds.length) {
+      throw new BadRequestException(
+        "Another cashier already processed one of the selected items. Refresh and try again."
+      );
+    }
+
+    return event;
+  });
+
+  return {
+    id: pickupEvent.id,
+    image_url: buildMediaUrl(body.image_path),
+    order_id: orderId,
+    picked_up_at: pickupEvent.picked_up_at,
+    service_ids: uniqueServiceIds,
+  };
+}

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -25,8 +25,6 @@ import {
 import {
   cancelOrder,
   createOrderDropoffPhotoPresign,
-  createOrderPickupEvent,
-  createOrderPickupEventPresign,
   createOrderRefund,
   createOrderServicePhotoPresign,
   deleteOrderServicePhoto,
@@ -42,6 +40,10 @@ import {
   updateOrderServiceHandler,
   updateOrderServiceStatus,
 } from "@/modules/orders/order-admin.service";
+import {
+  createOrderPickupEvent,
+  createOrderPickupEventPresign,
+} from "@/modules/orders/order-pickup.service";
 import { assertCanCreateOrder } from "@/modules/permissions/permissions";
 import { getStoreById } from "@/modules/stores/store.service";
 import { POSTOrderSchema } from "@/schema";


### PR DESCRIPTION
## Summary

Carves the pickup flow out of the 1200-line `order-admin.service.ts` into a dedicated `order-pickup.service.ts`, and lands ADR-0005's outstanding data-integrity fix. Continues the architecture-deepening plan (candidate #5).

## Changes

- **New `order-pickup.service.ts`** — owns `createOrderPickupEvent` (code-validate → readiness check → insert event + `completePickup`) and `createOrderPickupEventPresign`.
- **Transaction over compensating rollback** — pickup writes run inside `db.transaction`; the manual event-delete + service-reset on partial flip / error is gone. No external behavior change (same validations, error messages, concurrency guard).
- **Schema CHECK** `order_services_picked_up_requires_event_check` (`status != 'picked_up' OR pickup_event_id IS NOT NULL`) — the picked_up transition is now DB-enforced, not just application-enforced. Applied to dev via `push:dev` after a read-only data-safety query confirmed 0 violating rows.
- **Scope correction** — drop-off photo handlers stay in `order-admin.service.ts` (intake, not pickup; no ADR-0005 logic).
- Route imports repointed to the new module; orphaned imports cleaned. `order-admin.service.ts` 1249 → 1106 lines.

## Verification

- `tsc --noEmit` clean
- `bun test` 42/42 pass
- biome clean on touched files
- CHECK confirmed present in dev via `pg_constraint`

## Docs

- `architecture-deepening.md` #5 → ✅ Done
- ADR-0005 "Outstanding fix" → marked resolved