### PR TITLE
refactor(orders): extract reversal off-ramps into module

### DIFF
--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -35,7 +35,7 @@ Suggested order:
 | 3 | Permissions module (ADR-0004 capability table)  | ✅ Done      | See §3 + ADR-0006 |
 | 4 | Campaign eligibility → Campaigns module         | ⬜ Pending   | Independent |
 | 5 | Pickup module (ADR-0005 invariants)             | ✅ Done      | See §5 |
-| 6 | Reversal off-ramps (cancel + refund)            | ⬜ Pending   | Uses #1's `transitionOrderService` + `applyRefundTransition` seams |
+| 6 | Reversal off-ramps (cancel + refund)            | ✅ Done      | See §6 |
 | 7 | Collapse shallow CRUD services                  | ⬜ Pending   | Policy call, defer |
 | 8 | Product refunds + `refund_status` fix           | ⬜ Pending   | Bug; independent, schema change |
 
@@ -118,16 +118,16 @@ Web consumers updated:
 
 ## §2 — Split `order-admin.service.ts` ⬜
 
-**Problem**: 1106 lines (down from 1506; −#1 then −#5) still spanning queue +
-handler + refund + cancel + photo + payment. After #6 lands, residual is queue +
-photo + payment.
+**Problem**: 802 lines (down from 1506; −#1, −#5, −#6) now spanning queue +
+handler + photo + payment. Pickup and reversal are out.
 
 **Plan**: extract `order-queue.service.ts` and `order-photo.service.ts`.
 Maybe collapse `updateOrderPayment` into a small `order-payment.service.ts`
 or leave it.
 
-**Wait for**: #6 to land first — carves out reversal naturally. (#5 done — pickup
-already carved into `order-pickup.service.ts`.)
+**Unblocked**: #5 + #6 both landed (pickup → `order-pickup.service.ts`, reversal →
+`order-reversal.service.ts`). No remaining prerequisite — this is now the next
+natural candidate.
 
 ---
 
@@ -279,25 +279,57 @@ integration tests deferred (needs a test-DB strategy, same as #1).
 
 ---
 
-## §6 — Reversal off-ramps ⬜ (uses #1's `applyRefundTransition`)
+## §6 — Reversal off-ramps ✅
 
-**Problem**: Cancel + refund framed as disjoint off-ramps by ADR-0004 +
-CONTEXT.md, but live as sibling bare functions inside the giant file.
-`buildRefundItems` (largest-remainder allocation) is private helper used once.
-Zero shared scaffolding between cancel and refund despite same shape (terminal
-status + reason enum + status-log + recalc).
+**Goal**: gather the two Order off-ramps (cancel + refund) into one module so the
+reversal paths read in one place, out of the giant `order-admin.service.ts`.
 
-**Sketch**: `packages/server/src/modules/orders/order-reversal.service.ts`
-exports `cancelOrderServices` and `refundOrderServices`. Internal scaffold
-`applyTerminalExit({ orderId, items, terminalStatus, reason, audit })`
-shared between them. `buildRefundItems` collapses into the refund step.
-Payment-status gate asserted once at module entry, selects callable path.
+**Home**: `packages/server/src/modules/orders/order-reversal.service.ts`. Single
+file, peer of `order-pickup.service.ts`.
 
-**Design questions**
-- Should this module be a peer of #5 (own module), or a sub-folder
-  `orders/reversal/`?
-- Allocation math (`buildRefundItems`) stays in this module or moves to a
-  pure helper in `utils/`? It's used once — keep inline.
+**Scope correction — no shared scaffold**: the original sketch proposed an internal
+`applyTerminalExit` shared between cancel and refund, plus a payment-status gate "at
+module entry." Dropped after reading the code. Cancel and refund only *rhyme*
+("both terminal"); the concrete shared part — flip status + write status-log +
+recompute rollup — already lives in #1's seams (`transitionOrderService` for cancel,
+`applyRefundTransition` for refund). The payment-status gate already lives in #3's
+permissions (`assertCanCancelOrderService` = unpaid, `assertCanRefundOrderService` =
+paid). A new `applyTerminalExit` would either bypass those seams (re-implement
+transition validation = regression) or wrap them with no added logic (fails the
+deletion test). So #6 is **relocation-only** — the win is locality, not a new
+abstraction.
+
+**Exports** (names kept — only `routes/admin/orders.ts` imports them; rename = churn)
+
+| Symbol              | Role |
+|---------------------|------|
+| `createOrderRefund` | Refund flow: dup-check → caps → largest-remainder allocation → cap check → (tx) bump `refunded_amount` + insert `order_refunds`/`order_refund_items` + `applyRefundTransition`. |
+| `cancelOrder`       | Cancel flow: load non-terminal services → (tx) per-service `transitionOrderService(to:'cancelled')` + write `cancelled_at`. |
+
+Private to the module: `buildRefundItems` (largest-remainder rounding),
+`getOrderLineRefundCaps` (per-line discount allocation + already-refunded netting),
+`roundCurrencyUnit`. All three were refund-only; verified used nowhere else before
+moving.
+
+**Behavior changes vs pre-refactor**: none. Pure relocation — same validations,
+same error messages, same transactions, same permission gates. No status-machine or
+schema change.
+
+**Ported call sites**
+
+| Handler / Route | What changed |
+|-----------------|--------------|
+| `routes/admin/orders.ts` | The two reversal imports repointed from `order-admin.service` to `order-reversal.service`. Route bodies unchanged. |
+| `orders/order-admin.service.ts` | `createOrderRefund`, `cancelOrder` + 3 private refund helpers removed; orphaned imports cleaned (`orderRefundItemsTable`, `orderRefundsTable`, `applyRefundTransition`, `assertCanCancelOrderService`, `assertCanRefundOrderService`, the two reversal input types). 1106 → 802 lines (−27%). |
+
+**Tests**: existing suite 42/42 pass; server type-check (3/3 turbo tasks) + biome clean.
+
+**Outcomes**
+- Reversal reads end-to-end in one 319-line file.
+- `order-admin.service.ts` down to 802 lines (queue + handler + photo + payment).
+- #2 (split) now fully unblocked — pickup and reversal both carved out.
+- Rejected the sketch's `applyTerminalExit`: #1 seams + #3 permissions already own
+  everything it would have wrapped.
 
 ---
 

