### PR TITLE
refactor(orders): dissolve order-admin.service into concern modules

### DIFF
--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -31,7 +31,7 @@ Suggested order:
 | # | Candidate                                       | Status      | Notes |
 |---|-------------------------------------------------|-------------|-------|
 | 1 | Order Status Machine                            | ✅ Done      | See §1 |
-| 2 | Split `order-admin.service.ts` by lifecycle     | ⬜ Pending   | Partially eased by #1; depends on #5 + #6 |
+| 2 | Split `order-admin.service.ts` by lifecycle     | ✅ Done      | See §2 |
 | 3 | Permissions module (ADR-0004 capability table)  | ✅ Done      | See §3 + ADR-0006 |
 | 4 | Campaign eligibility → Campaigns module         | ⬜ Pending   | Independent |
 | 5 | Pickup module (ADR-0005 invariants)             | ✅ Done      | See §5 |
@@ -116,18 +116,60 @@ Web consumers updated:
 
 ---
 
-## §2 — Split `order-admin.service.ts` ⬜
+## §2 — Split `order-admin.service.ts` ✅
 
-**Problem**: 802 lines (down from 1506; −#1, −#5, −#6) now spanning queue +
-handler + photo + payment. Pickup and reversal are out.
+**Goal**: dissolve the last grab-bag file. After #1/#5/#6 the residual 802-line
+`order-admin.service.ts` still mixed four unrelated concerns. Split each into a
+single-concern module and delete the file — no `order-admin` remnant.
 
-**Plan**: extract `order-queue.service.ts` and `order-photo.service.ts`.
-Maybe collapse `updateOrderPayment` into a small `order-payment.service.ts`
-or leave it.
+**Scope correction**: the original plan named only "queue + photo" and missed the
+**work/handler axis** (start work, reassign handler, change status) — a third
+mutation cluster — plus `getOrderDetailById`, an Order-aggregate read sitting in the
+wrong file. Real decomposition is four concerns, not two.
 
-**Unblocked**: #5 + #6 both landed (pickup → `order-pickup.service.ts`, reversal →
-`order-reversal.service.ts`). No remaining prerequisite — this is now the next
-natural candidate.
+**Result — `order-admin.service.ts` deleted, replaced by:**
+
+| Module | Owns |
+|--------|------|
+| `order-queue.service.ts` | OrderService work surface: reads (`getOrderServiceQueue`, `getMyOrderServices`, `getOrderServiceById`, `getOrderServiceByItemCode`) + lifecycle mutations (`startOrderServiceWork`, `updateOrderServiceHandler`, `updateOrderServiceStatus`) + queue helpers (relation columns, prepared lookups, search regex). |
+| `order-photo.service.ts` | All 5 photo handlers (service-photo presign/save/delete + dropoff presign/save). |
+| `order-payment.service.ts` | `updateOrderPayment`. |
+| `order.service.ts` (existing) | Gained `getOrderDetailById` — colocated with the other Order-aggregate ops (`createOrder`, `listOrders`). |
+
+**Shared guard**: `getOrderServiceOrThrow` (+ its prepared statement) crossed the
+queue/photo boundary (handler-reassign path + all three service-photo handlers).
+Moved to `order.repository.ts` — the orders DB layer both modules already depend on.
+One source of truth, correct service → repository direction, no sibling coupling.
+(Considered pure `findOrderServiceByIds` + a throw in each consumer; rejected as a
+duplicated guard for no gain.)
+
+**Behavior changes vs pre-refactor**: none. Pure relocation. Confirmed the
+processing-axis handlers (`startOrderServiceWork`, `updateOrderServiceStatus`,
+`saveOrderServicePhoto`) carry no permission assert — **intentional** per the
+ADR-0004 amendment 2026-06-04 (processing-axis open to all staff), documented in
+`permissions.ts`. The §3 "Ported call sites" table is **stale** on this point (it
+lists `assertCanSelfAssign` / `assertCanProcessOrderService` /
+`assertCanUploadServicePhotos`, which the amendment removed and which exist nowhere
+in the code); left as historical record, not re-enforced here.
+
+**Ported call sites**
+
+| File | What changed |
+|------|--------------|
+| `routes/admin/orders.ts` | One 14-symbol `order-admin.service` import split four ways: `order.service` (+`getOrderDetailById`), `order-queue.service`, `order-photo.service`, `order-payment.service`. Route bodies unchanged. |
+| `order.repository.ts` | Gained `getOrderServiceOrThrow` + prepared statement. |
+| `order-admin.service.ts` | **Deleted.** |
+
+`order-admin.schema.ts` stays — shared Zod schemas, package-exported, consumed by the
+new modules + routes.
+
+**Tests**: existing suite 42/42 pass; server type-check (3/3 turbo tasks) + biome clean.
+
+**Outcomes**
+- `order-admin.service.ts` gone. Orders domain is now single-concern modules: queue,
+  photo, payment, pickup, reversal, status-machine, + Order aggregate (`order.service`).
+- The #1 → #5 → #6 → #2 teardown is complete: the 1506-line god-file fully dissolved.
+- Surfaced (not fixed): §3 doc drift on processing-axis asserts.
 
 ---
 

