### PR TITLE
refactor: unify store/date pickers and drop unused refund note

### DIFF
--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -1,5 +1,5 @@
 import { CalendarBlankIcon, XIcon } from "@phosphor-icons/react";
-import { format, parseISO } from "date-fns";
+import { format, parseISO, startOfToday } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import type { DateRange, Matcher } from "react-day-picker";
 import { Button } from "@/components/ui/button";
@@ -175,6 +175,7 @@ export const DateRangePicker = ({
 					defaultMonth={displayRange?.from}
 					selected={displayRange}
 					numberOfMonths={numberOfMonths}
+					disabled={{ after: startOfToday() }}
 					onSelect={(range) => {
 						setDraftRange(range);
 						if (commitOnComplete && !(range?.from && range?.to)) {

--- a/apps/web/src/features/orders/components/hold-to-confirm-button.tsx
+++ b/apps/web/src/features/orders/components/hold-to-confirm-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type PointerEvent, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -51,11 +51,12 @@ export function HoldToConfirmButton({
 		};
 	}, []);
 
-	const beginHold = () => {
+	const beginHold = (event: PointerEvent<HTMLButtonElement>) => {
 		if (disabled || loading || isHolding) {
 			return;
 		}
 
+		event.currentTarget.setPointerCapture(event.pointerId);
 		setIsHolding(true);
 		completedRef.current = false;
 		startTimeRef.current = performance.now();
@@ -97,18 +98,21 @@ export function HoldToConfirmButton({
 	return (
 		<Button
 			type="button"
-			className={cn("relative overflow-hidden", className)}
+			className={cn(
+				"relative touch-none overflow-hidden [-webkit-touch-callout:none]",
+				className,
+			)}
 			disabled={disabled || loading}
 			loading={loading}
 			loadingText="Starting..."
+			onContextMenu={(event) => event.preventDefault()}
 			onPointerDown={beginHold}
 			onPointerUp={cancelHold}
 			onPointerCancel={cancelHold}
-			onPointerLeave={cancelHold}
 		>
 			<span
 				aria-hidden="true"
-				className="pointer-events-none absolute inset-y-0 left-0 bg-background/20 transition-[width] duration-75"
+				className="pointer-events-none absolute inset-y-0 left-0 bg-primary-foreground/40 transition-[width] duration-75"
 				style={{ width: `${progress * 100}%` }}
 			/>
 			<span className="relative z-10">

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -339,7 +339,7 @@ export function QueueServiceDetail({
 								await startWorkMutation.mutateAsync();
 							}}
 						>
-							Hold 1s to Start Work
+							Hold to Start Work
 						</HoldToConfirmButton>
 					) : null}
 

--- a/apps/web/src/features/orders/components/refund-order-form.tsx
+++ b/apps/web/src/features/orders/components/refund-order-form.tsx
@@ -29,7 +29,6 @@ const refundFormSchema = z
 				note: z.string().optional(),
 			}),
 		),
-		note: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
 		const selectedCount = data.items.filter((item) => item.selected).length;
@@ -114,7 +113,6 @@ export const RefundOrderForm = ({
 				reason: "damaged",
 				note: "",
 			})),
-			note: "",
 		},
 	});
 	const { fields } = useFieldArray({ control: form.control, name: "items" });
@@ -153,7 +151,6 @@ export const RefundOrderForm = ({
 			orderId,
 			payload: {
 				items,
-				note: values.note?.trim() || undefined,
 			},
 		});
 		closeDialog();
@@ -218,16 +215,6 @@ export const RefundOrderForm = ({
 						);
 					})}
 				</div>
-
-				<Field>
-					<FieldLabel htmlFor="refund-note">Refund note (optional)</FieldLabel>
-					<Textarea
-						id="refund-note"
-						placeholder="General refund note"
-						disabled={isPending}
-						{...form.register("note")}
-					/>
-				</Field>
 
 				<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
 					<Button

--- a/apps/web/src/features/orders/components/store-autocomplete.tsx
+++ b/apps/web/src/features/orders/components/store-autocomplete.tsx
@@ -10,9 +10,11 @@ type StoreAutocompleteProps = {
 	disabled?: boolean;
 	required?: boolean;
 	label?: string;
+	hideLabel?: boolean;
 	id?: string;
 	error?: { message?: string };
 	placeholder?: string;
+	triggerClassName?: string;
 	allOptionLabel?: string;
 };
 