--- a/packages/server/src/modules/orders/order-admin.service.ts
+++ b/packages/server/src/modules/orders/order-admin.service.ts
@@ -1,8 +1,6 @@
 import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
-  orderRefundItemsTable,
-  orderRefundsTable,
   orderServiceHandlerLogsTable,
   orderServicesImagesTable,
   ordersServicesTable,
@@ -19,9 +17,7 @@ import type {
   PatchOrderPaymentInput,
   PatchOrderServiceHandlerInput,
   PatchOrderServiceStatusInput,
-  PostOrderCancelInput,
   PostOrderDropoffPhotoPresignInput,
-  PostOrderRefundInput,
   PostOrderServicePhotoInput,
   PostOrderServicePhotoPresignInput,
   PutOrderDropoffPhotoInput,
@@ -29,16 +25,13 @@ import type {
 import { normalizeOrderServiceQueueQuery } from "@/modules/orders/order-admin.schema";
 import { deriveOrderRefundStatus } from "@/modules/orders/order-refund-status";
 import {
-  applyRefundTransition,
   isTerminalOrderServiceStatus,
   summarizeOrderFulfillment,
   transitionOrderService,
 } from "@/modules/orders/order-status-machine";
 import {
-  assertCanCancelOrderService,
   assertCanProcessPayment,
   assertCanReassignHandler,
-  assertCanRefundOrderService,
 } from "@/modules/permissions/permissions";
 import type { JWTPayload } from "@/types";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
@@ -47,67 +40,6 @@ import { buildPaginationMeta } from "@/utils/pagination";
 import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
 
 const numericSearchRegex = /^\d+$/;
-
-function roundCurrencyUnit(value: number) {
-  return Math.round(value);
-}
-
-function buildRefundItems({
-  capsByServiceId,
-  items,
-}: {
-  capsByServiceId: Map<number, number>;
-  items: PostOrderRefundInput["items"];
-}) {
-  const refundItems = items.map((item) => {
-    const maxRefundable = capsByServiceId.get(item.order_service_id) ?? 0;
-    if (maxRefundable <= 0) {
-      throw new BadRequestException(
-        `Order service ${item.order_service_id} has no refundable amount remaining`
-      );
-    }
-
-    return {
-      ...item,
-      amount: Math.floor(maxRefundable),
-      preciseAmount: maxRefundable,
-    };
-  });
-
-  const roundedTotalRefundAmount = roundCurrencyUnit(
-    refundItems.reduce((sum, item) => sum + item.preciseAmount, 0)
-  );
-
-  let remainingWholeUnits =
-    roundedTotalRefundAmount -
-    refundItems.reduce((sum, item) => sum + item.amount, 0);
-
-  const itemsByLargestRemainder = [...refundItems].sort((left, right) => {
-    const remainderDiff =
-      right.preciseAmount - right.amount - (left.preciseAmount - left.amount);
-
-    return remainderDiff === 0
-      ? left.order_service_id - right.order_service_id
-      : remainderDiff;
-  });
-
-  for (const item of itemsByLargestRemainder) {
-    if (remainingWholeUnits <= 0) {
-      break;
-    }
-
-    item.amount += 1;
-    remainingWholeUnits -= 1;
-  }
-
-  if (remainingWholeUnits > 0) {
-    throw new BadRequestException(
-      "Refund amount could not be allocated across the selected services"
-    );
-  }
-
-  return refundItems.map(({ preciseAmount, ...item }) => item);
-}
 
 const getOrderServicePrepared = db.query.ordersServicesTable
   .findFirst({
@@ -129,65 +61,6 @@ async function getOrderServiceOrThrow(orderId: number, serviceId: number) {
   }
 
   return orderService;
-}
-
-async function getOrderLineRefundCaps(orderId: number) {
-  const [order, serviceRows, refundedRows] = await Promise.all([
-    db.query.ordersTable.findFirst({
-      where: { id: orderId },
-      columns: {
-        id: true,
-        total: true,
-        discount: true,
-      },
-    }),
-    db.query.ordersServicesTable.findMany({
-      where: { order_id: orderId },
-      columns: {
-        id: true,
-        subtotal: true,
-      },
-    }),
-    db
-      .select({
-        order_service_id: orderRefundItemsTable.order_service_id,
-        refunded_total: sql<string>`COALESCE(SUM(${orderRefundItemsTable.amount}), 0)`,
-      })
-      .from(orderRefundItemsTable)
-      .innerJoin(
-        orderRefundsTable,
-        eq(orderRefundItemsTable.order_refund_id, orderRefundsTable.id)
-      )
-      .where(eq(orderRefundsTable.order_id, orderId))
-      .groupBy(orderRefundItemsTable.order_service_id),
-  ]);
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  const grossTotal = Number(order.total ?? 0);
-  const orderDiscount = Number(order.discount);
-
-  const refundedByServiceId = new Map(
-    refundedRows.map((row) => [
-      row.order_service_id,
-      Number(row.refunded_total),
-    ])
-  );
-
-  return serviceRows.map((row) => {
-    const grossLine = Number(row.subtotal ?? 0);
-    const allocatedDiscount =
-      grossTotal > 0 ? (grossLine / grossTotal) * orderDiscount : 0;
-    const refundableGross = Math.max(0, grossLine - allocatedDiscount);
-    const alreadyRefunded = refundedByServiceId.get(row.id) ?? 0;
-
-    return {
-      maxRefundable: Math.max(0, refundableGross - alreadyRefunded),
-      order_service_id: row.id,
-    };
-  });
 }
 
 const queueRelationColumns = {
@@ -925,182 +798,5 @@ export async function saveOrderDropoffPhoto({
     id: order.id,
     dropoff_photo_uploaded_at: order.dropoff_photo_uploaded_at,
     dropoff_photo_url: buildMediaUrl(order.dropoff_photo_path),
-  };
-}
-
-export async function createOrderRefund({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PostOrderRefundInput;
-  user: JWTPayload;
-}) {
-  const uniqueServiceIds = [
-    ...new Set(body.items.map((item) => item.order_service_id)),
-  ];
-  if (uniqueServiceIds.length !== body.items.length) {
-    throw new BadRequestException(
-      "Duplicate order_service_id entries are not allowed"
-    );
-  }
-
-  const order = await db.query.ordersTable.findFirst({
-    where: { id: orderId },
-    columns: {
-      id: true,
-      payment_status: true,
-      paid_amount: true,
-      refunded_amount: true,
-    },
-  });
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  assertCanRefundOrderService(user, order);
-
-  const refundCaps = await getOrderLineRefundCaps(orderId);
-  const capsByServiceId = new Map(
-    refundCaps.map((item) => [item.order_service_id, item.maxRefundable])
-  );
-
-  const refundItems = buildRefundItems({
-    capsByServiceId,
-    items: body.items,
-  });
-
-  const totalRefundAmount = refundItems.reduce(
-    (sum, item) => sum + item.amount,
-    0
-  );
-
-  const refundablePaidAmount =
-    Number(order.paid_amount) - Number(order.refunded_amount);
-  if (totalRefundAmount > refundablePaidAmount) {
-    throw new BadRequestException(
-      "Refund exceeds remaining paid amount for this order"
-    );
-  }
-
-  const [refund] = await db.transaction(async (tx) => {
-    await tx
-      .update(ordersTable)
-      .set({
-        refunded_amount: sql`${ordersTable.refunded_amount} + ${totalRefundAmount}`,
-        updated_by: user.id,
-      })
-      .where(eq(ordersTable.id, orderId));
-
-    const [createdRefund] = await tx
-      .insert(orderRefundsTable)
-      .values({
-        order_id: orderId,
-        refunded_by: user.id,
-        total_amount: totalRefundAmount.toString(),
-        note: body.note,
-      })
-      .returning();
-
-    await tx.insert(orderRefundItemsTable).values(
-      refundItems.map((item) => ({
-        order_refund_id: createdRefund.id,
-        order_service_id: item.order_service_id,
-        amount: item.amount.toString(),
-        reason: item.reason,
-        note: item.note,
-      }))
-    );
-
-    await applyRefundTransition(tx, {
-      orderId,
-      by: user.id,
-      items: refundItems.map((item) => ({
-        serviceId: item.order_service_id,
-        note: item.note,
-      })),
-    });
-
-    return [createdRefund] as const;
-  });
-
-  return {
-    refund,
-    total_refund_amount: totalRefundAmount,
-  };
-}
-
-export async function cancelOrder({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PostOrderCancelInput;
-  user: JWTPayload;
-}) {
-  const order = await db.query.ordersTable.findFirst({
-    where: { id: orderId },
-    columns: {
-      id: true,
-      status: true,
-      payment_status: true,
-    },
-  });
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  assertCanCancelOrderService(user, order);
-
-  if (order.status === "cancelled") {
-    throw new BadRequestException("Order is already cancelled");
-  }
-
-  const allServices = await db.query.ordersServicesTable.findMany({
-    where: { order_id: orderId },
-    columns: { id: true, status: true },
-  });
-
-  const cancellableServices = allServices.filter(
-    (service) => !isTerminalOrderServiceStatus(service.status)
-  );
-
-  if (cancellableServices.length === 0) {
-    throw new BadRequestException("No cancellable services on this order");
-  }
-
-  const cancelReason = body.cancel_reason;
-  const cancelNote = body.cancel_note?.trim() || null;
-  const cancellableIds = cancellableServices.map((service) => service.id);
-
-  await db.transaction(async (tx) => {
-    for (const service of cancellableServices) {
-      await transitionOrderService(tx, {
-        orderId,
-        serviceId: service.id,
-        to: "cancelled",
-        by: user.id,
-        cancelReason,
-        cancelNote,
-        note: cancelNote ?? cancelReason,
-      });
-    }
-
-    await tx
-      .update(ordersTable)
-      .set({
-        cancelled_at: new Date(),
-        updated_by: user.id,
-      })
-      .where(eq(ordersTable.id, orderId));
-  });
-
-  return {
-    cancelled_service_ids: cancellableIds,
-    order_id: orderId,
   };
 }

--- a/packages/server/src/modules/orders/order-reversal.service.ts
+++ b/packages/server/src/modules/orders/order-reversal.service.ts
@@ -1,0 +1,319 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  orderRefundItemsTable,
+  orderRefundsTable,
+  ordersTable,
+} from "@/db/schema";
+import { BadRequestException } from "@/errors";
+import type {
+  PostOrderCancelInput,
+  PostOrderRefundInput,
+} from "@/modules/orders/order-admin.schema";
+import {
+  applyRefundTransition,
+  isTerminalOrderServiceStatus,
+  transitionOrderService,
+} from "@/modules/orders/order-status-machine";
+import {
+  assertCanCancelOrderService,
+  assertCanRefundOrderService,
+} from "@/modules/permissions/permissions";
+import type { JWTPayload } from "@/types";
+
+function roundCurrencyUnit(value: number) {
+  return Math.round(value);
+}
+
+function buildRefundItems({
+  capsByServiceId,
+  items,
+}: {
+  capsByServiceId: Map<number, number>;
+  items: PostOrderRefundInput["items"];
+}) {
+  const refundItems = items.map((item) => {
+    const maxRefundable = capsByServiceId.get(item.order_service_id) ?? 0;
+    if (maxRefundable <= 0) {
+      throw new BadRequestException(
+        `Order service ${item.order_service_id} has no refundable amount remaining`
+      );
+    }
+
+    return {
+      ...item,
+      amount: Math.floor(maxRefundable),
+      preciseAmount: maxRefundable,
+    };
+  });
+
+  const roundedTotalRefundAmount = roundCurrencyUnit(
+    refundItems.reduce((sum, item) => sum + item.preciseAmount, 0)
+  );
+
+  let remainingWholeUnits =
+    roundedTotalRefundAmount -
+    refundItems.reduce((sum, item) => sum + item.amount, 0);
+
+  const itemsByLargestRemainder = [...refundItems].sort((left, right) => {
+    const remainderDiff =
+      right.preciseAmount - right.amount - (left.preciseAmount - left.amount);
+
+    return remainderDiff === 0
+      ? left.order_service_id - right.order_service_id
+      : remainderDiff;
+  });
+
+  for (const item of itemsByLargestRemainder) {
+    if (remainingWholeUnits <= 0) {
+      break;
+    }
+
+    item.amount += 1;
+    remainingWholeUnits -= 1;
+  }
+
+  if (remainingWholeUnits > 0) {
+    throw new BadRequestException(
+      "Refund amount could not be allocated across the selected services"
+    );
+  }
+
+  return refundItems.map(({ preciseAmount, ...item }) => item);
+}
+
+async function getOrderLineRefundCaps(orderId: number) {
+  const [order, serviceRows, refundedRows] = await Promise.all([
+    db.query.ordersTable.findFirst({
+      where: { id: orderId },
+      columns: {
+        id: true,
+        total: true,
+        discount: true,
+      },
+    }),
+    db.query.ordersServicesTable.findMany({
+      where: { order_id: orderId },
+      columns: {
+        id: true,
+        subtotal: true,
+      },
+    }),
+    db
+      .select({
+        order_service_id: orderRefundItemsTable.order_service_id,
+        refunded_total: sql<string>`COALESCE(SUM(${orderRefundItemsTable.amount}), 0)`,
+      })
+      .from(orderRefundItemsTable)
+      .innerJoin(
+        orderRefundsTable,
+        eq(orderRefundItemsTable.order_refund_id, orderRefundsTable.id)
+      )
+      .where(eq(orderRefundsTable.order_id, orderId))
+      .groupBy(orderRefundItemsTable.order_service_id),
+  ]);
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  const grossTotal = Number(order.total ?? 0);
+  const orderDiscount = Number(order.discount);
+
+  const refundedByServiceId = new Map(
+    refundedRows.map((row) => [
+      row.order_service_id,
+      Number(row.refunded_total),
+    ])
+  );
+
+  return serviceRows.map((row) => {
+    const grossLine = Number(row.subtotal ?? 0);
+    const allocatedDiscount =
+      grossTotal > 0 ? (grossLine / grossTotal) * orderDiscount : 0;
+    const refundableGross = Math.max(0, grossLine - allocatedDiscount);
+    const alreadyRefunded = refundedByServiceId.get(row.id) ?? 0;
+
+    return {
+      maxRefundable: Math.max(0, refundableGross - alreadyRefunded),
+      order_service_id: row.id,
+    };
+  });
+}
+
+export async function createOrderRefund({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PostOrderRefundInput;
+  user: JWTPayload;
+}) {
+  const uniqueServiceIds = [
+    ...new Set(body.items.map((item) => item.order_service_id)),
+  ];
+  if (uniqueServiceIds.length !== body.items.length) {
+    throw new BadRequestException(
+      "Duplicate order_service_id entries are not allowed"
+    );
+  }
+
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: {
+      id: true,
+      payment_status: true,
+      paid_amount: true,
+      refunded_amount: true,
+    },
+  });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  assertCanRefundOrderService(user, order);
+
+  const refundCaps = await getOrderLineRefundCaps(orderId);
+  const capsByServiceId = new Map(
+    refundCaps.map((item) => [item.order_service_id, item.maxRefundable])
+  );
+
+  const refundItems = buildRefundItems({
+    capsByServiceId,
+    items: body.items,
+  });
+
+  const totalRefundAmount = refundItems.reduce(
+    (sum, item) => sum + item.amount,
+    0
+  );
+
+  const refundablePaidAmount =
+    Number(order.paid_amount) - Number(order.refunded_amount);
+  if (totalRefundAmount > refundablePaidAmount) {
+    throw new BadRequestException(
+      "Refund exceeds remaining paid amount for this order"
+    );
+  }
+
+  const [refund] = await db.transaction(async (tx) => {
+    await tx
+      .update(ordersTable)
+      .set({
+        refunded_amount: sql`${ordersTable.refunded_amount} + ${totalRefundAmount}`,
+        updated_by: user.id,
+      })
+      .where(eq(ordersTable.id, orderId));
+
+    const [createdRefund] = await tx
+      .insert(orderRefundsTable)
+      .values({
+        order_id: orderId,
+        refunded_by: user.id,
+        total_amount: totalRefundAmount.toString(),
+        note: body.note,
+      })
+      .returning();
+
+    await tx.insert(orderRefundItemsTable).values(
+      refundItems.map((item) => ({
+        order_refund_id: createdRefund.id,
+        order_service_id: item.order_service_id,
+        amount: item.amount.toString(),
+        reason: item.reason,
+        note: item.note,
+      }))
+    );
+
+    await applyRefundTransition(tx, {
+      orderId,
+      by: user.id,
+      items: refundItems.map((item) => ({
+        serviceId: item.order_service_id,
+        note: item.note,
+      })),
+    });
+
+    return [createdRefund] as const;
+  });
+
+  return {
+    refund,
+    total_refund_amount: totalRefundAmount,
+  };
+}
+
+export async function cancelOrder({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PostOrderCancelInput;
+  user: JWTPayload;
+}) {
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: {
+      id: true,
+      status: true,
+      payment_status: true,
+    },
+  });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  assertCanCancelOrderService(user, order);
+
+  if (order.status === "cancelled") {
+    throw new BadRequestException("Order is already cancelled");
+  }
+
+  const allServices = await db.query.ordersServicesTable.findMany({
+    where: { order_id: orderId },
+    columns: { id: true, status: true },
+  });
+
+  const cancellableServices = allServices.filter(
+    (service) => !isTerminalOrderServiceStatus(service.status)
+  );
+
+  if (cancellableServices.length === 0) {
+    throw new BadRequestException("No cancellable services on this order");
+  }
+
+  const cancelReason = body.cancel_reason;
+  const cancelNote = body.cancel_note?.trim() || null;
+  const cancellableIds = cancellableServices.map((service) => service.id);
+
+  await db.transaction(async (tx) => {
+    for (const service of cancellableServices) {
+      await transitionOrderService(tx, {
+        orderId,
+        serviceId: service.id,
+        to: "cancelled",
+        by: user.id,
+        cancelReason,
+        cancelNote,
+        note: cancelNote ?? cancelReason,
+      });
+    }
+
+    await tx
+      .update(ordersTable)
+      .set({
+        cancelled_at: new Date(),
+        updated_by: user.id,
+      })
+      .where(eq(ordersTable.id, orderId));
+  });
+
+  return {
+    cancelled_service_ids: cancellableIds,
+    order_id: orderId,
+  };
+}

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -23,9 +23,7 @@ import {
   PUTOrderDropoffPhotoSchema,
 } from "@/modules/orders/order-admin.schema";
 import {
-  cancelOrder,
   createOrderDropoffPhotoPresign,
-  createOrderRefund,
   createOrderServicePhotoPresign,
   deleteOrderServicePhoto,
   getMyOrderServices,
@@ -44,6 +42,10 @@ import {
   createOrderPickupEvent,
   createOrderPickupEventPresign,
 } from "@/modules/orders/order-pickup.service";
+import {
+  cancelOrder,
+  createOrderRefund,
+} from "@/modules/orders/order-reversal.service";
 import { assertCanCreateOrder } from "@/modules/permissions/permissions";
 import { getStoreById } from "@/modules/stores/store.service";
 import { POSTOrderSchema } from "@/schema";


### PR DESCRIPTION
## What
Extract the two Order off-ramps (cancel + refund) out of `order-admin.service.ts` into a new `order-reversal.service.ts`, peer of `order-pickup.service.ts`. Relocation only.

## Why
Architecture-deepening candidate #6. Reversal logic lived as sibling functions inside the 1106-line `order-admin.service.ts`; this gives it one readable home and shrinks that file to 802 lines.

## Notes
- No behavior change: same validations, error messages, transactions, permission gates.
- Rejected the planned `applyTerminalExit` scaffold — the status-machine seams (`transitionOrderService` / `applyRefundTransition`) and the permissions module already own the flip/log/recalc and payment-status gating it would have wrapped.

## Test plan
- type-check 3/3, biome clean
- server suite 42/42 pass