--- a/packages/server/src/modules/orders/order-payment.service.ts
+++ b/packages/server/src/modules/orders/order-payment.service.ts
@@ -1,0 +1,68 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { ordersTable } from "@/db/schema";
+import { BadRequestException } from "@/errors";
+import type { PatchOrderPaymentInput } from "@/modules/orders/order-admin.schema";
+import { assertCanProcessPayment } from "@/modules/permissions/permissions";
+import type { JWTPayload } from "@/types";
+
+export async function updateOrderPayment({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PatchOrderPaymentInput;
+  user: JWTPayload;
+}) {
+  assertCanProcessPayment(user);
+
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: {
+      id: true,
+      total: true,
+      discount: true,
+      refunded_amount: true,
+      payment_status: true,
+      status: true,
+    },
+  });
+
+  if (!order) {
+    return null;
+  }
+
+  if (order.payment_status === "paid") {
+    throw new BadRequestException("Order has already been paid");
+  }
+
+  if (order.status === "cancelled") {
+    throw new BadRequestException(
+      "Cannot collect payment on a cancelled order"
+    );
+  }
+
+  const netDue =
+    Number(order.total ?? 0) -
+    Number(order.discount) -
+    Number(order.refunded_amount);
+
+  const rows = await db
+    .update(ordersTable)
+    .set({
+      payment_method_id: body.payment_method_id,
+      payment_status: "paid",
+      paid_amount: Math.max(netDue, 0).toString(),
+      paid_at: new Date(),
+      updated_by: user.id,
+    })
+    .where(eq(ordersTable.id, orderId))
+    .returning({
+      id: ordersTable.id,
+      payment_status: ordersTable.payment_status,
+      paid_amount: ordersTable.paid_amount,
+    });
+
+  return rows[0] ?? null;
+}

