### PR TITLE
feat(orders): require item photo before processing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,7 +83,7 @@ A second derived field on Order, separate from Order status. Computed from money
 **OrderService status**:
 A single `orderServiceStatusEnum` column on `orders_services` that conflates two axes for v1:
 
-- **Processing axis** — `queued → processing → quality_check → (qc_reject → processing | ready_for_pickup) → picked_up`. QC redo always loops through `qc_reject` (no direct `quality_check → processing` shortcut) so every redo is auditable in `order_service_status_logs`. `picked_up` is the success terminal; the transition is gated by pickup-code validation in the pickup dialog and is never settable from a generic status dropdown.
+- **Processing axis** — `queued → processing → quality_check → (qc_reject → processing | ready_for_pickup) → picked_up`. QC redo always loops through `qc_reject` (no direct `quality_check → processing` shortcut) so every redo is auditable in `order_service_status_logs`. `queued → processing` requires ≥1 non-deleted service photo (proof-of-condition; the `qc_reject → processing` redo is exempt) — see [ADR-0012](docs/adr/0012-photo-precedes-processing.md). `picked_up` is the success terminal; the transition is gated by pickup-code validation in the pickup dialog and is never settable from a generic status dropdown.
 - **Terminal-outcome axis** — `cancelled` and `refunded` are exit states gated by the Order's `payment_status` (unpaid → `cancelled`, paid → `refunded`). See [ADR-0004](docs/adr/0004-role-capabilities-v1.md). Reading these values loses the processing step the OrderService was in at the moment of exit; reconstruct from `order_service_status_logs` if needed.
 
 Splitting the two axes into separate columns is a recorded follow-up tied to the Order Status Machine refactor; v1 ships with the conflated encoding.
@@ -92,7 +92,7 @@ Splitting the two axes into separate columns is a recorded follow-up tied to the
 One module owns every status write on `orders` and `orders_services`, plus the matching audit-log entry. Lives at `packages/server/src/modules/orders/order-status-machine.ts`. It holds:
 
 - `deriveOrderStatus` — pure function. Children OrderService statuses + product count → Order rollup status.
-- `transitionOrderService` — public seam for non-terminal status changes. Looks up the transition graph (`ORDER_SERVICE_TRANSITIONS`), rejects illegal moves, writes the row + status-log entry + recomputed Order rollup. Refuses `picked_up` and `refunded`; callers must use the sibling-only seams below. Refuses `cancelled` when Order is paid (per ADR-0004 disjoint off-ramps).
+- `transitionOrderService` — public seam for non-terminal status changes. Looks up the transition graph (`ORDER_SERVICE_TRANSITIONS`), rejects illegal moves, writes the row + status-log entry + recomputed Order rollup. Refuses `picked_up` and `refunded`; callers must use the sibling-only seams below. Refuses `cancelled` when Order is paid (per ADR-0004 disjoint off-ramps). Refuses `queued → processing` when the OrderService has zero non-deleted photos (per [ADR-0012](docs/adr/0012-photo-precedes-processing.md)).
 - `completePickup` / `applyRefundTransition` — sibling-only seams for terminal transitions. The Pickup module calls `completePickup` **after** writing `order_pickup_events`; the Reversal module calls `applyRefundTransition` **after** writing `order_refunds` + `order_refund_items`.
 
 All status writes go through this module. Do not write `orders_services.status` or `orders.status` directly from a handler.
@@ -113,7 +113,7 @@ The POS phone→name prefill. A dedicated `GET /admin/customers/lookup?phone=` r
 One per Order, captured on the store iPad at intake. **Required at intake** — the POS blocks checkout until one is attached. Captured before the Order exists and attached immediately after checkout commits; still replaceable later on the order detail page. Not a hard invariant: if the post-checkout attach fails, the Order can briefly exist without one, surfaced as "Missing" on the detail page for retry. (Was "Non-blocking" pre-2026-06-15.)
 
 **Service detail photo**:
-N per OrderService, no cap, captured during processing on the worker phone. Optional per-photo note.
+N per OrderService, no cap, capturable from intake onward on the worker phone (upload is **not** status-gated). Optional per-photo note. **At least one is required to start work**: an OrderService cannot transition `queued → processing` with zero non-deleted photos — proof-of-condition before the shop touches the pair. See [ADR-0012](docs/adr/0012-photo-precedes-processing.md).
 
 **Pickup photo**:
 Captured per OrderPickupEvent, **blocking** at the picked-up transition.

