### PR TITLE
feat: orders filters, table and order detail refinements

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.4.0",
+		"dayjs": "^1.11.21",
 		"hono": "catalog:",
 		"input-otp": "^1.4.2",
 		"jwt-decode": "^4.0.0",

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -390,7 +390,7 @@ export const DataTable = <TData extends RowData>({
 					table.getRowModel().rows.map((row) => (
 						<TableRow key={row.id} className="border-border/60">
 							{row.getVisibleCells().map((cell) => (
-								<TableCell key={cell.id}>
+								<TableCell key={cell.id} className="py-3">
 									{flexRender(cell.column.columnDef.cell, cell.getContext())}
 								</TableCell>
 							))}

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -44,6 +44,9 @@ interface MobileCardColumnOptions {
 declare module "@tanstack/react-table" {
 	interface ColumnMeta<TData extends RowData, TValue> {
 		mobileCard?: MobileCardColumnOptions;
+		// Extra classes for the desktop table th/td (e.g. sticky columns).
+		headerClassName?: string;
+		cellClassName?: string;
 	}
 }
 
@@ -336,7 +339,10 @@ export const DataTable = <TData extends RowData>({
 							return (
 								<TableHead
 									key={header.id}
-									className="sticky top-0 z-10 h-9 bg-muted font-medium font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]"
+									className={cn(
+										"sticky top-0 z-10 h-9 bg-muted font-medium font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]",
+										header.column.columnDef.meta?.headerClassName,
+									)}
 								>
 									{header.isPlaceholder ? null : canSort ? (
 										<button
@@ -390,7 +396,13 @@ export const DataTable = <TData extends RowData>({
 					table.getRowModel().rows.map((row) => (
 						<TableRow key={row.id} className="border-border/60">
 							{row.getVisibleCells().map((cell) => (
-								<TableCell key={cell.id} className="py-3">
+								<TableCell
+									key={cell.id}
+									className={cn(
+										"py-3",
+										cell.column.columnDef.meta?.cellClassName,
+									)}
+								>
 									{flexRender(cell.column.columnDef.cell, cell.getContext())}
 								</TableCell>
 							))}

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -92,11 +92,15 @@ export function Combobox({
 			</ComboboxPrimitive.Trigger>
 
 			<ComboboxPrimitive.Portal>
-				<ComboboxPrimitive.Positioner className="isolate z-50" sideOffset={4}>
+				<ComboboxPrimitive.Positioner
+					align="start"
+					className="isolate z-50"
+					sideOffset={4}
+				>
 					<ComboboxPrimitive.Popup
 						data-slot="combobox-content"
 						className={cn(
-							"relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-none bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+							"relative isolate z-50 max-h-(--available-height) min-w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-none bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
 							className,
 						)}
 					>

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -1,5 +1,5 @@
 import { CalendarBlankIcon, XIcon } from "@phosphor-icons/react";
-import { format, parseISO, startOfToday } from "date-fns";
+import dayjs from "dayjs";
 import { useEffect, useMemo, useState } from "react";
 import type { DateRange, Matcher } from "react-day-picker";
 import { Button } from "@/components/ui/button";
@@ -11,8 +11,8 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-const DISPLAY_FORMAT = "MMM d, yyyy";
-const WIRE_FORMAT = "yyyy-MM-dd";
+const DISPLAY_FORMAT = "MMM D, YYYY";
+const WIRE_FORMAT = "YYYY-MM-DD";
 
 interface DatePickerProps {
 	id?: string;
@@ -36,15 +36,15 @@ export const DatePicker = ({
 	className,
 }: DatePickerProps) => {
 	const [isOpen, setIsOpen] = useState(false);
-	const selected = value ? parseISO(value) : undefined;
+	const selected = value ? dayjs(value).toDate() : undefined;
 
 	const disabledMatchers = useMemo<Matcher[] | undefined>(() => {
 		const matchers: Matcher[] = [];
 		if (max) {
-			matchers.push({ after: parseISO(max) });
+			matchers.push({ after: dayjs(max).toDate() });
 		}
 		if (min) {
-			matchers.push({ before: parseISO(min) });
+			matchers.push({ before: dayjs(min).toDate() });
 		}
 		return matchers.length > 0 ? matchers : undefined;
 	}, [min, max]);
@@ -68,7 +68,7 @@ export const DatePicker = ({
 				}
 			>
 				<span className="truncate">
-					{value ? format(selected as Date, DISPLAY_FORMAT) : placeholder}
+					{value ? dayjs(value).format(DISPLAY_FORMAT) : placeholder}
 				</span>
 			</PopoverTrigger>
 			<PopoverContent align="start" className="w-auto p-0">
@@ -78,7 +78,7 @@ export const DatePicker = ({
 					defaultMonth={selected}
 					disabled={disabledMatchers}
 					onSelect={(date) => {
-						onChange(date ? format(date, WIRE_FORMAT) : undefined);
+						onChange(date ? dayjs(date).format(WIRE_FORMAT) : undefined);
 						setIsOpen(false);
 					}}
 				/>
@@ -119,8 +119,8 @@ export const DateRangePicker = ({
 			return undefined;
 		}
 		return {
-			from: from ? parseISO(from) : undefined,
-			to: to ? parseISO(to) : undefined,
+			from: from ? dayjs(from).toDate() : undefined,
+			to: to ? dayjs(to).toDate() : undefined,
 		};
 	}, [from, to]);
 
@@ -138,13 +138,13 @@ export const DateRangePicker = ({
 
 	const label = (() => {
 		if (displayRange?.from && displayRange?.to) {
-			return `${format(displayRange.from, DISPLAY_FORMAT)} - ${format(displayRange.to, DISPLAY_FORMAT)}`;
+			return `${dayjs(displayRange.from).format(DISPLAY_FORMAT)} - ${dayjs(displayRange.to).format(DISPLAY_FORMAT)}`;
 		}
 		if (displayRange?.from) {
-			return format(displayRange.from, DISPLAY_FORMAT);
+			return dayjs(displayRange.from).format(DISPLAY_FORMAT);
 		}
 		if (displayRange?.to) {
-			return format(displayRange.to, DISPLAY_FORMAT);
+			return dayjs(displayRange.to).format(DISPLAY_FORMAT);
 		}
 		return placeholder;
 	})();
@@ -177,7 +177,7 @@ export const DateRangePicker = ({
 					defaultMonth={displayRange?.from}
 					selected={displayRange}
 					numberOfMonths={numberOfMonths}
-					disabled={{ after: startOfToday() }}
+					disabled={{ after: dayjs().startOf("day").toDate() }}
 					onSelect={(range) => {
 						setDraftRange(range);
 						if (commitOnComplete && !(range?.from && range?.to)) {
@@ -187,8 +187,10 @@ export const DateRangePicker = ({
 							return;
 						}
 						onChange({
-							from: range?.from ? format(range.from, WIRE_FORMAT) : undefined,
-							to: range?.to ? format(range.to, WIRE_FORMAT) : undefined,
+							from: range?.from
+								? dayjs(range.from).format(WIRE_FORMAT)
+								: undefined,
+							to: range?.to ? dayjs(range.to).format(WIRE_FORMAT) : undefined,
 						});
 					}}
 				/>

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -134,6 +134,7 @@ export const DateRangePicker = ({
 
 	const displayRange = draftRange ?? selectedFromProps;
 	const hasValue = Boolean(from || to);
+	const showClear = Boolean(onClear) && hasValue;
 
 	const label = (() => {
 		if (displayRange?.from && displayRange?.to) {
@@ -160,6 +161,7 @@ export const DateRangePicker = ({
 						className={cn(
 							"h-10 justify-start font-normal",
 							!hasValue && "text-muted-foreground",
+							showClear && "pr-9",
 							className,
 						)}
 						icon={<CalendarBlankIcon className="size-4" />}
@@ -199,18 +201,17 @@ export const DateRangePicker = ({
 	}
 
 	return (
-		<div className="flex flex-wrap items-center gap-2">
+		<div className="relative inline-flex w-fit">
 			{picker}
-			{hasValue ? (
-				<Button
+			{showClear ? (
+				<button
 					type="button"
-					variant="outline"
-					className="h-10"
-					icon={<XIcon className="size-4" />}
+					aria-label="Clear date range"
 					onClick={onClear}
+					className="absolute inset-y-0 right-0 flex w-9 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
 				>
-					Clear
-				</Button>
+					<XIcon className="size-4" />
+				</button>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/features/orders/components/order-dropoff-photo-card.tsx
+++ b/apps/web/src/features/orders/components/order-dropoff-photo-card.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PhotoLightbox } from "@/features/orders/components/photo-lightbox";
 import { SinglePhotoUploadDialog } from "@/features/orders/components/photo-upload-dialog";
+import { formatOrderDateTime } from "@/features/orders/lib/format";
 import { uploadOrderDropoffPhoto } from "@/features/orders/utils/photo-upload";
 import type { OrderDetail } from "@/lib/api";
 
@@ -63,14 +64,7 @@ export const OrderDropoffPhotoCard = memo(
 						</div>
 						{order.dropoff_photo_uploaded_at ? (
 							<p className="text-muted-foreground text-xs">
-								Uploaded{" "}
-								{new Date(order.dropoff_photo_uploaded_at).toLocaleString(
-									"en-ID",
-									{
-										dateStyle: "medium",
-										timeStyle: "short",
-									},
-								)}
+								Uploaded {formatOrderDateTime(order.dropoff_photo_uploaded_at)}
 							</p>
 						) : null}
 						<Button

--- a/apps/web/src/features/orders/components/order-filters.tsx
+++ b/apps/web/src/features/orders/components/order-filters.tsx
@@ -1,0 +1,217 @@
+import { FunnelIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { DebouncedSearchInput } from "@/components/debounced-search-input";
+import { SelectField } from "@/components/form/select-field";
+import { Button } from "@/components/ui/button";
+import { DateRangePicker } from "@/components/ui/date-picker";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
+import { formatOrderStatus, formatPaymentStatus } from "@/lib/status";
+
+export const ORDER_STATUS_VALUES = [
+	"created",
+	"processing",
+	"ready_for_pickup",
+	"completed",
+	"cancelled",
+] as const;
+
+export const PAYMENT_STATUS_VALUES = ["paid", "unpaid"] as const;
+
+type OrderStatusFilter = (typeof ORDER_STATUS_VALUES)[number];
+type PaymentStatusFilter = (typeof PAYMENT_STATUS_VALUES)[number];
+
+export interface OrderFilterValues {
+	search?: string;
+	storeId?: number;
+	status?: OrderStatusFilter;
+	paymentStatus?: PaymentStatusFilter;
+	dateFrom?: string;
+	dateTo?: string;
+}
+
+interface OrderFiltersProps {
+	values: OrderFilterValues;
+	role?: string;
+	userStoreIds: number[];
+	onChange: (patch: Partial<OrderFilterValues>) => void;
+}
+
+// "" is the all-stores/statuses sentinel — selecting it maps back to undefined.
+const STATUS_ITEMS: Record<string, string> = {
+	"": "All statuses",
+	created: formatOrderStatus("created"),
+	processing: formatOrderStatus("processing"),
+	ready_for_pickup: formatOrderStatus("ready_for_pickup"),
+	completed: formatOrderStatus("completed"),
+	cancelled: formatOrderStatus("cancelled"),
+};
+
+const PAYMENT_ITEMS: Record<string, string> = {
+	"": "All payments",
+	paid: formatPaymentStatus("paid"),
+	unpaid: formatPaymentStatus("unpaid"),
+};
+
+interface FilterControlsProps extends OrderFiltersProps {
+	idPrefix: string;
+}
+
+const FilterControls = ({
+	values,
+	role,
+	userStoreIds,
+	onChange,
+	idPrefix,
+}: FilterControlsProps) => (
+	<>
+		<StoreAutocomplete
+			id={`${idPrefix}-store`}
+			hideLabel
+			value={values.storeId?.toString() ?? ""}
+			onValueChange={(value) =>
+				onChange({ storeId: value ? Number(value) : undefined })
+			}
+			allowedStoreIds={role === "admin" ? undefined : userStoreIds}
+			allOptionLabel={role === "admin" ? "All stores" : undefined}
+			placeholder="Filter by store"
+			triggerClassName="h-10 w-full lg:w-max lg:min-w-40"
+		/>
+		<SelectField
+			id={`${idPrefix}-status`}
+			aria-label="Filter by order status"
+			items={STATUS_ITEMS}
+			value={values.status ?? ""}
+			onValueChange={(value) =>
+				onChange({ status: (value || undefined) as OrderStatusFilter })
+			}
+			placeholder="All statuses"
+			className="w-full lg:w-max lg:min-w-40"
+		/>
+		<SelectField
+			id={`${idPrefix}-payment`}
+			aria-label="Filter by payment status"
+			items={PAYMENT_ITEMS}
+			value={values.paymentStatus ?? ""}
+			onValueChange={(value) =>
+				onChange({ paymentStatus: (value || undefined) as PaymentStatusFilter })
+			}
+			placeholder="All payments"
+			className="w-full lg:w-max lg:min-w-40"
+		/>
+		<DateRangePicker
+			id={`${idPrefix}-date`}
+			resetOnSelect
+			commitOnComplete
+			from={values.dateFrom}
+			to={values.dateTo}
+			onChange={({ from, to }) => onChange({ dateFrom: from, dateTo: to })}
+			onClear={() => onChange({ dateFrom: undefined, dateTo: undefined })}
+			className="w-full lg:w-max"
+		/>
+	</>
+);
+
+export const OrderFilters = ({
+	values,
+	role,
+	userStoreIds,
+	onChange,
+}: OrderFiltersProps) => {
+	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
+	const isAdmin = role === "admin";
+
+	const activeCount =
+		(values.status ? 1 : 0) +
+		(values.paymentStatus ? 1 : 0) +
+		(values.dateFrom || values.dateTo ? 1 : 0) +
+		(isAdmin && values.storeId ? 1 : 0);
+
+	const handleClearAll = () => {
+		onChange({
+			status: undefined,
+			paymentStatus: undefined,
+			dateFrom: undefined,
+			dateTo: undefined,
+			...(isAdmin ? { storeId: undefined } : {}),
+		});
+	};
+
+	return (
+		<div className="mb-4 flex flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center">
+			<DebouncedSearchInput
+				id="orders-search"
+				value={values.search ?? ""}
+				onDebouncedChange={(next) => onChange({ search: next || undefined })}
+				placeholder="Order ID, customer, phone"
+				ariaLabel="Search orders"
+				className="w-full lg:w-72"
+			/>
+
+			<div className="hidden lg:flex lg:flex-wrap lg:items-center lg:gap-2">
+				<FilterControls
+					idPrefix="orders-desktop"
+					values={values}
+					role={role}
+					userStoreIds={userStoreIds}
+					onChange={onChange}
+				/>
+			</div>
+
+			<div className="lg:hidden">
+				<Dialog open={isMobileFilterOpen} onOpenChange={setIsMobileFilterOpen}>
+					<DialogTrigger
+						render={
+							<Button
+								type="button"
+								variant="outline"
+								className="h-10 w-full"
+								icon={<FunnelIcon className="size-4" />}
+							/>
+						}
+					>
+						{activeCount > 0 ? `Filters (${activeCount})` : "Filters"}
+					</DialogTrigger>
+					<DialogContent className="gap-5">
+						<DialogHeader>
+							<DialogTitle>Filters</DialogTitle>
+						</DialogHeader>
+						<div className="grid gap-4">
+							<FilterControls
+								idPrefix="orders-mobile"
+								values={values}
+								role={role}
+								userStoreIds={userStoreIds}
+								onChange={onChange}
+							/>
+							<div className="flex gap-2">
+								<Button
+									type="button"
+									variant="outline"
+									className="h-10 flex-1"
+									disabled={activeCount === 0}
+									onClick={handleClearAll}
+								>
+									Clear all
+								</Button>
+								<Button
+									type="button"
+									className="h-10 flex-1"
+									onClick={() => setIsMobileFilterOpen(false)}
+								>
+									Done
+								</Button>
+							</div>
+						</div>
+					</DialogContent>
+				</Dialog>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/order-identity-strip.tsx
+++ b/apps/web/src/features/orders/components/order-identity-strip.tsx
@@ -149,10 +149,25 @@ export const OrderIdentityStrip = ({
 		.filter(Boolean)
 		.join(" · ");
 
+	const renderPickupButton = (className: string) =>
+		readyCount > 0 ? (
+			<Button
+				aria-describedby={
+					gates.canOpenPickup ? undefined : "pickup-disabled-reason"
+				}
+				className={className}
+				disabled={!gates.canOpenPickup}
+				onClick={openPickupDialog}
+				type="button"
+			>
+				Pick up · {readyCount}
+			</Button>
+		) : null;
+
 	return (
 		<Card className="mb-4 sm:mb-6">
-			<CardContent className="grid gap-4 pt-5 sm:pt-6">
-				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+			<CardContent className="grid gap-4">
+				<div className="flex items-start justify-between gap-3">
 					<div className="min-w-0 space-y-2">
 						<div className="flex flex-wrap items-center gap-2">
 							<h1 className="break-all font-mono font-semibold text-lg tracking-tight sm:text-xl">
@@ -178,20 +193,8 @@ export const OrderIdentityStrip = ({
 					</div>
 
 					{showActions ? (
-						<div className="flex w-full items-center gap-2 sm:w-auto sm:shrink-0">
-							{readyCount > 0 ? (
-								<Button
-									aria-describedby={
-										gates.canOpenPickup ? undefined : "pickup-disabled-reason"
-									}
-									className="flex-1 sm:flex-none"
-									disabled={!gates.canOpenPickup}
-									onClick={openPickupDialog}
-									type="button"
-								>
-									Pick up · {readyCount}
-								</Button>
-							) : null}
+						<div className="flex shrink-0 items-center gap-2">
+							{renderPickupButton("hidden sm:inline-flex")}
 							{hasMenu ? (
 								<DropdownMenu>
 									<DropdownMenuTrigger
@@ -233,6 +236,8 @@ export const OrderIdentityStrip = ({
 						</div>
 					) : null}
 				</div>
+
+				{renderPickupButton("w-full sm:hidden")}
 
 				{totalCount > 0 ? (
 					<div className="grid gap-1.5">

--- a/apps/web/src/features/orders/components/order-line-items-card.tsx
+++ b/apps/web/src/features/orders/components/order-line-items-card.tsx
@@ -103,7 +103,7 @@ export const OrderLineItemsCard = ({
 	return (
 		<div className="grid gap-3 sm:gap-4">
 			<Card className="gap-0 overflow-hidden py-0">
-				<SectionHeader>Services · {services.length}</SectionHeader>
+				<SectionHeader>Services</SectionHeader>
 				{services.length > 0 ? (
 					services.map((service) => (
 						<OrderServiceRow
@@ -122,7 +122,7 @@ export const OrderLineItemsCard = ({
 
 			{products.length > 0 ? (
 				<Card className="gap-0 overflow-hidden py-0">
-					<SectionHeader>Products · {products.length}</SectionHeader>
+					<SectionHeader>Products</SectionHeader>
 					{products.map((item) => (
 						<ProductLine
 							key={item.id}

--- a/apps/web/src/features/orders/components/order-money-summary.tsx
+++ b/apps/web/src/features/orders/components/order-money-summary.tsx
@@ -12,9 +12,38 @@ export const OrderMoneySummary = ({ detail }: OrderMoneySummaryProps) => {
 	const net = Number(detail.total ?? 0) - discount;
 	const refunded = Number(detail.refunded_amount ?? 0);
 
+	const servicesSubtotal = detail.services.reduce(
+		(sum, service) => sum + Number(service.subtotal ?? 0),
+		0,
+	);
+	const productsSubtotal = detail.products.reduce(
+		(sum, product) => sum + Number(product.subtotal ?? 0),
+		0,
+	);
+	// Only worth splitting when the subtotal mixes both — otherwise the component
+	// line just repeats the Subtotal.
+	const showSubtotalBreakdown =
+		detail.services.length > 0 && detail.products.length > 0;
+
 	return (
 		<div className="px-4 py-4">
 			<dl className="grid gap-1.5 text-sm tabular-nums">
+				{showSubtotalBreakdown ? (
+					<>
+						<div className="flex justify-between gap-4">
+							<dt className="text-muted-foreground">Services</dt>
+							<dd className="font-mono">
+								{formatIDRCurrency(String(servicesSubtotal))}
+							</dd>
+						</div>
+						<div className="flex justify-between gap-4">
+							<dt className="text-muted-foreground">Products</dt>
+							<dd className="font-mono">
+								{formatIDRCurrency(String(productsSubtotal))}
+							</dd>
+						</div>
+					</>
+				) : null}
 				<div className="flex justify-between gap-4">
 					<dt className="text-muted-foreground">Subtotal</dt>
 					<dd className="font-mono">

--- a/apps/web/src/features/orders/components/order-service-row.tsx
+++ b/apps/web/src/features/orders/components/order-service-row.tsx
@@ -7,6 +7,7 @@ import {
 	formatOrderServiceStatus,
 	getOrderServiceStatusBadgeVariant,
 } from "@/lib/status";
+import { formatIDRCurrency } from "@/shared/utils";
 import { useSheet } from "@/stores/sheet-store";
 
 type OrderServiceRowService = OrderDetail["services"][number];
@@ -24,7 +25,9 @@ export const OrderServiceRow = memo(
 		const code = service.item_code ?? `Service #${service.id}`;
 		const serviceName = service.service?.name ?? "Service";
 		const itemDetails = getOrderServiceItemDetails(service);
-		const handlerName = service.handler?.name;
+		const metaLine = [itemDetails, service.handler?.name]
+			.filter(Boolean)
+			.join(" · ");
 
 		const handleClick = () => {
 			openSheet({
@@ -51,24 +54,24 @@ export const OrderServiceRow = memo(
 						{code}
 					</span>
 					<span className="block text-sm leading-snug">{serviceName}</span>
-					{itemDetails ? (
+					{metaLine ? (
 						<span className="block text-muted-foreground text-xs leading-snug">
-							{itemDetails}
-						</span>
-					) : null}
-					{handlerName ? (
-						<span className="block text-muted-foreground text-xs leading-snug">
-							Handler · {handlerName}
+							{metaLine}
 						</span>
 					) : null}
 				</span>
-				<span className="flex shrink-0 flex-wrap justify-end gap-1.5">
-					{service.is_priority ? (
-						<Badge variant="warning">Priority</Badge>
-					) : null}
-					<Badge variant={getOrderServiceStatusBadgeVariant(service.status)}>
-						{formatOrderServiceStatus(service.status)}
-					</Badge>
+				<span className="flex shrink-0 flex-col items-end gap-1.5">
+					<span className="flex flex-wrap justify-end gap-1.5">
+						{service.is_priority ? (
+							<Badge variant="warning">Priority</Badge>
+						) : null}
+						<Badge variant={getOrderServiceStatusBadgeVariant(service.status)}>
+							{formatOrderServiceStatus(service.status)}
+						</Badge>
+					</span>
+					<span className="font-mono text-sm tabular-nums">
+						{formatIDRCurrency(String(service.subtotal ?? 0))}
+					</span>
 				</span>
 			</button>
 		);

--- a/apps/web/src/features/orders/components/photo-lightbox.tsx
+++ b/apps/web/src/features/orders/components/photo-lightbox.tsx
@@ -3,6 +3,7 @@ import {
 	ArrowRightIcon,
 	ImageSquareIcon,
 } from "@phosphor-icons/react";
+import dayjs from "dayjs";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -14,11 +15,6 @@ import {
 } from "@/components/ui/dialog";
 
 const SWIPE_THRESHOLD = 56;
-
-const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
-	dateStyle: "medium",
-	timeStyle: "short",
-});
 
 export interface PhotoLightboxItem {
 	alt: string;
@@ -49,11 +45,11 @@ export function getPhotoPrimaryLabel(item: {
 }
 
 export function formatPhotoTimestamp(createdAt: string) {
-	const timestamp = new Date(createdAt);
-	if (Number.isNaN(timestamp.getTime())) {
+	const parsed = dayjs(createdAt);
+	if (!parsed.isValid()) {
 		return createdAt;
 	}
-	return dateTimeFormatter.format(timestamp);
+	return parsed.format("DD MMM YYYY, HH:mm");
 }
 
 export const PhotoLightbox = ({

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -99,8 +99,13 @@ const PhotoUploadDialogBase = ({
 		if (cameraOnly) {
 			void openCamera();
 		}
-		return resetDialogState;
-	}, [open, cameraOnly, openCamera, resetDialogState]);
+	}, [open, cameraOnly, openCamera]);
+
+	// Release the camera if the dialog unmounts while still open. The visual reset
+	// (stop camera + clear photos) is deferred to onOpenChangeComplete so the popup
+	// keeps its full height through the close animation instead of collapsing and
+	// re-centering first — that snap was the layout shift.
+	useEffect(() => stopCamera, [stopCamera]);
 
 	const addFiles = useCallback(
 		(files: File[]) => {
@@ -245,7 +250,15 @@ const PhotoUploadDialogBase = ({
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={onOpenChange}
+			onOpenChangeComplete={(isOpen) => {
+				if (!isOpen) {
+					resetDialogState();
+				}
+			}}
+		>
 			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle className="flex items-center justify-between gap-3 pr-8">

--- a/apps/web/src/features/orders/components/status-timeline.tsx
+++ b/apps/web/src/features/orders/components/status-timeline.tsx
@@ -1,4 +1,5 @@
 import { CaretRightIcon } from "@phosphor-icons/react";
+import { formatOrderDateTime } from "@/features/orders/lib/format";
 import { formatOrderServiceStatus } from "@/lib/status";
 
 type StatusLog = {
@@ -27,7 +28,7 @@ export function StatusTimeline({ logs }: { logs: StatusLog[] }) {
 								{formatOrderServiceStatus(log.to_status)}
 							</p>
 							<p className="text-muted-foreground">
-								{`${log.changedBy?.name ?? "—"} · ${new Date(log.created_at).toLocaleString()}`}
+								{`${log.changedBy?.name ?? "—"} · ${formatOrderDateTime(log.created_at)}`}
 							</p>
 							{log.note ? (
 								<p className="text-muted-foreground">{log.note}</p>

--- a/apps/web/src/features/orders/lib/format.ts
+++ b/apps/web/src/features/orders/lib/format.ts
@@ -1,5 +1,4 @@
+import dayjs from "dayjs";
+
 export const formatOrderDateTime = (value: string): string =>
-	new Date(value).toLocaleString("en-ID", {
-		dateStyle: "medium",
-		timeStyle: "short",
-	});
+	dayjs(value).format("DD MMM YYYY, HH:mm");

--- a/apps/web/src/features/reports/utils/granularity.ts
+++ b/apps/web/src/features/reports/utils/granularity.ts
@@ -1,5 +1,5 @@
-import dayjs from "dayjs";
 import type { ReportGranularity } from "@/lib/api";
+import dayjs, { JAKARTA_TZ } from "@/lib/dayjs";
 
 export function daysBetween(from: string, to: string): number {
 	return dayjs(to).diff(dayjs(from), "day") + 1;
@@ -19,25 +19,15 @@ export function pickGranularity(from: string, to: string): ReportGranularity {
 	return "year";
 }
 
-const monthLabelFormatter = new Intl.DateTimeFormat("en-ID", {
-	month: "short",
-	year: "2-digit",
-});
-
-const dayShortFormatter = new Intl.DateTimeFormat("en-ID", {
-	day: "2-digit",
-	month: "short",
-});
-
 export function bucketToLabel(
 	bucket: string,
 	granularity: ReportGranularity,
 ): string {
 	if (granularity === "day") {
-		return dayShortFormatter.format(new Date(`${bucket}T00:00:00+07:00`));
+		return dayjs.tz(bucket, JAKARTA_TZ).format("DD MMM");
 	}
 	if (granularity === "month") {
-		return monthLabelFormatter.format(new Date(`${bucket}-01T00:00:00+07:00`));
+		return dayjs.tz(`${bucket}-01`, JAKARTA_TZ).format("MMM YY");
 	}
 	if (granularity === "year") {
 		return bucket;
@@ -51,19 +41,10 @@ export function bucketToTooltipLabel(
 	granularity: ReportGranularity,
 ): string {
 	if (granularity === "day") {
-		const d = new Date(`${bucket}T00:00:00+07:00`);
-		return d.toLocaleDateString("en-ID", {
-			weekday: "short",
-			day: "2-digit",
-			month: "short",
-			year: "numeric",
-		});
+		return dayjs.tz(bucket, JAKARTA_TZ).format("ddd, DD MMM YYYY");
 	}
 	if (granularity === "month") {
-		return new Date(`${bucket}-01T00:00:00+07:00`).toLocaleDateString("en-ID", {
-			month: "long",
-			year: "numeric",
-		});
+		return dayjs.tz(`${bucket}-01`, JAKARTA_TZ).format("MMMM YYYY");
 	}
 	if (granularity === "year") {
 		return `Year ${bucket}`;

--- a/apps/web/src/features/reports/utils/report-filters.ts
+++ b/apps/web/src/features/reports/utils/report-filters.ts
@@ -1,14 +1,7 @@
-import dayjs from "dayjs";
-
-const jakartaDateFormatter = new Intl.DateTimeFormat("en-CA", {
-	timeZone: "Asia/Jakarta",
-	year: "numeric",
-	month: "2-digit",
-	day: "2-digit",
-});
+import dayjs, { JAKARTA_TZ } from "@/lib/dayjs";
 
 export function jakartaToday(): string {
-	return jakartaDateFormatter.format(new Date());
+	return dayjs().tz(JAKARTA_TZ).format("YYYY-MM-DD");
 }
 
 export type DatePreset =

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -264,7 +264,12 @@ export type FetchOrdersQuery = {
 	offset?: number;
 	search?: string;
 	store_id?: number;
-	status?: "created" | "processing" | "completed" | "cancelled";
+	status?:
+		| "created"
+		| "processing"
+		| "ready_for_pickup"
+		| "completed"
+		| "cancelled";
 	payment_status?: "paid" | "unpaid";
 	date_from?: string;
 	date_to?: string;

--- a/apps/web/src/lib/dayjs.ts
+++ b/apps/web/src/lib/dayjs.ts
@@ -1,0 +1,13 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+// Plugins for Asia/Jakarta-aware formatting (reports). Importing from this
+// module guarantees the plugins are extended before `.tz()` is called and
+// makes `.tz()` type-visible project-wide.
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const JAKARTA_TZ = "Asia/Jakarta";
+
+export default dayjs;

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -2,19 +2,23 @@ import { CrosshairSimpleIcon, PlusIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
+import dayjs from "dayjs";
 import { useCallback, useEffect, useMemo } from "react";
 import { z } from "zod";
 import { DataTable } from "@/components/data-table";
-import { DebouncedSearchInput } from "@/components/debounced-search-input";
 import { PageHeader } from "@/components/page-header";
 import { TablePagination } from "@/components/table-pagination";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { DateRangePicker } from "@/components/ui/date-picker";
+import {
+	ORDER_STATUS_VALUES,
+	OrderFilters,
+	type OrderFilterValues,
+	PAYMENT_STATUS_VALUES,
+} from "@/features/orders/components/order-filters";
 import { PickupRadar } from "@/features/orders/components/pickup-radar";
-import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
-import type { Order } from "@/lib/api";
+import type { FetchOrdersQuery, Order } from "@/lib/api";
 import {
 	meQueryOptions,
 	ordersPageQueryOptions,
@@ -32,17 +36,12 @@ import { formatIDRCurrency } from "@/shared/utils";
 import { getCurrentUser } from "@/stores/auth-store";
 import { useSheet } from "@/stores/sheet-store";
 
-const orderCreatedFormatter = new Intl.DateTimeFormat("en-ID", {
-	day: "2-digit",
-	month: "short",
-	hour: "2-digit",
-	minute: "2-digit",
-});
-
 const ordersSearchSchema = z.object({
 	page: z.coerce.number().int().positive().catch(1),
 	search: z.string().trim().min(1).max(100).optional(),
 	storeId: z.coerce.number().int().positive().optional(),
+	status: z.enum(ORDER_STATUS_VALUES).optional(),
+	paymentStatus: z.enum(PAYMENT_STATUS_VALUES).optional(),
 	dateFrom: z
 		.string()
 		.regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -54,6 +53,22 @@ const ordersSearchSchema = z.object({
 });
 
 const PAGE_SIZE = 25;
+
+function buildOrdersListParams(
+	filters: OrderFilterValues & { page: number },
+	storeId?: number,
+): FetchOrdersQuery {
+	return {
+		limit: PAGE_SIZE,
+		offset: (filters.page - 1) * PAGE_SIZE,
+		...(filters.search ? { search: filters.search } : {}),
+		...(storeId !== undefined ? { store_id: storeId } : {}),
+		...(filters.status ? { status: filters.status } : {}),
+		...(filters.paymentStatus ? { payment_status: filters.paymentStatus } : {}),
+		...(filters.dateFrom ? { date_from: filters.dateFrom } : {}),
+		...(filters.dateTo ? { date_to: filters.dateTo } : {}),
+	};
+}
 
 export const Route = createFileRoute("/_admin/orders/")({
 	validateSearch: (search) => ordersSearchSchema.parse(search),
@@ -69,24 +84,7 @@ export const Route = createFileRoute("/_admin/orders/")({
 
 		if (me?.role === "admin" || deps.storeId !== undefined) {
 			await context.queryClient.ensureQueryData(
-				ordersPageQueryOptions(
-					deps.storeId !== undefined
-						? {
-								limit: PAGE_SIZE,
-								offset: (deps.page - 1) * PAGE_SIZE,
-								...(deps.search ? { search: deps.search } : {}),
-								store_id: deps.storeId,
-								...(deps.dateFrom ? { date_from: deps.dateFrom } : {}),
-								...(deps.dateTo ? { date_to: deps.dateTo } : {}),
-							}
-						: {
-								limit: PAGE_SIZE,
-								offset: (deps.page - 1) * PAGE_SIZE,
-								...(deps.search ? { search: deps.search } : {}),
-								...(deps.dateFrom ? { date_from: deps.dateFrom } : {}),
-								...(deps.dateTo ? { date_to: deps.dateTo } : {}),
-							},
-				),
+				ordersPageQueryOptions(buildOrdersListParams(deps, deps.storeId)),
 			);
 		}
 	},
@@ -130,48 +128,22 @@ function OrdersPage() {
 		}
 	}, [currentUser, navigate, role, search.storeId, userStoreIds]);
 
-	const handleSearchChange = useCallback(
-		(next: string) => {
+	const handleFilterChange = useCallback(
+		(patch: Partial<OrderFilterValues>) => {
 			void navigate({
-				search: (prev) => ({
-					...prev,
-					page: 1,
-					search: next || undefined,
-				}),
+				search: (prev) => ({ ...prev, page: 1, ...patch }),
 			});
 		},
 		[navigate],
 	);
 
 	const parsedStoreId = search.storeId;
+	// Admin and non-admin build the same params once a store is chosen; the only
+	// gap — non-admin with no store — never runs (gated by `enabled` below).
 	const orderQuery =
-		role === "admin"
-			? parsedStoreId
-				? {
-						limit: PAGE_SIZE,
-						offset: (search.page - 1) * PAGE_SIZE,
-						...(search.search ? { search: search.search } : {}),
-						store_id: parsedStoreId,
-						...(search.dateFrom ? { date_from: search.dateFrom } : {}),
-						...(search.dateTo ? { date_to: search.dateTo } : {}),
-					}
-				: {
-						limit: PAGE_SIZE,
-						offset: (search.page - 1) * PAGE_SIZE,
-						...(search.search ? { search: search.search } : {}),
-						...(search.dateFrom ? { date_from: search.dateFrom } : {}),
-						...(search.dateTo ? { date_to: search.dateTo } : {}),
-					}
-			: parsedStoreId
-				? {
-						limit: PAGE_SIZE,
-						offset: (search.page - 1) * PAGE_SIZE,
-						...(search.search ? { search: search.search } : {}),
-						store_id: parsedStoreId,
-						...(search.dateFrom ? { date_from: search.dateFrom } : {}),
-						...(search.dateTo ? { date_to: search.dateTo } : {}),
-					}
-				: undefined;
+		role !== "admin" && parsedStoreId === undefined
+			? undefined
+			: buildOrdersListParams(search, parsedStoreId);
 
 	const ordersQuery = useQuery({
 		...ordersPageQueryOptions(orderQuery),
@@ -222,8 +194,8 @@ function OrdersPage() {
 					},
 				},
 				cell: ({ row }) => (
-					<span className="font-mono font-medium text-muted-foreground text-xs tabular-nums">
-						{orderCreatedFormatter.format(new Date(row.original.created_at))}
+					<span className="font-mono text-muted-foreground tabular-nums">
+						{dayjs(row.original.created_at).format("D MMM HH:mm")}
 					</span>
 				),
 			},
@@ -236,9 +208,7 @@ function OrdersPage() {
 					},
 				},
 				cell: ({ row }) => (
-					<span className="font-mono font-medium text-foreground">
-						{row.original.store_code}
-					</span>
+					<span className="font-mono">{row.original.store_code}</span>
 				),
 			},
 			{
@@ -357,60 +327,12 @@ function OrdersPage() {
 			<div className="grid gap-4">
 				<Card>
 					<CardContent>
-						<div className="mb-4 flex flex-wrap items-center gap-2">
-							<DebouncedSearchInput
-								id="orders-search"
-								value={search.search ?? ""}
-								onDebouncedChange={handleSearchChange}
-								placeholder="Order ID, customer, phone"
-								ariaLabel="Search orders"
-								className="w-full sm:w-72"
-							/>
-							<StoreAutocomplete
-								id="orders-store-filter"
-								hideLabel
-								value={search.storeId?.toString() ?? ""}
-								onValueChange={(value) => {
-									void navigate({
-										search: (prev) => ({
-											...prev,
-											page: 1,
-											storeId: value ? Number(value) : undefined,
-										}),
-									});
-								}}
-								allowedStoreIds={role === "admin" ? undefined : userStoreIds}
-								allOptionLabel={role === "admin" ? "All stores" : undefined}
-								placeholder="Filter by store"
-								triggerClassName="h-10 w-max min-w-48 text-sm"
-							/>
-							<DateRangePicker
-								resetOnSelect
-								commitOnComplete
-								from={search.dateFrom}
-								to={search.dateTo}
-								onChange={({ from, to }) => {
-									void navigate({
-										search: (prev) => ({
-											...prev,
-											page: 1,
-											dateFrom: from,
-											dateTo: to,
-										}),
-									});
-								}}
-								onClear={() => {
-									void navigate({
-										search: (prev) => ({
-											...prev,
-											page: 1,
-											dateFrom: undefined,
-											dateTo: undefined,
-										}),
-									});
-								}}
-							/>
-						</div>
+						<OrderFilters
+							values={search}
+							role={role}
+							userStoreIds={userStoreIds}
+							onChange={handleFilterChange}
+						/>
 						{hasNoStoreAssignment ? (
 							<div className="border border-dashed border-border bg-muted/20 px-6 py-10 text-center font-medium font-mono text-[11px] text-muted-foreground uppercase tracking-[0.18em]">
 								No store assigned

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -176,21 +176,18 @@ function OrdersPage() {
 					mobileCard: {
 						slot: "title",
 					},
-					headerClassName: "left-0 z-20 border-border border-r",
-					cellClassName:
-						"sticky left-0 z-10 border-border border-r bg-background",
 				},
 				cell: ({ row }) => (
 					<div className="flex flex-col gap-0.5">
 						<Link
 							to="/orders/$orderId"
 							params={{ orderId: String(row.original.id) }}
-							className="font-mono font-semibold text-foreground underline underline-offset-4 md:font-normal"
+							className="font-mono font-semibold"
 						>
 							{row.original.code}
 						</Link>
 						<span className="font-mono font-normal text-[11px] text-muted-foreground tabular-nums">
-							{dayjs(row.original.created_at).format("DD MMM")}
+							{row.original.store_name}
 						</span>
 					</div>
 				),
@@ -204,7 +201,7 @@ function OrdersPage() {
 					},
 				},
 				cell: ({ row }) => (
-					<span className="font-mono">{row.original.store_code}</span>
+					<span>{dayjs(row.original.created_at).format("DD MMM HH:mm")}</span>
 				),
 			},
 			{
@@ -213,27 +210,14 @@ function OrdersPage() {
 				meta: {
 					mobileCard: {
 						label: "Customer",
+						className: "col-span-2",
 						valueClassName: "truncate",
 					},
 				},
 			},
 			{
-				id: "items",
-				header: "Items",
-				meta: {
-					mobileCard: {
-						label: "Items",
-					},
-				},
-				cell: ({ row }) => (
-					<span className="font-mono tabular-nums">
-						{row.original.fulfillment.service_total_count}
-					</span>
-				),
-			},
-			{
 				accessorKey: "status",
-				header: "Status",
+				header: "Fulfillment",
 				meta: {
 					mobileCard: {
 						slot: "badges",

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -38,18 +38,20 @@ import { useSheet } from "@/stores/sheet-store";
 
 const ordersSearchSchema = z.object({
 	page: z.coerce.number().int().positive().catch(1),
-	search: z.string().trim().min(1).max(100).optional(),
-	storeId: z.coerce.number().int().positive().optional(),
-	status: z.enum(ORDER_STATUS_VALUES).optional(),
-	paymentStatus: z.enum(PAYMENT_STATUS_VALUES).optional(),
+	search: z.string().trim().min(1).max(100).optional().catch(undefined),
+	storeId: z.coerce.number().int().positive().optional().catch(undefined),
+	status: z.enum(ORDER_STATUS_VALUES).optional().catch(undefined),
+	paymentStatus: z.enum(PAYMENT_STATUS_VALUES).optional().catch(undefined),
 	dateFrom: z
 		.string()
 		.regex(/^\d{4}-\d{2}-\d{2}$/)
-		.optional(),
+		.optional()
+		.catch(undefined),
 	dateTo: z
 		.string()
 		.regex(/^\d{4}-\d{2}-\d{2}$/)
-		.optional(),
+		.optional()
+		.catch(undefined),
 });
 
 const PAGE_SIZE = 25;

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -1,4 +1,4 @@
-import { CrosshairSimpleIcon, PlusIcon } from "@phosphor-icons/react";
+import { CrosshairSimpleIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -176,29 +176,23 @@ function OrdersPage() {
 					mobileCard: {
 						slot: "title",
 					},
+					headerClassName: "left-0 z-20 border-border border-r",
+					cellClassName:
+						"sticky left-0 z-10 border-border border-r bg-background",
 				},
 				cell: ({ row }) => (
-					<Link
-						to="/orders/$orderId"
-						params={{ orderId: String(row.original.id) }}
-						className="font-mono font-semibold text-foreground underline underline-offset-4 md:font-normal"
-					>
-						{row.original.code}
-					</Link>
-				),
-			},
-			{
-				id: "created",
-				header: "Created",
-				meta: {
-					mobileCard: {
-						slot: "eyebrow",
-					},
-				},
-				cell: ({ row }) => (
-					<span className="font-mono text-muted-foreground tabular-nums">
-						{dayjs(row.original.created_at).format("D MMM HH:mm")}
-					</span>
+					<div className="flex flex-col gap-0.5">
+						<Link
+							to="/orders/$orderId"
+							params={{ orderId: String(row.original.id) }}
+							className="font-mono font-semibold text-foreground underline underline-offset-4 md:font-normal"
+						>
+							{row.original.code}
+						</Link>
+						<span className="font-mono font-normal text-[11px] text-muted-foreground tabular-nums">
+							{dayjs(row.original.created_at).format("DD MMM")}
+						</span>
+					</div>
 				),
 			},
 			{
@@ -298,32 +292,18 @@ function OrdersPage() {
 		[],
 	);
 
-	const handleAddOrder = () => {
-		void navigate({
-			to: "/transactions",
-		});
-	};
-
 	return (
 		<>
 			<PageHeader
 				title="Orders"
 				actions={
-					<>
-						<Button
-							variant="outline"
-							onClick={handleOpenPickupRadar}
-							icon={<CrosshairSimpleIcon className="size-4" />}
-						>
-							Pickup Radar
-						</Button>
-						<Button
-							onClick={handleAddOrder}
-							icon={<PlusIcon className="size-4" />}
-						>
-							Add Order
-						</Button>
-					</>
+					<Button
+						variant="outline"
+						onClick={handleOpenPickupRadar}
+						icon={<CrosshairSimpleIcon className="size-4" />}
+					>
+						Pickup Radar
+					</Button>
 				}
 			/>
 			<div className="grid gap-4">

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
+        "dayjs": "^1.11.21",
         "hono": "catalog:",
         "input-otp": "^1.4.2",
         "jwt-decode": "^4.0.0",
@@ -391,7 +392,7 @@
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.101.0", "", { "dependencies": { "@tanstack/query-devtools": "5.101.0" }, "peerDependencies": { "@tanstack/react-query": "^5.101.0", "react": "^18 || ^19" } }, "sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 


### PR DESCRIPTION
## Summary
- New `OrderFilters` component: search + store/status/payment selects + date range. Responsive — inline row on desktop, `Filters (n)` dialog on mobile. Selects self-clear via the "All …" sentinel; date range clears via its inline X (no separate chips).
- `orders.index.tsx` is now a thin orchestrator: duplicated list-param branches collapsed into a single `buildOrdersListParams` shared by loader and component.
- Orders table columns recreated to essentials: Code · **Created** · **Store code** · Customer · Items · Status · Payment · Total.
- Rows given more vertical space (`py-3`), scoped to `DataTable` (raw `<Table>` usages untouched).

## Shared component changes
- `DateRangePicker`: Clear relocated from a sibling button to an inline X inside the trigger.
- `Combobox`: popup grows to content width (`min-w-anchor`/`max-w-available`) and left-aligns, so long store names are no longer truncated on narrow triggers.
- `FetchOrdersQuery.status` now includes `ready_for_pickup`.

## Test plan
- `/orders` desktop: filter row aligned (store/status/payment same size); apply status/payment/date, clear each.
- `/orders` mobile: `Filters` dialog, count badge, Clear all.
- Store filter: open dropdown on a narrow trigger → full `CODE - Name` visible, left-aligned.
- Table: Created + store code render; rows taller.