--- a/packages/server/src/modules/orders/order-photo.service.ts
+++ b/packages/server/src/modules/orders/order-photo.service.ts
@@ -1,0 +1,159 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { orderServicesImagesTable, ordersTable } from "@/db/schema";
+import { BadRequestException, ForbiddenException } from "@/errors";
+import { softDeleteOrderServiceImageById } from "@/modules/order-service-images/order-service-image.repository";
+import { getOrderServiceOrThrow } from "@/modules/orders/order.repository";
+import type {
+  PostOrderDropoffPhotoPresignInput,
+  PostOrderServicePhotoInput,
+  PostOrderServicePhotoPresignInput,
+  PutOrderDropoffPhotoInput,
+} from "@/modules/orders/order-admin.schema";
+import type { JWTPayload } from "@/types";
+import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
+
+export async function createOrderServicePhotoPresign({
+  orderId,
+  serviceId,
+  body,
+}: {
+  orderId: number;
+  serviceId: number;
+  body: PostOrderServicePhotoPresignInput;
+}) {
+  await getOrderServiceOrThrow(orderId, serviceId);
+
+  const key = `orders/${orderId}/services/${serviceId}/${crypto.randomUUID()}`;
+  return createPresignedUploadUrl({
+    contentType: body.content_type,
+    key,
+  });
+}
+
+export async function createOrderDropoffPhotoPresign({
+  orderId,
+  body,
+}: {
+  orderId: number;
+  body: PostOrderDropoffPhotoPresignInput;
+}) {
+  const order = await db.query.ordersTable.findFirst({
+    where: { id: orderId },
+    columns: { id: true },
+  });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  const key = `orders/${orderId}/dropoff/${crypto.randomUUID()}`;
+  return createPresignedUploadUrl({
+    contentType: body.content_type,
+    key,
+  });
+}
+
+export async function saveOrderServicePhoto({
+  orderId,
+  serviceId,
+  body,
+  user,
+}: {
+  orderId: number;
+  serviceId: number;
+  body: PostOrderServicePhotoInput;
+  user: JWTPayload;
+}) {
+  await getOrderServiceOrThrow(orderId, serviceId);
+
+  const [photo] = await db
+    .insert(orderServicesImagesTable)
+    .values({
+      order_service_id: serviceId,
+      image_path: body.image_path,
+      note: body.note ?? null,
+      uploaded_by: user.id,
+    })
+    .returning();
+
+  return {
+    ...photo,
+    image_url: buildMediaUrl(photo.image_path),
+  };
+}
+
+export async function deleteOrderServicePhoto({
+  orderId,
+  serviceId,
+  photoId,
+  user,
+}: {
+  orderId: number;
+  serviceId: number;
+  photoId: number;
+  user: JWTPayload;
+}) {
+  await getOrderServiceOrThrow(orderId, serviceId);
+
+  const photo = await db.query.orderServicesImagesTable.findFirst({
+    where: {
+      id: photoId,
+      order_service_id: serviceId,
+      deleted_at: { isNull: true },
+    },
+    columns: { id: true, uploaded_by: true },
+  });
+
+  if (!photo) {
+    throw new BadRequestException("Photo not found");
+  }
+
+  if (user.role !== "admin" && photo.uploaded_by !== user.id) {
+    throw new ForbiddenException(
+      "Only the uploader or an admin can delete this photo"
+    );
+  }
+
+  const [deleted] = await softDeleteOrderServiceImageById(photoId, user.id);
+  if (!deleted) {
+    throw new BadRequestException("Photo already deleted");
+  }
+
+  return { id: deleted.id };
+}
+
+export async function saveOrderDropoffPhoto({
+  orderId,
+  body,
+  user,
+}: {
+  orderId: number;
+  body: PutOrderDropoffPhotoInput;
+  user: JWTPayload;
+}) {
+  const [order] = await db
+    .update(ordersTable)
+    .set({
+      dropoff_photo_path: body.image_path,
+      dropoff_photo_uploaded_at: new Date(),
+      dropoff_photo_uploaded_by: user.id,
+      updated_by: user.id,
+    })
+    .where(eq(ordersTable.id, orderId))
+    .returning({
+      id: ordersTable.id,
+      dropoff_photo_uploaded_at: ordersTable.dropoff_photo_uploaded_at,
+      dropoff_photo_path: ordersTable.dropoff_photo_path,
+    });
+
+  if (!order) {
+    throw new BadRequestException("Order not found");
+  }
+
+  return {
+    id: order.id,
+    dropoff_photo_uploaded_at: order.dropoff_photo_uploaded_at,
+    dropoff_photo_url: buildMediaUrl(order.dropoff_photo_path),
+  };
+}

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -2,7 +2,6 @@ import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
   orderServiceHandlerLogsTable,
-  orderServicesImagesTable,
   ordersServicesTable,
   ordersTable,
   servicesTable,
@@ -10,58 +9,25 @@ import {
   usersTable,
 } from "@/db/schema";
 import { BadRequestException, ForbiddenException } from "@/errors";
-import { softDeleteOrderServiceImageById } from "@/modules/order-service-images/order-service-image.repository";
+import { getOrderServiceOrThrow } from "@/modules/orders/order.repository";
 import type {
   GetMyOrderServicesQuery,
   GetOrderServiceQueueQuery,
-  PatchOrderPaymentInput,
   PatchOrderServiceHandlerInput,
   PatchOrderServiceStatusInput,
-  PostOrderDropoffPhotoPresignInput,
-  PostOrderServicePhotoInput,
-  PostOrderServicePhotoPresignInput,
-  PutOrderDropoffPhotoInput,
 } from "@/modules/orders/order-admin.schema";
 import { normalizeOrderServiceQueueQuery } from "@/modules/orders/order-admin.schema";