--- a/apps/web/src/features/orders/components/order-service-detail.tsx
+++ b/apps/web/src/features/orders/components/order-service-detail.tsx
@@ -124,6 +124,9 @@ export const OrderServiceDetail = ({
 			!TERMINAL_SERVICE_STATUSES.has(nextStatus),
 	);
 	const itemLabel = service.item_code ?? `Service #${service.id}`;
+	// ADR-0012: a pair cannot start processing without a photo.
+	const needsPhotoToStart =
+		service.status === "queued" && service.images.length === 0;
 
 	return (
 		<div className="grid gap-5 text-sm">
@@ -135,15 +138,23 @@ export const OrderServiceDetail = ({
 			</div>
 
 			{availableTransitions.length > 0 ? (
-				<div className="flex flex-wrap gap-2">
-					{availableTransitions.map((nextStatus) => (
-						<ServiceStatusUpdateButton
-							key={nextStatus}
-							nextStatus={nextStatus}
-							serviceId={service.id}
-							updateStatusMutation={updateStatusMutation}
-						/>
-					))}
+				<div className="grid gap-2">
+					<div className="flex flex-wrap gap-2">
+						{availableTransitions.map((nextStatus) => (
+							<ServiceStatusUpdateButton
+								disabled={nextStatus === "processing" && needsPhotoToStart}
+								key={nextStatus}
+								nextStatus={nextStatus}
+								serviceId={service.id}
+								updateStatusMutation={updateStatusMutation}
+							/>
+						))}
+					</div>
+					{needsPhotoToStart ? (
+						<p className="text-muted-foreground text-xs">
+							Add an item photo before starting work.
+						</p>
+					) : null}
 				</div>
 			) : null}
 

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -173,6 +173,8 @@ export function QueueServiceDetail({
 		!isHandledByCurrentUser;
 	const nextStatuses = ORDER_SERVICE_TRANSITIONS[selectedService.status] ?? [];
 	const canStartWork = selectedService.status === "queued";
+	// ADR-0012: a pair cannot start processing without a photo.
+	const needsPhotoToStart = canStartWork && selectedService.images.length === 0;
 	const actionStatuses = nextStatuses.filter(
 		(status) =>
 			!WORKER_BLOCKED_QUEUE_STATUSES.has(status) &&
@@ -328,11 +330,16 @@ export function QueueServiceDetail({
 			</div>
 
 			<div className="sticky bottom-0 z-10 mt-6 border-t border-border bg-background/95 px-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-3 backdrop-blur sm:px-0 sm:pb-3">
+				{needsPhotoToStart ? (
+					<p className="mb-2 text-xs text-muted-foreground">
+						Add an item photo before starting work.
+					</p>
+				) : null}
 				<div className="flex flex-col gap-2 sm:flex-row">
 					{canStartWork ? (
 						<HoldToConfirmButton
 							className="h-12 sm:flex-1"
-							disabled={isHandledByAnotherWorker}
+							disabled={isHandledByAnotherWorker || needsPhotoToStart}
 							loading={startWorkMutation.isPending}
 							onComplete={async () => {
 								await startWorkMutation.mutateAsync();

--- a/apps/web/src/features/orders/components/service-status-update-button.tsx
+++ b/apps/web/src/features/orders/components/service-status-update-button.tsx
@@ -11,17 +11,22 @@ interface ServiceStatusUpdateButtonProps {
 	serviceId: number;
 	nextStatus: NonTerminalServiceStatus;
 	updateStatusMutation: UpdateStatusMutation;
+	disabled?: boolean;
 }
 
 export const ServiceStatusUpdateButton = ({
 	serviceId,
 	nextStatus,
 	updateStatusMutation,
+	disabled,
 }: ServiceStatusUpdateButtonProps) => {
 	const openDialog = useDialog((s) => s.openDialog);
 	const closeDialog = useDialog((s) => s.closeDialog);
 
 	const handleClick = () => {
+		if (disabled) {
+			return;
+		}
 		openDialog({
 			title: `Update Status to ${STATUS_ACTION_LABELS[nextStatus]}`,
 			description: `Are you sure you want to change the status to ${STATUS_ACTION_LABELS[nextStatus]}?`,
@@ -37,7 +42,12 @@ export const ServiceStatusUpdateButton = ({
 	};
 
 	return (
-		<Button variant="secondary" size="sm" onClick={handleClick}>
+		<Button
+			disabled={disabled}
+			onClick={handleClick}
+			size="sm"
+			variant="secondary"
+		>
 			{STATUS_ACTION_LABELS[nextStatus]}
 		</Button>
 	);

--- a/docs/adr/0012-photo-precedes-processing.md
+++ b/docs/adr/0012-photo-precedes-processing.md
@@ -1,0 +1,25 @@
+# Photo precedes processing
+
+Service detail photos shipped as **optional**, captured *during* processing on the worker phone ([CONTEXT.md](../../CONTEXT.md) — Photos). The business now wants at least one photo of a pair **before** work starts on it: proof-of-condition before the shop touches the shoes (dispute/liability evidence). We decided that an `OrderService` cannot leave `queued → processing` while it has **zero non-deleted** service photos.
+
+This is the per-pair twin of the order-level drop-off gate: the drop-off photo proves what arrived at intake; the per-pair photo proves each pair's condition before cleaning begins.
+
+## Considered options
+
+- **Hard gate, server-enforced (chosen).** The `queued → processing` transition refuses when the OrderService has zero non-deleted `order_services_images`. Enforced in the status-machine seam, mirrored in the UI.
+- **UI-only nudge on the order detail screen.** Rejected: the queue's "Hold to Start Work" does the identical `queued → processing`, and the raw status endpoint is callable directly — both would bypass a button-level check. A real rule belongs at the single write seam, not on one button.
+- **New "before-work" photo kind, separate from detail photos.** Rejected: `order_services_images` has no kind discriminator today and nobody asked to split before/after. Any non-deleted service photo counts for v1; revisit if the business later wants a typed split.
+
+## Decisions
+
+- **Enforced server-side in `transitionOrderService`** (`order-status-machine.ts`) — the single chokepoint both `updateOrderServiceStatus` (order detail) and `startOrderServiceWork` (queue) funnel through. The check fires only when `from === "queued" && to === "processing"`; zero non-deleted images → `BadRequestException`. The count runs on the same executor (transaction) as the transition.
+- **Scope: `queued → processing` only.** `qc_reject → processing` (the QC redo loop) is exempt — by then the pair was already processed once and photos exist; re-gating a redo is friction without liability gain.
+- **No override.** Uniform for every role including admin. The processing axis is role-open (any staff start work); the photo gate is role-blind. A gate admins can wave through is not a gate.
+- **Web mirror.** Order detail disables the "Process" button and the queue disables "Hold to Start Work" when `status === "queued" && images.length === 0`, with the hint "Add an item photo before starting work." The photo-add control sits in the same panel on both surfaces. The server stays the source of truth; the UI only explains the gate early.
+- **Count is soft-delete aware** — only `order_services_images` rows with `deleted_at IS NULL` count, matching the client's `service.images`.
+
+## Consequences
+
+- A photo is **capturable while still queued** — `saveOrderServicePhoto` does not gate on status — so the rule is no chicken-and-egg deadlock: photograph the pair, then start.
+- An Order now has **two** photo gates with distinct purposes: the order-level drop-off photo at intake ([CONTEXT.md](../../CONTEXT.md) — Drop-off photo) and the per-pair service photo at work start.
+- **No schema change.** Existing `queued` items with zero photos become un-startable until one is added; nothing migrates.

--- a/packages/server/src/modules/orders/order-status-machine.test.ts
+++ b/packages/server/src/modules/orders/order-status-machine.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { orderServiceStatusEnum } from "@/db/schema";
+import { BadRequestException } from "@/errors";
 import {
+  type DbExecutor,
   deriveOrderStatus,
   isTerminalOrderServiceStatus,
   ORDER_SERVICE_TRANSITIONS,
   ORDER_TERMINAL_SERVICE_STATUSES,
   type OrderServiceStatus,
   summarizeOrderFulfillment,
+  transitionOrderService,
 } from "@/modules/orders/order-status-machine";
 
 const s = (status: OrderServiceStatus) => ({ status });
@@ -151,6 +154,77 @@ describe("isTerminalOrderServiceStatus", () => {
     for (const status of active) {
       expect(isTerminalOrderServiceStatus(status)).toBe(false);
     }
+  });
+});
+
+// transitionOrderService takes its DB handle as a parameter, so a hand-rolled
+// fake executor exercises the photo gate without a database. The fluent
+// update/insert stubs only need to satisfy the write + rollup path that runs
+// once the gate passes.
+const makeExecutor = ({
+  serviceStatus,
+  hasPhoto,
+}: {
+  serviceStatus: OrderServiceStatus;
+  hasPhoto: boolean;
+}) =>
+  ({
+    query: {
+      ordersServicesTable: {
+        findFirst: () => Promise.resolve({ id: 1, status: serviceStatus }),
+        findMany: () =>
+          Promise.resolve([{ status: "processing" as OrderServiceStatus }]),
+      },
+      orderServicesImagesTable: {
+        findFirst: () => Promise.resolve(hasPhoto ? { id: 10 } : undefined),
+      },
+      ordersProductsTable: {
+        findMany: () => Promise.resolve([]),
+      },
+    },
+    update: () => ({
+      set: () => ({
+        where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }),
+      }),
+    }),
+    insert: () => ({ values: () => Promise.resolve() }),
+  }) as unknown as DbExecutor;
+
+const transitionTo = (executor: DbExecutor, to: OrderServiceStatus) =>
+  transitionOrderService(executor, { orderId: 1, serviceId: 1, to, by: 1 });
+
+describe("transitionOrderService photo gate (ADR-0012)", () => {
+  it("blocks queued -> processing when the service has no photo", async () => {
+    const executor = makeExecutor({ serviceStatus: "queued", hasPhoto: false });
+    let error: unknown;
+    try {
+      await transitionTo(executor, "processing");
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Add an item photo before starting work"
+    );
+  });
+
+  it("allows queued -> processing once a photo exists", async () => {
+    const executor = makeExecutor({ serviceStatus: "queued", hasPhoto: true });
+    expect(await transitionTo(executor, "processing")).toEqual({
+      from: "queued",
+      to: "processing",
+    });
+  });
+
+  it("exempts the qc_reject -> processing redo from the gate", async () => {
+    const executor = makeExecutor({
+      serviceStatus: "qc_reject",
+      hasPhoto: false,
+    });
+    expect(await transitionTo(executor, "processing")).toEqual({
+      from: "qc_reject",
+      to: "processing",
+    });
   });
 });
 

--- a/packages/server/src/modules/orders/order-status-machine.ts
+++ b/packages/server/src/modules/orders/order-status-machine.ts
@@ -199,6 +199,19 @@ export async function transitionOrderService(
     );
   }
 
+  // ADR-0012: proof-of-condition before work starts. A pair cannot leave
+  // queued → processing without at least one non-deleted photo. The qc_reject
+  // redo loop is exempt — photos already exist by then.
+  if (from === "queued" && to === "processing") {
+    const photo = await executor.query.orderServicesImagesTable.findFirst({
+      where: { order_service_id: serviceId, deleted_at: { isNull: true } },
+      columns: { id: true },
+    });
+    if (!photo) {
+      throw new BadRequestException("Add an item photo before starting work");
+    }
+  }
+
   if (to === "cancelled") {
     if (!cancelReason) {
       throw new BadRequestException(


### PR DESCRIPTION
## What

An OrderService cannot move `queued -> processing` without at least one non-deleted photo — a per-pair proof-of-condition gate, the twin of the order-level drop-off photo.

## Where

- **Server (real gate):** `transitionOrderService` (`order-status-machine.ts`) — the single chokepoint both entry points (order-detail status update, queue start-work) and the raw API funnel through. Scope `queued -> processing` only; `qc_reject -> processing` redo exempt; no role override.
- **Web mirrors:** order-detail "Process" and queue "Hold to Start Work" buttons disabled with a hint when the pair is queued with zero photos. `ServiceStatusUpdateButton` gained a `disabled` prop. Server stays source of truth; UI explains the gate early.
- **Docs:** new ADR-0012 + 3 CONTEXT.md edits (Service detail photo, OrderService processing-axis, Order Status Machine seam).
- **Tests:** +3 fake-executor cases — blocks queued+0-photo, allows queued+photo, exempts qc_reject redo.

## Notes

No schema change. A photo is uploadable while queued (upload is not status-gated), so the rule is no deadlock. Existing zero-photo queued items become un-startable until one photo is added.

## Verify

- `bun test order-status-machine` -> 26 pass
- `bun run type-check` -> 3/3
- `bun x ultracite check` -> clean