### PR TITLE
feat(orders): compress photos to 1600px webp on save, scope image paths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "fresclean",
+      "dependencies": {
+        "@types/bun": "^1.3.14",
+      },
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,8 @@
   "workspaces": {
     "": {
       "name": "fresclean",
-      "dependencies": {
-        "@types/bun": "^1.3.14",
-      },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
         "turbo": "^2.9.16",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "sideEffects": false,
   "private": true,
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
@@ -31,5 +31,8 @@
   },
   "lint-staged": {
     "*": "bunx ultracite fix"
+  },
+  "dependencies": {
+    "@types/bun": "^1.3.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,14 +25,12 @@
     "ultracite": "7.8.1"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
     "turbo": "^2.9.16"
   },
   "lint-staged": {
     "*": "bunx ultracite fix"
-  },
-  "dependencies": {
-    "@types/bun": "^1.3.14"
   }
 }

--- a/packages/server/src/modules/orders/order-photo.service.ts
+++ b/packages/server/src/modules/orders/order-photo.service.ts
@@ -11,7 +11,11 @@ import type {
   PutOrderDropoffPhotoInput,
 } from "@/modules/orders/order-admin.schema";
 import type { JWTPayload } from "@/types";
-import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
+import {
+  buildMediaUrl,
+  createPresignedUploadUrl,
+  optimizeUploadedImage,
+} from "@/utils/s3";
 
 export async function createOrderServicePhotoPresign({
   orderId,
@@ -66,6 +70,12 @@ export async function saveOrderServicePhoto({
   user: JWTPayload;
 }) {
   await getOrderServiceOrThrow(orderId, serviceId);
+
+  if (!body.image_path.startsWith(`orders/${orderId}/services/${serviceId}/`)) {
+    throw new BadRequestException("Invalid image path");
+  }
+
+  await optimizeUploadedImage(body.image_path);
 
   const [photo] = await db
     .insert(orderServicesImagesTable)
@@ -132,6 +142,12 @@ export async function saveOrderDropoffPhoto({
   body: PutOrderDropoffPhotoInput;
   user: JWTPayload;
 }) {
+  if (!body.image_path.startsWith(`orders/${orderId}/dropoff/`)) {
+    throw new BadRequestException("Invalid image path");
+  }
+
+  await optimizeUploadedImage(body.image_path);
+
   const [order] = await db
     .update(ordersTable)
     .set({

--- a/packages/server/src/modules/orders/order-pickup.service.ts
+++ b/packages/server/src/modules/orders/order-pickup.service.ts
@@ -8,7 +8,11 @@ import type {
 import { completePickup } from "@/modules/orders/order-status-machine";
 import { assertCanProcessPickup } from "@/modules/permissions/permissions";
 import type { JWTPayload } from "@/types";
-import { buildMediaUrl, createPresignedUploadUrl } from "@/utils/s3";
+import {
+  buildMediaUrl,
+  createPresignedUploadUrl,
+  optimizeUploadedImage,
+} from "@/utils/s3";
 
 // ADR-0005: the pickup code proves the customer in front of the cashier placed
 // this Order. It is a per-Order check, never a cross-Order lookup.
@@ -101,6 +105,12 @@ export async function createOrderPickupEvent({
         .join(", ")}`
     );
   }
+
+  if (!body.image_path.startsWith(`orders/${orderId}/pickup/`)) {
+    throw new BadRequestException("Invalid image path");
+  }
+
+  await optimizeUploadedImage(body.image_path);
 
   // One transaction: insert the pickup event + flip the services together. A
   // concurrent pickup of the same items leaves fewer rows ready, so completePickup

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -1,6 +1,9 @@
 import { s3 } from "bun";
+import { BadRequestException } from "@/errors";
 
 const DEFAULT_PRESIGNED_EXPIRES_SECONDS = 300;
+const MAX_IMAGE_DIMENSION = 1600;
+const WEBP_QUALITY = 80;
 
 export function buildMediaUrl(path: string): string;
 export function buildMediaUrl(path: null | undefined): null;
@@ -41,4 +44,28 @@ export function createPresignedUploadUrl({
     key,
     expires_in_seconds: DEFAULT_PRESIGNED_EXPIRES_SECONDS,
   };
+}
+
+export async function optimizeUploadedImage(key: string): Promise<void> {
+  const file = s3.file(key);
+
+  let optimized: Uint8Array;
+  try {
+    optimized = await file
+      .image()
+      .resize(MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION, {
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .webp({ quality: WEBP_QUALITY })
+      .bytes();
+  } catch (error) {
+    // Format Bun can't decode on this platform (e.g. HEIC) — keep the original.
+    if ((error as { code?: string }).code === "ERR_IMAGE_FORMAT_UNSUPPORTED") {
+      return;
+    }
+    throw new BadRequestException("Uploaded file is missing or not an image");
+  }
+
+  await file.write(optimized, { type: "image/webp" });
 }

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -60,11 +60,17 @@ export async function optimizeUploadedImage(key: string): Promise<void> {
       .webp({ quality: WEBP_QUALITY })
       .bytes();
   } catch (error) {
+    const code = (error as { code?: string }).code;
     // Format Bun can't decode on this platform (e.g. HEIC) — keep the original.
-    if ((error as { code?: string }).code === "ERR_IMAGE_FORMAT_UNSUPPORTED") {
+    if (code === "ERR_IMAGE_FORMAT_UNSUPPORTED") {
       return;
     }
-    throw new BadRequestException("Uploaded file is missing or not an image");
+    // Any other image error means the upload isn't a usable image.
+    if (code?.startsWith("ERR_IMAGE_")) {
+      throw new BadRequestException("Uploaded file is not a valid image");
+    }
+    // S3/network/other infra fault — propagate, don't mislabel as a bad image.
+    throw error;
   }
 
   await file.write(optimized, { type: "image/webp" });


### PR DESCRIPTION
## Summary
- Re-encode every saved photo (service, drop-off, pickup) to max 1600px webp q80 via `Bun.Image` — addresses production-readiness audit item C.9 (~6MB iPhone uploads, ~90GB/mo projected → ~3GB/mo)
- Save now fails with 400 if the S3 object is missing or doesn't decode as an image (presigned uploads previously had zero server-side validation); platform-unsupported formats (e.g. HEIC without a decoder) keep the original upload
- Reject `image_path` outside the order-scoped prefix the presign issued (`orders/{id}/services/{sid}/`, `.../dropoff/`, `.../pickup/`) — prevents cross-order photo references
- Bump `packageManager` to `bun@1.3.14` (`Bun.Image` ships in 1.3.14)

Note: `bun update @types/bun` placed `@types/bun` in root `dependencies`; should likely move to `devDependencies` (can fix on this branch if preferred).

## Test plan
- `tsc --noEmit` and ultracite clean
- Smoke-tested `Bun.Image` pipeline locally: PNG → RIFF/webp output; garbage bytes → `ERR_IMAGE_UNKNOWN_FORMAT` → 400 path
- Manual: upload drop-off/service/pickup photo from web app, verify saved object is webp ≤1600px and renders in lightbox
- Manual: POST save with foreign `image_path` → expect 400 "Invalid image path"
- Deploy check: verify HEIC decode support on prod target (fallback keeps original if absent)