-import { deriveOrderRefundStatus } from "@/modules/orders/order-refund-status";
 import {
   isTerminalOrderServiceStatus,
-  summarizeOrderFulfillment,
   transitionOrderService,
 } from "@/modules/orders/order-status-machine";
-import {
-  assertCanProcessPayment,
-  assertCanReassignHandler,
-} from "@/modules/permissions/permissions";
+import { assertCanReassignHandler } from "@/modules/permissions/permissions";
 import type { JWTPayload } from "@/types";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
 import { jakartaDayEnd, jakartaDayStart } from "@/utils/date";
 import { buildPaginationMeta } from "@/utils/pagination";
-import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
 
 const numericSearchRegex = /^\d+$/;
-
-const getOrderServicePrepared = db.query.ordersServicesTable
-  .findFirst({
-    where: {
-      order_id: { eq: sql.placeholder("order_id") },
-      id: { eq: sql.placeholder("id") },
-    },
-  })
-  .prepare("get_order_service");
-
-async function getOrderServiceOrThrow(orderId: number, serviceId: number) {
-  const orderService = await getOrderServicePrepared.execute({
-    order_id: orderId,
-    id: serviceId,
-  });
-
-  if (!orderService) {
-    throw new BadRequestException("Order service not found for this order");
-  }
-
-  return orderService;
-}
 
 const queueRelationColumns = {
   order: {
@@ -286,195 +252,6 @@ export async function getOrderServiceQueue(
   };
 }
 
-export async function getOrderDetailById(id: number) {
-  const detail = await db.query.ordersTable.findFirst({
-    where: { id },
-    with: {
-      campaigns: {
-        with: {
-          campaign: true,
-        },
-        orderBy: { id: "asc" },
-      },
-      customer: true,
-      paymentMethod: true,
-      pickupEvents: {
-        with: {
-          pickedUpBy: {
-            columns: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-        orderBy: { picked_up_at: "asc" },
-      },
-      products: {
-        with: {
-          product: true,
-        },
-      },
-      refunds: {
-        with: {
-          items: true,
-          refundedBy: {
-            columns: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-        orderBy: { id: "asc" },
-      },
-      services: {
-        with: {
-          handler: {
-            columns: {
-              id: true,
-              name: true,
-            },
-          },
-          handlerLogs: {
-            with: {
-              changedBy: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-              fromHandler: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-              toHandler: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-            },
-            orderBy: { id: "asc" },
-          },
-          images: {
-            where: { deleted_at: { isNull: true } },
-            orderBy: { id: "asc" },
-          },
-          refundItems: true,
-          service: true,
-          statusLogs: {
-            with: {
-              changedBy: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-            },
-            orderBy: { id: "asc" },
-          },
-        },
-        orderBy: { id: "asc" },
-      },
-      store: true,
-    },
-  });
-
-  if (!detail) {
-    return null;
-  }
-
-  const { pickup_code: _pickup_code, ...detailWithoutPickupCode } = detail;
-
-  return {
-    ...detailWithoutPickupCode,
-    dropoff_photo_url: buildMediaUrl(detail.dropoff_photo_path),
-    refund_status: deriveOrderRefundStatus({
-      paid_amount: detail.paid_amount,
-      refunded_amount: detail.refunded_amount,
-    }),
-    pickup_events: detail.pickupEvents.map((event) => ({
-      created_at: event.created_at,
-      id: event.id,
-      image_url: buildMediaUrl(event.image_path),
-      picked_up_at: event.picked_up_at,
-      picked_up_by: event.pickedUpBy,
-    })),
-    services: detail.services.map((service) => ({
-      ...service,
-      images: service.images.map((image) => ({
-        ...image,
-        image_url: buildMediaUrl(image.image_path),
-      })),
-    })),
-    fulfillment: summarizeOrderFulfillment(
-      detail.services.map((service) => service.status)
-    ),
-  };
-}
-
-export async function updateOrderPayment({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PatchOrderPaymentInput;
-  user: JWTPayload;
-}) {
-  assertCanProcessPayment(user);
-
-  const order = await db.query.ordersTable.findFirst({
-    where: { id: orderId },
-    columns: {
-      id: true,
-      total: true,
-      discount: true,
-      refunded_amount: true,
-      payment_status: true,
-      status: true,
-    },
-  });
-
-  if (!order) {
-    return null;
-  }
-
-  if (order.payment_status === "paid") {
-    throw new BadRequestException("Order has already been paid");
-  }
-
-  if (order.status === "cancelled") {
-    throw new BadRequestException(
-      "Cannot collect payment on a cancelled order"
-    );
-  }
-
-  const netDue =
-    Number(order.total ?? 0) -
-    Number(order.discount) -
-    Number(order.refunded_amount);
-
-  const rows = await db
-    .update(ordersTable)
-    .set({
-      payment_method_id: body.payment_method_id,
-      payment_status: "paid",
-      paid_amount: Math.max(netDue, 0).toString(),
-      paid_at: new Date(),
-      updated_by: user.id,
-    })
-    .where(eq(ordersTable.id, orderId))
-    .returning({
-      id: ordersTable.id,
-      payment_status: ordersTable.payment_status,
-      paid_amount: ordersTable.paid_amount,
-    });
-
-  return rows[0] ?? null;
-}
-
 export async function startOrderServiceWork({
   orderId,
   serviceId,
@@ -653,150 +430,5 @@ export async function updateOrderServiceStatus({
     from_status: fromStatus,
     order_service_id: serviceId,
     to_status: body.status,
-  };
-}
-
-export async function createOrderServicePhotoPresign({
-  orderId,
-  serviceId,
-  body,
-}: {
-  orderId: number;
-  serviceId: number;
-  body: PostOrderServicePhotoPresignInput;
-}) {
-  await getOrderServiceOrThrow(orderId, serviceId);
-
-  const key = `orders/${orderId}/services/${serviceId}/${crypto.randomUUID()}`;
-  return createPresignedUploadUrl({
-    contentType: body.content_type,
-    key,
-  });
-}
-
-export async function createOrderDropoffPhotoPresign({
-  orderId,
-  body,
-}: {
-  orderId: number;
-  body: PostOrderDropoffPhotoPresignInput;
-}) {
-  const order = await db.query.ordersTable.findFirst({
-    where: { id: orderId },
-    columns: { id: true },
-  });
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  const key = `orders/${orderId}/dropoff/${crypto.randomUUID()}`;
-  return createPresignedUploadUrl({
-    contentType: body.content_type,
-    key,
-  });
-}
-
-export async function saveOrderServicePhoto({
-  orderId,
-  serviceId,
-  body,
-  user,
-}: {
-  orderId: number;
-  serviceId: number;
-  body: PostOrderServicePhotoInput;
-  user: JWTPayload;
-}) {
-  await getOrderServiceOrThrow(orderId, serviceId);
-
-  const [photo] = await db
-    .insert(orderServicesImagesTable)
-    .values({
-      order_service_id: serviceId,
-      image_path: body.image_path,
-      note: body.note ?? null,
-      uploaded_by: user.id,
-    })
-    .returning();
-
-  return {
-    ...photo,
-    image_url: buildMediaUrl(photo.image_path),
-  };
-}
-
-export async function deleteOrderServicePhoto({
-  orderId,
-  serviceId,
-  photoId,
-  user,
-}: {
-  orderId: number;
-  serviceId: number;
-  photoId: number;
-  user: JWTPayload;
-}) {
-  await getOrderServiceOrThrow(orderId, serviceId);
-
-  const photo = await db.query.orderServicesImagesTable.findFirst({
-    where: {
-      id: photoId,
-      order_service_id: serviceId,
-      deleted_at: { isNull: true },
-    },
-    columns: { id: true, uploaded_by: true },
-  });
-
-  if (!photo) {
-    throw new BadRequestException("Photo not found");
-  }
-
-  if (user.role !== "admin" && photo.uploaded_by !== user.id) {
-    throw new ForbiddenException(
-      "Only the uploader or an admin can delete this photo"
-    );
-  }
-
-  const [deleted] = await softDeleteOrderServiceImageById(photoId, user.id);
-  if (!deleted) {
-    throw new BadRequestException("Photo already deleted");
-  }
-
-  return { id: deleted.id };
-}
-
-export async function saveOrderDropoffPhoto({
-  orderId,
-  body,
-  user,
-}: {
-  orderId: number;
-  body: PutOrderDropoffPhotoInput;
-  user: JWTPayload;
-}) {
-  const [order] = await db
-    .update(ordersTable)
-    .set({
-      dropoff_photo_path: body.image_path,
-      dropoff_photo_uploaded_at: new Date(),
-      dropoff_photo_uploaded_by: user.id,
-      updated_by: user.id,
-    })
-    .where(eq(ordersTable.id, orderId))
-    .returning({
-      id: ordersTable.id,
-      dropoff_photo_uploaded_at: ordersTable.dropoff_photo_uploaded_at,
-      dropoff_photo_path: ordersTable.dropoff_photo_path,
-    });
-
-  if (!order) {
-    throw new BadRequestException("Order not found");
-  }
-
-  return {
-    id: order.id,
-    dropoff_photo_uploaded_at: order.dropoff_photo_uploaded_at,
-    dropoff_photo_url: buildMediaUrl(order.dropoff_photo_path),
   };
 }

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -7,6 +7,7 @@ import {
   ordersServicesTable,
   ordersTable,
 } from "@/db/schema";
+import { BadRequestException } from "@/errors";
 import type { NormalizedOrderListQuery } from "@/modules/orders/order.schema";
 import {
   deriveOrderRefundStatus,
@@ -16,6 +17,31 @@ import { summarizeOrderFulfillment } from "@/modules/orders/order-status-machine
 import { jakartaDayEnd, jakartaDayStart } from "@/utils/date";
 
 export type OrderTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+const getOrderServicePrepared = db.query.ordersServicesTable
+  .findFirst({
+    where: {
+      order_id: { eq: sql.placeholder("order_id") },
+      id: { eq: sql.placeholder("id") },
+    },
+  })
+  .prepare("get_order_service");
+
+export async function getOrderServiceOrThrow(
+  orderId: number,
+  serviceId: number
+) {
+  const orderService = await getOrderServicePrepared.execute({
+    order_id: orderId,
+    id: serviceId,
+  });
+
+  if (!orderService) {
+    throw new BadRequestException("Order service not found for this order");
+  }
+
+  return orderService;
+}
 
 export interface OrderListItem {
   code: string;

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -15,6 +15,8 @@ import {
   type GetOrdersQuery,
   normalizeOrderListQuery,
 } from "@/modules/orders/order.schema";
+import { deriveOrderRefundStatus } from "@/modules/orders/order-refund-status";
+import { summarizeOrderFulfillment } from "@/modules/orders/order-status-machine";
 import {
   decrementProductStock,
   findProducts,
@@ -27,6 +29,7 @@ import type { Store } from "@/types/entity";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
 import { jakartaNow } from "@/utils/date";
 import { buildPaginationMeta } from "@/utils/pagination";
+import { buildMediaUrl } from "@/utils/s3";
 
 function formatOrderCode(storeCode: string, dateStr: string, sequence: number) {
   return `#${storeCode}/${dateStr}/${sequence}`;
@@ -458,4 +461,132 @@ export async function createOrder(
       total_after_discount: netTotal,
     };
   });
+}
+
+export async function getOrderDetailById(id: number) {
+  const detail = await db.query.ordersTable.findFirst({
+    where: { id },
+    with: {
+      campaigns: {
+        with: {
+          campaign: true,
+        },
+        orderBy: { id: "asc" },
+      },
+      customer: true,
+      paymentMethod: true,
+      pickupEvents: {
+        with: {
+          pickedUpBy: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        orderBy: { picked_up_at: "asc" },
+      },
+      products: {
+        with: {
+          product: true,
+        },
+      },
+      refunds: {
+        with: {
+          items: true,
+          refundedBy: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        orderBy: { id: "asc" },
+      },
+      services: {
+        with: {
+          handler: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+          handlerLogs: {
+            with: {
+              changedBy: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+              fromHandler: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+              toHandler: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+            orderBy: { id: "asc" },
+          },
+          images: {
+            where: { deleted_at: { isNull: true } },
+            orderBy: { id: "asc" },
+          },
+          refundItems: true,
+          service: true,
+          statusLogs: {
+            with: {
+              changedBy: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+            orderBy: { id: "asc" },
+          },
+        },
+        orderBy: { id: "asc" },
+      },
+      store: true,
+    },
+  });
+
+  if (!detail) {
+    return null;
+  }
+
+  const { pickup_code: _pickup_code, ...detailWithoutPickupCode } = detail;
+
+  return {
+    ...detailWithoutPickupCode,
+    dropoff_photo_url: buildMediaUrl(detail.dropoff_photo_path),
+    refund_status: deriveOrderRefundStatus({
+      paid_amount: detail.paid_amount,
+      refunded_amount: detail.refunded_amount,
+    }),
+    pickup_events: detail.pickupEvents.map((event) => ({
+      created_at: event.created_at,
+      id: event.id,
+      image_url: buildMediaUrl(event.image_path),
+      picked_up_at: event.picked_up_at,
+      picked_up_by: event.pickedUpBy,
+    })),
+    services: detail.services.map((service) => ({
+      ...service,
+      images: service.images.map((image) => ({
+        ...image,
+        image_url: buildMediaUrl(image.image_path),
+      })),
+    })),
+    fulfillment: summarizeOrderFulfillment(
+      detail.services.map((service) => service.status)
+    ),
+  };
 }

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -2,7 +2,11 @@ import { Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import { NotFoundException } from "@/errors";
 import { GETOrdersQuerySchema } from "@/modules/orders/order.schema";
-import { createOrder, listOrders } from "@/modules/orders/order.service";
+import {
+  createOrder,
+  getOrderDetailById,
+  listOrders,
+} from "@/modules/orders/order.service";
 import {
   GETMyOrderServicesQuerySchema,
   GETOrderByItemCodeQuerySchema,
@@ -22,26 +26,27 @@ import {
   POSTOrderServicePhotoSchema,
   PUTOrderDropoffPhotoSchema,
 } from "@/modules/orders/order-admin.schema";
+import { updateOrderPayment } from "@/modules/orders/order-payment.service";
 import {
   createOrderDropoffPhotoPresign,
   createOrderServicePhotoPresign,
   deleteOrderServicePhoto,
-  getMyOrderServices,
-  getOrderDetailById,
-  getOrderServiceById,
-  getOrderServiceByItemCode,
-  getOrderServiceQueue,
   saveOrderDropoffPhoto,
   saveOrderServicePhoto,
-  startOrderServiceWork,
-  updateOrderPayment,
-  updateOrderServiceHandler,
-  updateOrderServiceStatus,
-} from "@/modules/orders/order-admin.service";
+} from "@/modules/orders/order-photo.service";
 import {
   createOrderPickupEvent,
   createOrderPickupEventPresign,
 } from "@/modules/orders/order-pickup.service";
+import {
+  getMyOrderServices,
+  getOrderServiceById,
+  getOrderServiceByItemCode,
+  getOrderServiceQueue,
+  startOrderServiceWork,
+  updateOrderServiceHandler,
+  updateOrderServiceStatus,
+} from "@/modules/orders/order-queue.service";
 import {
   cancelOrder,
   createOrderRefund,


### PR DESCRIPTION
## What
Architecture-deepening #2: dissolve the residual `order-admin.service.ts` into single-concern modules and delete it.
- `order-queue.service.ts` — OrderService reads + work-axis (start / handler / status)
- `order-photo.service.ts` — the 5 photo handlers
- `order-payment.service.ts` — `updateOrderPayment`
- `order.service.ts` += `getOrderDetailById` (Order-aggregate read)
- `order.repository.ts` += `getOrderServiceOrThrow` (guard shared across queue + photo)

## Why
Completes the #1 / #5 / #6 / #2 teardown of the original 1506-line god-file. (#6 reversal landed separately in #38.) The orders domain is now all single-concern modules.

## Notes
- Pure relocation, no behavior change: same validations, error messages, transactions, permission gates. `routes/admin/orders.ts` repointed (route bodies unchanged); `order-admin.schema.ts` kept (package-exported).
- Surfaced (not fixed): the plan §3 ported-asserts table is stale — `assertCanSelfAssign` / `assertCanProcessOrderService` / `assertCanUploadServicePhotos` exist nowhere in the code; processing-axis is intentionally ungated per the ADR-0004 amendment (`permissions.ts` lines 53-55).

## Test plan
- type-check 3/3, biome clean
- server suite 42/42 pass