### PR TITLE
refactor(campaigns): move eligibility out of order.service

### DIFF
--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -303,10 +303,12 @@ same throw semantics. Pure relocation + the provably-equivalent tx→db read swa
 | `campaigns/campaign.service.ts` | Gained `assertCampaignUsable` + `getUsableCampaigns`; imports `NotFoundException` + `findCampaignsByIdsWithEligibility`. |
 | `orders/order.service.ts` | `loadAndValidateCampaigns`, `assertCampaignUsable`, the `ValidatedCampaign` type removed. `resolveDiscount` drops its `tx` param, calls `getUsableCampaigns`, stacks the flattened campaigns directly. Orphaned `OrderTx` import removed. `createOrder` call site drops the `tx` arg. |
 
-**Tests**: `campaign-eligibility.test.ts` — 7 unit tests via `bun:test` (happy
-path + 5 reject branches + store-scope allow). Full server suite 49/49 pass;
-type-check 3/3 turbo tasks + biome clean. Loader (`getUsableCampaigns`) is
-DB-touching — integration test deferred, same as #1/#5.
+**Tests**: `campaign-eligibility.test.ts` — 10 unit tests via `bun:test` (happy
+path + 5 reject branches + store-scope allow + 3 inclusive-boundary allows that
+pin the strict `<`/`>` operators: `now === starts_at`, `now === ends_at`,
+`grossTotal === min_order_total`). Full server suite 52/52 pass; type-check 3/3
+turbo tasks + biome clean. Loader (`getUsableCampaigns`) is DB-touching —
+integration test deferred, same as #1/#5.
 
 **Outcomes**
 - Campaign eligibility reads in the Campaigns module; Order no longer owns it.

--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -33,7 +33,7 @@ Suggested order:
 | 1 | Order Status Machine                            | ✅ Done      | See §1 |
 | 2 | Split `order-admin.service.ts` by lifecycle     | ✅ Done      | See §2 |
 | 3 | Permissions module (ADR-0004 capability table)  | ✅ Done      | See §3 + ADR-0006 |
-| 4 | Campaign eligibility → Campaigns module         | ⬜ Pending   | Independent |
+| 4 | Campaign eligibility → Campaigns module         | ✅ Done      | See §4 |
 | 5 | Pickup module (ADR-0005 invariants)             | ✅ Done      | See §5 |
 | 6 | Reversal off-ramps (cancel + refund)            | ✅ Done      | See §6 |
 | 7 | Collapse shallow CRUD services                  | ⬜ Pending   | Policy call, defer |
@@ -244,21 +244,80 @@ payment-status-deny. Full server suite 80/80 pass.
 
 ---
 
-## §4 — Campaign eligibility → Campaigns ⬜ (independent)
+## §4 — Campaign eligibility → Campaigns ✅
 
-**Problem**: `order.service.ts:120-193` (`loadAndValidateCampaigns`,
-`assertCampaignUsable`) lives in Order. Campaigns module owns CRUD only,
-not eligibility. Future POS price-preview would duplicate the rules.
+**Goal**: `loadAndValidateCampaigns` + `assertCampaignUsable` lived in
+`order.service.ts` — Order owned Campaign eligibility while the Campaigns module
+owned only CRUD. Move both into `campaigns/campaign.service.ts` so eligibility
+reads in the module that owns the concept.
 
-**Sketch**: move both into `campaigns/campaign.service.ts` as
-`loadApplicableCampaigns({ campaignIds, storeId, serviceIds, subtotal, when })`.
-Returns ready-to-apply Campaigns or typed validation error.
+**Premise correction**: the sketch justified the move partly by "future POS
+price-preview would duplicate the rules." Reading the code: the preview **already
+exists and is client-side** (`apps/web/.../transactions/lib/transactions.ts` →
+`getStackedDiscount` → `stackCampaignDiscounts`). The part worth sharing — the
+discount **math** — is *already* DRY via the pure `@fresclean/api/schema` export.
+What's duplicated is the eligibility *rules* (server validates active+dates+store+
+min-order; web's `isCampaignAvailable` checks active+dates only — a subset), and a
+client preview can't call a server module without a new endpoint that doesn't
+exist. So the move stands on **locality alone**, not on de-duplication.
 