@@ -23,9 +25,11 @@ export function StoreAutocomplete({
 	disabled,
 	required,
 	label = "Store",
+	hideLabel = false,
 	id = "order-store",
 	error,
 	placeholder = "Select store",
+	triggerClassName = "h-10 w-full text-sm",
 	allOptionLabel,
 }: StoreAutocompleteProps) {
 	const { data: stores = [], isPending } = useQuery({
@@ -38,10 +42,30 @@ export function StoreAutocomplete({
 
 	const options = filteredStores.map((store) => ({
 		value: String(store.id),
-		label: store.name,
+		label: `${store.code} - ${store.name}`,
 	}));
 	if (allOptionLabel) {
 		options.unshift({ value: "", label: allOptionLabel });
+	}
+
+	const combobox = (
+		<Combobox
+			id={id}
+			required={required}
+			triggerClassName={triggerClassName}
+			options={options}
+			value={value}
+			onValueChange={onValueChange}
+			loading={isPending}
+			placeholder={placeholder}
+			searchPlaceholder="Search store..."
+			emptyText="No store found"
+			disabled={disabled}
+		/>
+	);
+
+	if (hideLabel) {
+		return combobox;
 	}
 
 	return (
@@ -49,19 +73,7 @@ export function StoreAutocomplete({
 			<FieldLabel htmlFor={id} asterisk={required}>
 				{label}
 			</FieldLabel>
-			<Combobox
-				id={id}
-				required={required}
-				triggerClassName="h-10 w-full text-sm"
-				options={options}
-				value={value}
-				onValueChange={onValueChange}
-				loading={isPending}
-				placeholder={placeholder}
-				searchPlaceholder="Search store..."
-				emptyText="No store found"
-				disabled={disabled}
-			/>
+			{combobox}
 			<FieldError errors={[error]} />
 		</Field>
 	);

--- a/apps/web/src/features/shifts/components/shift-clock-card.tsx
+++ b/apps/web/src/features/shifts/components/shift-clock-card.tsx
@@ -1,8 +1,8 @@
 import { ClockIcon } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { SelectField } from "@/components/form/select-field";
 import { Button } from "@/components/ui/button";
+import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
 import { useCurrentShift } from "@/features/shifts/hooks/useCurrentShift";
 import { clockInShift, clockOutShift, queryKeys, type Store } from "@/lib/api";
 
@@ -89,15 +89,13 @@ export const ShiftClockCard = ({ stores }: ShiftClockCardProps) => {
 	return (
 		<div className="flex items-center gap-2">
 			{stores.length > 1 ? (
-				<SelectField
-					items={stores.map((store) => ({
-						value: String(store.id),
-						label: store.code,
-					}))}
+				<StoreAutocomplete
+					id="shift-clock-store"
+					hideLabel
 					value={selectedStoreId}
 					onValueChange={(value) => setStoreOverride(value || null)}
-					size="sm"
-					className="h-8 min-w-24 text-xs"
+					allowedStoreIds={stores.map((store) => store.id)}
+					triggerClassName="h-8 min-w-24 text-xs"
 					placeholder="Store"
 				/>
 			) : null}

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -7,9 +7,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useEffect, useMemo, useRef } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Card, CardContent } from "@/components/ui/card";
-import { Combobox } from "@/components/ui/combobox";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
 import type { TransactionDraftValues } from "@/features/transactions/cart/cart";
 import { useCartOps } from "@/features/transactions/cart/useCart";
 import { getEntityCategoryName } from "@/features/transactions/lib/transactions";
@@ -143,20 +143,16 @@ export function TransactionsCatalog() {
 				<CardContent className="grid gap-4 p-4 sm:p-5">
 					<div className="grid gap-3">
 						<Field>
-							<Combobox
+							<StoreAutocomplete
 								id="transaction-store"
+								hideLabel
 								required
-								triggerClassName="h-11 w-full border-border/70 bg-background text-sm"
-								options={visibleStores.map((store) => ({
-									value: String(store.id),
-									label: `${store.code} - ${store.name}`,
-								}))}
 								value={selectedStoreId}
 								onValueChange={handleStoreChange}
-								placeholder="Select store"
-								searchPlaceholder="Search store..."
-								emptyText="No store available"
+								allowedStoreIds={visibleStores.map((store) => store.id)}
 								disabled={!isAdmin}
+								triggerClassName="h-11 w-full border-border/70 bg-background text-sm"
+								placeholder="Select store"
 							/>
 						</Field>
 

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo } from "react";
 import { z } from "zod";
 import { DataTable } from "@/components/data-table";
 import { DebouncedSearchInput } from "@/components/debounced-search-input";
-import { SelectField } from "@/components/form/select-field";
 import { PageHeader } from "@/components/page-header";
 import { TablePagination } from "@/components/table-pagination";
 import { Badge } from "@/components/ui/badge";
@@ -14,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { DateRangePicker } from "@/components/ui/date-picker";
 import { PickupRadar } from "@/features/orders/components/pickup-radar";
+import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
 import type { Order } from "@/lib/api";
 import {
 	meQueryOptions,
@@ -333,23 +333,6 @@ function OrdersPage() {
 		});
 	};
 
-	const visibleStores =
-		role === "admin"
-			? (storesQuery.data ?? [])
-			: (storesQuery.data ?? []).filter((store) =>
-					userStoreIds.includes(store.id),
-				);
-	const storeFilterItems = useMemo(
-		() => [
-			...(role === "admin" ? [{ value: "all", label: "All stores" }] : []),
-			...visibleStores.map((store) => ({
-				value: String(store.id),
-				label: `${store.code} - ${store.name}`,
-			})),
-		],
-		[role, visibleStores],
-	);
-
 	return (
 		<>
 			<PageHeader
@@ -387,26 +370,23 @@ function OrdersPage() {
 								ariaLabel="Search orders"
 								className="w-full sm:w-72"
 							/>
-							<SelectField
-								items={storeFilterItems}
-								value={
-									role === "admin"
-										? (search.storeId?.toString() ?? "all")
-										: (search.storeId?.toString() ?? "")
-								}
+							<StoreAutocomplete
+								id="orders-store-filter"
+								hideLabel
+								value={search.storeId?.toString() ?? ""}
 								onValueChange={(value) => {
 									void navigate({
 										search: (prev) => ({
 											...prev,
 											page: 1,
-											storeId:
-												value && value !== "all" ? Number(value) : undefined,
+											storeId: value ? Number(value) : undefined,
 										}),
 									});
 								}}
-								aria-label="Filter by store"
-								className="min-w-48 w-max"
+								allowedStoreIds={role === "admin" ? undefined : userStoreIds}
+								allOptionLabel={role === "admin" ? "All stores" : undefined}
 								placeholder="Filter by store"
+								triggerClassName="h-10 w-max min-w-48 text-sm"
 							/>
 							<DateRangePicker
 								resetOnSelect

--- a/apps/web/src/routes/_admin/worker.index.tsx
+++ b/apps/web/src/routes/_admin/worker.index.tsx
@@ -10,7 +10,6 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
-import { SelectField } from "@/components/form/select-field";
 import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -24,6 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
 import {
 	type FetchOrderServiceQueueQuery,
@@ -156,7 +156,6 @@ function WorkerQueuePage() {
 	const rafRef = useRef<number | null>(null);
 	const scanningRef = useRef(false);
 
-	const storesQuery = useQuery(storesQueryOptions());
 	const meQuery = useQuery({
 		...meQueryOptions(),
 		enabled: !!currentUser,
@@ -440,20 +439,6 @@ function WorkerQueuePage() {
 		}
 	};
 
-	const visibleStores =
-		role === "admin"
-			? (storesQuery.data ?? [])
-			: (storesQuery.data ?? []).filter((store) =>
-					userStoreIds.includes(store.id),
-				);
-	const storeSelectItems = useMemo(
-		() =>
-			visibleStores.map((store) => ({
-				value: String(store.id),
-				label: `${store.code} - ${store.name}`,
-			})),
-		[visibleStores],
-	);
 	const statusTabItems = useMemo(
 		() => [
 			{ value: "all", label: "All active statuses" },
@@ -558,18 +543,15 @@ function WorkerQueuePage() {
 									<DialogTitle>Filters</DialogTitle>
 								</DialogHeader>
 								<div className="grid gap-4">
-									<Field>
-										<FieldLabel htmlFor="queue-store-mobile">Store</FieldLabel>
-										<SelectField
-											id="queue-store-mobile"
-											items={storeSelectItems}
-											value={parsedStoreId?.toString() ?? ""}
-											onValueChange={updateStoreFilter}
-											size="lg"
-											className="w-full"
-											placeholder="Select store"
-										/>
-									</Field>
+									<StoreAutocomplete
+										id="queue-store-mobile"
+										value={parsedStoreId?.toString() ?? ""}
+										onValueChange={updateStoreFilter}
+										allowedStoreIds={
+											role === "admin" ? undefined : userStoreIds
+										}
+										placeholder="Select store"
+									/>
 
 									<div className="grid gap-2">
 										<p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
@@ -631,18 +613,13 @@ function WorkerQueuePage() {
 
 					<div className="grid gap-3 md:grid-cols-[minmax(0,220px)_1fr]">
 						<div className="hidden md:block">
-							<Field>
-								<FieldLabel htmlFor="queue-store">Store</FieldLabel>
-								<SelectField
-									id="queue-store"
-									items={storeSelectItems}
-									value={parsedStoreId?.toString() ?? ""}
-									onValueChange={updateStoreFilter}
-									size="lg"
-									className="w-full"
-									placeholder="Select store"
-								/>
-							</Field>
+							<StoreAutocomplete
+								id="queue-store"
+								value={parsedStoreId?.toString() ?? ""}
+								onValueChange={updateStoreFilter}
+								allowedStoreIds={role === "admin" ? undefined : userStoreIds}
+								placeholder="Select store"
+							/>
 						</div>
 						<div className="grid gap-2">
 							<Field>

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -678,7 +678,6 @@ export const orderRefundsTable = pgTable(
   {
     created_at: timestamp("created_at").defaultNow().notNull(),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    note: text("note"),
     order_id: integer("order_id")
       .references(() => ordersTable.id, { onDelete: "cascade" })
       .notNull(),

--- a/packages/server/src/db/seed/run-seed.ts
+++ b/packages/server/src/db/seed/run-seed.ts
@@ -1759,7 +1759,6 @@ async function seedOrders(params: {
             order_id: order.id,
             refunded_by: createdBy,
             total_amount: asMoney(boundedRefund),
-            note: faker.lorem.sentence(),
             created_at: dayjs(updatedAt).add(randInt(5, 45), "minute").toDate(),
           })
           .returning({ id: orderRefundsTable.id });

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -163,7 +163,6 @@ export const POSTOrderRefundSchema = z.object({
         })
     )
     .min(1),
-  note: z.string().trim().optional(),
 });
 
 export const GETOrderByItemCodeQuerySchema = z.object({

--- a/packages/server/src/modules/orders/order-reversal.service.ts
+++ b/packages/server/src/modules/orders/order-reversal.service.ts
@@ -283,7 +283,6 @@ export async function createOrderRefund({
         order_id: orderId,
         refunded_by: user.id,
         total_amount: totalRefundAmount.toString(),
-        note: body.note,
       })
       .returning();
 


### PR DESCRIPTION
## Summary

- **Store dropdowns** — every store selector now uses `StoreAutocomplete` with `code - name` labels: orders filter, worker queue (mobile + desktop), shift clock-in, POS catalog. Extended the component with `hideLabel` + `triggerClassName` for inline/compact spots; replaced raw `Combobox`/`SelectField` one-offs. Store scoping preserved via `allowedStoreIds`; admin "All stores" sentinel is now `""` via `allOptionLabel`.
- **Date ranges** — future dates disabled in the shared `DateRangePicker` (`disabled={{ after: startOfToday() }}`), so all consumers (orders, worker, shifts, reports) inherit it. No per-call-site change. Business context: all date filters are historical/operational.
- **Refund note** — the top-level "Refund note (optional)" field was write-only (captured → stored → returned, never rendered). Removed from the dialog, `POSTOrderRefundSchema`, the refund insert, and the seed; dropped the `order_refunds.note` column. Per-item refund note kept (required when reason = `other`, displayed in product card). Cancel flow inspected — only has a per-item note, which is used; nothing removed.

## DB

`order_refunds.note` dropped on **dev**. Prod still has the column — run `ALTER TABLE order_refunds DROP COLUMN note` (or `push:prod`) on deploy.

## Verification

- `bun run type-check` — clean
- `bun x ultracite check` — clean across changed files