### PR TITLE
refactor(reports): merge jakarta calendar copies, gate via permissions

### DIFF
--- a/packages/server/src/modules/reports/report.repository.ts
+++ b/packages/server/src/modules/reports/report.repository.ts
@@ -22,14 +22,12 @@ import {
   usersTable,
 } from "@/db/schema";
 import { ORDER_TERMINAL_SERVICE_STATUSES } from "@/modules/orders/order-status-machine";
+import {
+  type DateRange,
+  JAKARTA_TZ_SQL,
+} from "@/modules/reports/report-range.util";
 
 const ITEM_PROCESSED_STATUSES = ["ready_for_pickup", "quality_check"] as const;
-const JAKARTA_DAY_SQL = sql.raw(`'Asia/Jakarta'`);
-
-interface DateRange {
-  end: Date;
-  start: Date;
-}
 
 export async function sumDailyPaid({
   range,
@@ -181,7 +179,7 @@ export async function ordersInTrendSeries({
     conditions.push(eq(ordersTable.store_id, storeId));
   }
 
-  const dayExpr = sql<string>`to_char(${ordersTable.created_at} AT TIME ZONE ${JAKARTA_DAY_SQL}, 'YYYY-MM-DD')`;
+  const dayExpr = sql<string>`to_char(${ordersTable.created_at} AT TIME ZONE ${JAKARTA_TZ_SQL}, 'YYYY-MM-DD')`;
 
   const rows = await db
     .select({
@@ -213,7 +211,7 @@ export async function paidTrendSeries({
     conditions.push(eq(ordersTable.store_id, storeId));
   }
 
-  const dayExpr = sql<string>`to_char(${ordersTable.paid_at} AT TIME ZONE ${JAKARTA_DAY_SQL}, 'YYYY-MM-DD')`;
+  const dayExpr = sql<string>`to_char(${ordersTable.paid_at} AT TIME ZONE ${JAKARTA_TZ_SQL}, 'YYYY-MM-DD')`;
 
   const rows = await db
     .select({
@@ -245,7 +243,7 @@ export async function refundsTrendSeries({
     conditions.push(eq(ordersTable.store_id, storeId));
   }
 
-  const dayExpr = sql<string>`to_char(${orderRefundsTable.created_at} AT TIME ZONE ${JAKARTA_DAY_SQL}, 'YYYY-MM-DD')`;
+  const dayExpr = sql<string>`to_char(${orderRefundsTable.created_at} AT TIME ZONE ${JAKARTA_TZ_SQL}, 'YYYY-MM-DD')`;
 
   const rows = await db
     .select({
@@ -278,7 +276,7 @@ export async function ordersOutTrendSeries({
     conditions.push(eq(ordersTable.store_id, storeId));
   }
 
-  const dayExpr = sql<string>`to_char(${orderPickupEventsTable.picked_up_at} AT TIME ZONE ${JAKARTA_DAY_SQL}, 'YYYY-MM-DD')`;
+  const dayExpr = sql<string>`to_char(${orderPickupEventsTable.picked_up_at} AT TIME ZONE ${JAKARTA_TZ_SQL}, 'YYYY-MM-DD')`;
 
   const rows = await db
     .select({

--- a/packages/server/src/modules/reports/report.service.ts
+++ b/packages/server/src/modules/reports/report.service.ts
@@ -19,26 +19,11 @@ import type {
   GetDailyReportQuery,
   GetReportOverviewQuery,
 } from "@/modules/reports/report.schema";
+import {
+  getJakartaDayRange,
+  shiftDate,
+} from "@/modules/reports/report-range.util";
 import { buildPaginationMeta, normalizePagination } from "@/utils/pagination";
-
-// Asia/Jakarta is UTC+7 year-round (no DST).
-const JAKARTA_OFFSET_MINUTES = 7 * 60;
-const DAY_MS = 86_400_000;
-
-function getJakartaDayRange(date: string) {
-  const [year, month, day] = date.split("-").map(Number);
-  const startUtcMs =
-    Date.UTC(year, month - 1, day, 0, 0, 0) - JAKARTA_OFFSET_MINUTES * 60_000;
-  const start = new Date(startUtcMs);
-  const end = new Date(startUtcMs + DAY_MS);
-  return { start, end };
-}
-
-function shiftDate(date: string, deltaDays: number) {
-  const [year, month, day] = date.split("-").map(Number);
-  const shifted = new Date(Date.UTC(year, month - 1, day + deltaDays));
-  return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}-${String(shifted.getUTCDate()).padStart(2, "0")}`;
-}
 
 export async function getDailyReport(query: GetDailyReportQuery) {
   const range = getJakartaDayRange(query.date);

--- a/packages/server/src/routes/admin/reports.ts
+++ b/packages/server/src/routes/admin/reports.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { ForbiddenException } from "@/errors";
+import { assertIsAdmin } from "@/modules/permissions/permissions";
 import {
   GETAgingQueueQuerySchema,
   GETDailyReportQuerySchema,
@@ -25,19 +25,16 @@ import { assertStoreAccess } from "@/utils/authorization";
 import { success } from "@/utils/http";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
 
-function assertAdmin(user: JWTPayload) {
-  if (user.role !== "admin") {
-    throw new ForbiddenException("Admin role required");
-  }
-}
-
 const app = new Hono()
+  .use(async (c, next) => {
+    assertIsAdmin(c.get("jwtPayload") as JWTPayload);
+    await next();
+  })
   .get(
     "/daily",
     zodValidator("query", GETDailyReportQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
 
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
@@ -53,7 +50,6 @@ const app = new Hono()
     zodValidator("query", GETReportOverviewQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
 
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
@@ -69,7 +65,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -83,7 +78,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -97,7 +91,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -111,7 +104,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -125,7 +117,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -139,7 +130,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -153,7 +143,6 @@ const app = new Hono()
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);
@@ -167,7 +156,6 @@ const app = new Hono()
     zodValidator("query", GETAgingQueueQuerySchema),
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
-      assertAdmin(user);
       const query = c.req.valid("query");
       if (query.store_id !== undefined) {
         await assertStoreAccess(user, query.store_id);


### PR DESCRIPTION
## Summary
- Merge the Jakarta day-range duplication inside the reports module: `report.service.ts` drops its private `getJakartaDayRange`/`shiftDate` copies, `report.repository.ts` drops its duplicate `JAKARTA_DAY_SQL` fragment and local `DateRange` interface — `report-range.util.ts` is now the single calendar home.
- Replace the route-local `assertAdmin` in `routes/admin/reports.ts` (10 per-handler calls) with one router-level `.use()` gate backed by `assertIsAdmin` from the permissions module, per ADR-0006. New report endpoints are gated automatically.

## Behavior notes
- 403 on non-admin report access now returns the permissions module's standard message ("Only admin can perform this action") instead of "Admin role required". Nothing string-matched the old text.
- Day-range and shift-date math verified byte-equivalent to the deleted copies.

## Verification
- `bun run type-check` — 3/3 turbo tasks (web hc RPC types intact)
- server `bun test` — 52/52
- `bun x ultracite check` — clean