-**Design questions**
-- Return shape: `{ applicable: Campaign[]; rejected: Array<{ id, reason }> }`
-  vs throw-on-first-rejection. POS price-preview may want non-throwing.
-- Subtotal computation: caller passes, or campaigns module re-derives from
-  service IDs?
+**Home**: `packages/server/src/modules/campaigns/campaign.service.ts`.
+
+**Exports added**
+
+| Symbol | Role |
+|--------|------|
+| `assertCampaignUsable(campaign, ctx)` | Pure rule — active / started / not-ended / store-scoped / min-order. Throws `BadRequestException`. Exported so the branches unit-test without a DB. |
+| `getUsableCampaigns({ campaignIds, grossTotal, storeId, storeCode })` | DB load (`findCampaignsByIdsWithEligibility`) → missing-id check (`NotFoundException`) → `assertCampaignUsable` per campaign → returns discount-ready `{ ...campaign, eligible_service_ids }[]`. |
+
+**Design decisions (grilled)**
+
+- **Throw-on-first-rejection** kept (not the sketch's `{ applicable, rejected }`).
+  Only caller is `createOrder`, which wants atomic fail; the phantom non-throwing
+  consumer is YAGNI. Add a non-throwing variant when a *server* preview endpoint
+  actually lands.
+- **`db` read, not `tx`-threaded.** Used the already-built-but-unused
+  `findCampaignsByIdsWithEligibility` (db-bound) and dropped `tx` from
+  `resolveDiscount`. Postgres default isolation is READ COMMITTED and nothing in
+  the order tx writes campaigns before this read, so in-tx vs out-of-tx is
+  outcome-identical. Closes the loop on the orphaned repo fn; deletes the
+  duplicate inline `tx.query`.
+- **Discount-ready return**: module flattens `eligibleServices → eligible_service_ids`
+  and drops the validation-only `stores` relation, so `order.service` no longer
+  re-maps and the campaign relation shape stays inside Campaigns.
+- **Subtotal** passed by caller (`grossTotal`) — Campaigns can't re-derive it
+  (gross includes *products*, which Campaigns knows nothing about).
+- **`now`**: the pure `assertCampaignUsable` takes `now` in its ctx (the test pins
+  dates there); `getUsableCampaigns` computes `new Date()` internally — no unused
+  injection seam on the loader. Plain instant comparison, no Jakarta-TZ rule.
+- **`CampaignEligibility`** is a `Pick<>` of the repo row type (not a hand-rolled
+  literal) — drift-safe, and the validator's read-surface stays explicit.
+
+**Behavior changes vs pre-refactor**: none. Same validations, same error messages,
+same throw semantics. Pure relocation + the provably-equivalent tx→db read swap.
+
+**Ported call sites**
+
+| File | What changed |
+|------|--------------|
+| `campaigns/campaign.service.ts` | Gained `assertCampaignUsable` + `getUsableCampaigns`; imports `NotFoundException` + `findCampaignsByIdsWithEligibility`. |
+| `orders/order.service.ts` | `loadAndValidateCampaigns`, `assertCampaignUsable`, the `ValidatedCampaign` type removed. `resolveDiscount` drops its `tx` param, calls `getUsableCampaigns`, stacks the flattened campaigns directly. Orphaned `OrderTx` import removed. `createOrder` call site drops the `tx` arg. |
+
+**Tests**: `campaign-eligibility.test.ts` — 7 unit tests via `bun:test` (happy
+path + 5 reject branches + store-scope allow). Full server suite 49/49 pass;
+type-check 3/3 turbo tasks + biome clean. Loader (`getUsableCampaigns`) is
+DB-touching — integration test deferred, same as #1/#5.
+
+**Outcomes**
+- Campaign eligibility reads in the Campaigns module; Order no longer owns it.
+- `findCampaignsByIdsWithEligibility` is no longer dead code.
+- Validation rules pinned by unit tests for the first time.
+- No new abstraction — the discount math was already shared; this was locality.
+
+**Not done (recorded)**: web `isCampaignAvailable` still duplicates a *subset* of
+the rules client-side. Unifying it requires a server preview endpoint (doesn't
+exist) or shipping the full rule set as another pure `@fresclean/api/schema`
+export. No signal to do either today.
 
 ---
 

--- a/packages/server/src/modules/campaigns/campaign-eligibility.test.ts
+++ b/packages/server/src/modules/campaigns/campaign-eligibility.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { BadRequestException } from "@/errors";
+import { assertCampaignUsable } from "@/modules/campaigns/campaign.service";
+
+const baseCampaign = {
+  code: "SAVE10",
+  is_active: true,
+  starts_at: null as Date | null,
+  ends_at: null as Date | null,
+  min_order_total: "0",
+  stores: [] as { store_id: number }[],
+};
+
+const ctx = {
+  now: new Date("2026-06-09T00:00:00Z"),
+  grossTotal: 100_000,
+  storeId: 1,
+  storeCode: "JKT",
+};
+
+describe("assertCampaignUsable", () => {
+  it("allows an active, in-window, in-store, above-minimum campaign", () => {
+    expect(() => assertCampaignUsable(baseCampaign, ctx)).not.toThrow();
+  });
+
+  it("rejects an inactive campaign", () => {
+    expect(() =>
+      assertCampaignUsable({ ...baseCampaign, is_active: false }, ctx)
+    ).toThrow(BadRequestException);
+  });
+
+  it("rejects a campaign that has not started", () => {
+    expect(() =>
+      assertCampaignUsable(
+        { ...baseCampaign, starts_at: new Date("2026-07-01T00:00:00Z") },
+        ctx
+      )
+    ).toThrow(BadRequestException);
+  });
+
+  it("rejects a campaign that has ended", () => {
+    expect(() =>
+      assertCampaignUsable(
+        { ...baseCampaign, ends_at: new Date("2026-01-01T00:00:00Z") },
+        ctx
+      )
+    ).toThrow(BadRequestException);
+  });
+
+  it("rejects a campaign scoped to other stores", () => {
+    expect(() =>
+      assertCampaignUsable({ ...baseCampaign, stores: [{ store_id: 2 }] }, ctx)
+    ).toThrow(BadRequestException);
+  });
+
+  it("allows a store-scoped campaign that includes the order's store", () => {
+    expect(() =>
+      assertCampaignUsable(
+        { ...baseCampaign, stores: [{ store_id: 1 }, { store_id: 2 }] },
+        ctx
+      )
+    ).not.toThrow();
+  });
+
+  it("rejects when gross total is below the campaign minimum", () => {
+    expect(() =>
+      assertCampaignUsable({ ...baseCampaign, min_order_total: "200000" }, ctx)
+    ).toThrow(BadRequestException);
+  });
+});

--- a/packages/server/src/modules/campaigns/campaign-eligibility.test.ts
+++ b/packages/server/src/modules/campaigns/campaign-eligibility.test.ts
@@ -67,4 +67,25 @@ describe("assertCampaignUsable", () => {
       assertCampaignUsable({ ...baseCampaign, min_order_total: "200000" }, ctx)
     ).toThrow(BadRequestException);
   });
+
+  it("allows a campaign starting exactly at now (inclusive lower bound)", () => {
+    expect(() =>
+      assertCampaignUsable({ ...baseCampaign, starts_at: ctx.now }, ctx)
+    ).not.toThrow();
+  });
+
+  it("allows a campaign ending exactly at now (inclusive upper bound)", () => {
+    expect(() =>
+      assertCampaignUsable({ ...baseCampaign, ends_at: ctx.now }, ctx)
+    ).not.toThrow();
+  });
+
+  it("allows a gross total exactly at the campaign minimum", () => {
+    expect(() =>
+      assertCampaignUsable(
+        { ...baseCampaign, min_order_total: String(ctx.grossTotal) },
+        ctx
+      )
+    ).not.toThrow();
+  });
 });

--- a/packages/server/src/modules/campaigns/campaign.service.ts
+++ b/packages/server/src/modules/campaigns/campaign.service.ts
@@ -1,7 +1,8 @@
-import { BadRequestException } from "@/errors";
+import { BadRequestException, NotFoundException } from "@/errors";
 import {
   deleteCampaignById,
   findCampaignById,
+  findCampaignsByIdsWithEligibility,
   findServicesByIds,
   findStoresByIds,
   insertCampaignWithStores,
@@ -217,4 +218,76 @@ export async function updateCampaign({
 export function deleteCampaign({ user, id }: { user: JWTPayload; id: number }) {
   assertCanManageCampaigns(user);
   return deleteCampaignById(id);
+}
+
+type CampaignEligibility = Pick<
+  Awaited<ReturnType<typeof findCampaignsByIdsWithEligibility>>[number],
+  "code" | "ends_at" | "is_active" | "min_order_total" | "starts_at" | "stores"
+>;
+
+export function assertCampaignUsable(
+  campaign: CampaignEligibility,
+  {
+    now,
+    grossTotal,
+    storeId,
+    storeCode,
+  }: { now: Date; grossTotal: number; storeId: number; storeCode: string }
+) {
+  if (!campaign.is_active) {
+    throw new BadRequestException(`Campaign ${campaign.code} is not active`);
+  }
+  if (campaign.starts_at && now < campaign.starts_at) {
+    throw new BadRequestException(
+      `Campaign ${campaign.code} has not started yet`
+    );
+  }
+  if (campaign.ends_at && now > campaign.ends_at) {
+    throw new BadRequestException(`Campaign ${campaign.code} has ended`);
+  }
+
+  const storeScopes = campaign.stores.map((item) => item.store_id);
+  if (storeScopes.length > 0 && !storeScopes.includes(storeId)) {
+    throw new BadRequestException(
+      `Campaign ${campaign.code} is not available for store ${storeCode}`
+    );
+  }
+
+  if (grossTotal < Number(campaign.min_order_total)) {
+    throw new BadRequestException(
+      `Order total does not meet minimum for campaign ${campaign.code}`
+    );
+  }
+}
+
+export async function getUsableCampaigns({
+  campaignIds,
+  grossTotal,
+  storeId,
+  storeCode,
+}: {
+  campaignIds: number[];
+  grossTotal: number;
+  storeId: number;
+  storeCode: string;
+}) {
+  const campaigns = await findCampaignsByIdsWithEligibility(campaignIds);
+
+  const foundIds = new Set(campaigns.map((item) => item.id));
+  const missing = campaignIds.filter((id) => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new NotFoundException(`Campaign not found: ${missing.join(", ")}`);
+  }
+
+  const now = new Date();
+  for (const campaign of campaigns) {
+    assertCampaignUsable(campaign, { now, grossTotal, storeId, storeCode });
+  }
+
+  return campaigns.map(
+    ({ stores: _stores, eligibleServices, ...campaign }) => ({
+      ...campaign,
+      eligible_service_ids: eligibleServices.map((entry) => entry.service_id),
+    })
+  );
 }

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -3,12 +3,12 @@ import type z from "zod";
 import { db } from "@/db";
 import { orderCampaignsTable, ordersTable } from "@/db/schema";
 import { BadRequestException, NotFoundException } from "@/errors";
+import { getUsableCampaigns } from "@/modules/campaigns/campaign.service";
 import {
   findOrders,
   insertOrder,
   insertOrderProducts,
   insertOrderServices,
-  type OrderTx,
   reserveNextOrderNumber,
 } from "@/modules/orders/order.repository";
 import {
@@ -111,87 +111,7 @@ function buildOrderServiceRows({
   });
 }
 
-type ValidatedCampaign = Awaited<
-  ReturnType<OrderTx["query"]["campaignsTable"]["findFirst"]>
->;
-
-async function loadAndValidateCampaigns({
-  tx,
-  campaignIds,
-  grossTotal,
-  storeId,
-  storeCode,
-}: {
-  tx: OrderTx;
-  campaignIds: number[];
-  grossTotal: number;
-  storeId: number;
-  storeCode: string;
-}) {
-  const campaigns = await tx.query.campaignsTable.findMany({
-    where: { id: { in: campaignIds } },
-    with: {
-      stores: { columns: { store_id: true } },
-      eligibleServices: { columns: { service_id: true } },
-    },
-  });
-
-  const campaignsById = new Map(campaigns.map((item) => [item.id, item]));
-  const missing = campaignIds.filter((id) => !campaignsById.has(id));
-  if (missing.length > 0) {
-    throw new NotFoundException(`Campaign not found: ${missing.join(", ")}`);
-  }
-
-  const now = new Date();
-  for (const campaign of campaigns) {
-    assertCampaignUsable(campaign, {
-      now,
-      grossTotal,
-      storeId,
-      storeCode,
-    });
-  }
-
-  return campaigns;
-}
-
-function assertCampaignUsable(
-  campaign: NonNullable<ValidatedCampaign> & { stores: { store_id: number }[] },
-  {
-    now,
-    grossTotal,
-    storeId,
-    storeCode,
-  }: { now: Date; grossTotal: number; storeId: number; storeCode: string }
-) {
-  if (!campaign.is_active) {
-    throw new BadRequestException(`Campaign ${campaign.code} is not active`);
-  }
-  if (campaign.starts_at && now < campaign.starts_at) {
-    throw new BadRequestException(
-      `Campaign ${campaign.code} has not started yet`
-    );
-  }
-  if (campaign.ends_at && now > campaign.ends_at) {
-    throw new BadRequestException(`Campaign ${campaign.code} has ended`);
-  }
-
-  const storeScopes = campaign.stores.map((item) => item.store_id);
-  if (storeScopes.length > 0 && !storeScopes.includes(storeId)) {
-    throw new BadRequestException(
-      `Campaign ${campaign.code} is not available for store ${storeCode}`
-    );
-  }
-
-  if (grossTotal < Number(campaign.min_order_total)) {
-    throw new BadRequestException(
-      `Order total does not meet minimum for campaign ${campaign.code}`
-    );
-  }
-}
-
 async function resolveDiscount({
-  tx,
   campaignIds,
   grossTotal,
   manualDiscount,
@@ -199,7 +119,6 @@ async function resolveDiscount({
   storeCode,
   lines,
 }: {
-  tx: OrderTx;
   campaignIds: number[];
   grossTotal: number;
   manualDiscount: number;
@@ -217,24 +136,16 @@ async function resolveDiscount({
     };
   }
 
-  const campaigns = await loadAndValidateCampaigns({
-    tx,
+  const campaigns = await getUsableCampaigns({
     campaignIds,
     grossTotal,
     storeId,
     storeCode,
   });
 
-  const stackInput = campaigns.map((campaign) => ({
-    ...campaign,
-    eligible_service_ids: campaign.eligibleServices.map(
-      (entry) => entry.service_id
-    ),
-  }));
-
   const { total: campaignDiscount, breakdown } = stackCampaignDiscounts(
     grossTotal,
-    stackInput,
+    campaigns,
     lines
   );
 
@@ -412,7 +323,6 @@ export async function createOrder(
 
     const { discountAmount, discountSource, campaignRows } =
       await resolveDiscount({
-        tx,
         campaignIds: [...new Set(campaign_ids)],
         grossTotal,
         manualDiscount: Number(orderPayload.discount),


### PR DESCRIPTION
## What

Moves Campaign eligibility from `order.service.ts` into the Campaigns module that owns the concept (architecture-deepening section 4).

- `campaign.service.ts` gains `getUsableCampaigns(...)` + an exported pure `assertCampaignUsable(campaign, ctx)`.
- `order.service.ts` sheds `loadAndValidateCampaigns`, the local `assertCampaignUsable`, the `ValidatedCampaign` type, and the orphaned `OrderTx` import; `resolveDiscount` now calls `getUsableCampaigns` and stacks the flattened campaigns directly.
- `findCampaignsByIdsWithEligibility` (previously dead code) is now used; the duplicate inline `tx.query` is deleted.

## Decisions

- **Throw-on-first-rejection** kept — the only caller (`createOrder`) wants atomic fail; no server price-preview consumer exists.
- **`db` read, not tx-threaded** — outcome-identical under READ COMMITTED; the small extra pool checkout is accepted at POS volume.
- **`CampaignEligibility`** derived as a `Pick<>` of the repo row — drift-safe.

## Behavior

None changed. Pure relocation — same validations, same error messages, same throw semantics.

## Tests

- New `campaign-eligibility.test.ts` — 7 unit tests (happy path + 5 reject branches + store-scope allow).
- Full server suite **49/49 pass**; type-check **3/3** turbo tasks; biome clean.