### PR TITLE
test: cover discount and order gates, wire turbo test task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ bun install            # Install all workspace dependencies
 bun run dev            # Turbo: build API types, then start server (8000) + web (5173)
 bun run build          # Turbo: build all packages (cached)
 bun run lint           # Turbo: lint all packages (cached)
+bun run test           # Turbo: run all bun test suites (cached)
 bun run type-check     # Turbo: type-check all packages (cached)
 ```
 
@@ -65,7 +66,7 @@ The server reads from `process.env`:
 - **Toasts:** Sonner (auto-handled by global mutation callbacks)
 
 ### Monorepo Tooling
-- **Turborepo** for task orchestration (`turbo.json`): `build`, `dev`, `lint`, `type-check`
+- **Turborepo** for task orchestration (`turbo.json`): `build`, `dev`, `lint`, `test`, `type-check`
 - Pipeline topology: `api#build` (tsdown) runs before any web task via `^build` dependency
 - Local caching enabled; no remote caching
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"type-check": "bun run generate-routes && tsc -b",
+		"test": "bun test",
 		"generate-routes": "tsr generate"
 	},
 	"dependencies": {

--- a/apps/web/src/features/orders/lib/order-action-gates.test.ts
+++ b/apps/web/src/features/orders/lib/order-action-gates.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import type { Me, OrderDetail } from "@/lib/api";
+import { getOrderActionGates } from "./order-action-gates";
+
+type ServiceOverrides = Record<string, unknown>;
+
+const service = (over: ServiceOverrides = {}) => ({
+	id: 1,
+	status: "queued",
+	reworkOf: null,
+	complaints: [],
+	...over,
+});
+
+const product = (over: Record<string, unknown> = {}) => ({
+	id: 1,
+	refunded_at: null,
+	cancelled_at: null,
+	...over,
+});
+
+const detail = (over: Record<string, unknown> = {}): OrderDetail =>
+	({
+		status: "processing",
+		payment_status: "paid",
+		services: [],
+		products: [],
+		...over,
+	}) as unknown as OrderDetail;
+
+const admin = { role: "admin" } as Me;
+const cashier = { role: "cashier" } as Me;
+const worker = { role: "worker", can_process_pickup: false } as Me;
+const pickupWorker = { role: "worker", can_process_pickup: true } as Me;
+
+describe("role gates", () => {
+	it("grants money gates to admin and cashier only", () => {
+		expect(getOrderActionGates(admin, detail()).isPaymentAllowed).toBe(true);
+		expect(getOrderActionGates(cashier, detail()).isPaymentAllowed).toBe(true);
+		expect(getOrderActionGates(worker, detail()).isPaymentAllowed).toBe(false);
+	});
+
+	it("grants pickup to payment roles and flagged workers", () => {
+		expect(getOrderActionGates(cashier, detail()).isPickupAllowed).toBe(true);
+		expect(getOrderActionGates(pickupWorker, detail()).isPickupAllowed).toBe(
+			true,
+		);
+		expect(getOrderActionGates(worker, detail()).isPickupAllowed).toBe(false);
+	});
+
+	it("lets workers manage the drop-off photo", () => {
+		expect(getOrderActionGates(worker, detail()).canManageDropoffPhoto).toBe(
+			true,
+		);
+	});
+
+	it("denies everything without a user", () => {
+		const gates = getOrderActionGates(undefined, detail());
+		expect(gates.isAdmin).toBe(false);
+		expect(gates.isPaymentAllowed).toBe(false);
+		expect(gates.isPickupAllowed).toBe(false);
+	});
+});
+
+describe("refundable lines", () => {
+	it("excludes refunded, cancelled, and rework service lines", () => {
+		const gates = getOrderActionGates(
+			admin,
+			detail({
+				services: [
+					service({ id: 1, status: "picked_up" }),
+					service({ id: 2, status: "refunded" }),
+					service({ id: 3, status: "cancelled" }),
+					service({ id: 4, status: "picked_up", reworkOf: { id: 9 } }),
+				],
+			}),
+		);
+
+		expect(gates.refundableServices.map((s) => s.id)).toEqual([1]);
+	});
+
+	it("excludes product lines that already took an off-ramp", () => {
+		const gates = getOrderActionGates(
+			admin,
+			detail({
+				products: [
+					product({ id: 1 }),
+					product({ id: 2, refunded_at: "2026-07-01" }),
+					product({ id: 3, cancelled_at: "2026-07-01" }),
+				],
+			}),
+		);
+
+		expect(gates.refundableProducts.map((p) => p.id)).toEqual([1]);
+	});
+});
+
+describe("cancellable lines", () => {
+	it("excludes picked_up, refunded, and cancelled service lines", () => {
+		const gates = getOrderActionGates(
+			admin,
+			detail({
+				services: [
+					service({ id: 1, status: "processing" }),
+					service({ id: 2, status: "picked_up" }),
+					service({ id: 3, status: "refunded" }),
+					service({ id: 4, status: "cancelled" }),
+				],
+			}),
+		);
+
+		expect(gates.cancellableServices.map((s) => s.id)).toEqual([1]);
+	});
+});
+
+describe("canOpenPickup (ADR-0009: payment precedes pickup)", () => {
+	const readyPaid = detail({
+		payment_status: "paid",
+		services: [service({ status: "ready_for_pickup" })],
+	});
+	const readyUnpaid = detail({
+		payment_status: "unpaid",
+		services: [service({ status: "ready_for_pickup" })],
+	});
+
+	it("opens for a paid order with ready items", () => {
+		expect(getOrderActionGates(cashier, readyPaid).canOpenPickup).toBe(true);
+	});
+
+	it("blocks an unpaid order and explains why per role", () => {
+		const cashierGates = getOrderActionGates(cashier, readyUnpaid);
+		expect(cashierGates.canOpenPickup).toBe(false);
+		expect(cashierGates.pickupDisabledReason).toBe(
+			"Order must be paid before pickup.",
+		);
+
+		const workerGates = getOrderActionGates(pickupWorker, readyUnpaid);
+		expect(workerGates.pickupDisabledReason).toBe(
+			"A cashier must collect payment before pickup.",
+		);
+	});
+
+	it("stays closed with nothing ready", () => {
+		const gates = getOrderActionGates(
+			cashier,
+			detail({ services: [service({ status: "processing" })] }),
+		);
+		expect(gates.canOpenPickup).toBe(false);
+		expect(gates.pickupDisabledReason).toBe(undefined);
+	});
+});
+
+describe("order off-ramps (ADR-0008: disjoint by payment_status)", () => {
+	it("allows cancel only while unpaid", () => {
+		const unpaid = detail({
+			payment_status: "unpaid",
+			services: [service()],
+		});
+		expect(getOrderActionGates(worker, unpaid).canCancelOrder).toBe(true);
+
+		const paid = detail({ payment_status: "paid", services: [service()] });
+		expect(getOrderActionGates(worker, paid).canCancelOrder).toBe(false);
+	});
+
+	it("never cancels a cancelled order", () => {
+		const gates = getOrderActionGates(
+			worker,
+			detail({
+				status: "cancelled",
+				payment_status: "unpaid",
+				services: [service()],
+			}),
+		);
+		expect(gates.canCancelOrder).toBe(false);
+	});
+
+	it("allows refund only for admins on paid orders with refundable lines", () => {
+		const paid = detail({ payment_status: "paid", services: [service()] });
+		expect(getOrderActionGates(admin, paid).canRefundWholeOrder).toBe(true);
+		expect(getOrderActionGates(cashier, paid).canRefundWholeOrder).toBe(false);
+
+		const unpaid = detail({
+			payment_status: "unpaid",
+			services: [service()],
+		});
+		expect(getOrderActionGates(admin, unpaid).canRefundWholeOrder).toBe(false);
+	});
+});
+
+describe("complaintable lines (ADR-0013)", () => {
+	it("offers only picked_up lines with no complaint that are not reworks", () => {
+		const gates = getOrderActionGates(
+			worker,
+			detail({
+				services: [
+					service({ id: 1, status: "picked_up" }),
+					service({ id: 2, status: "picked_up", complaints: [{ id: 7 }] }),
+					service({ id: 3, status: "picked_up", reworkOf: { id: 1 } }),
+					service({ id: 4, status: "ready_for_pickup" }),
+				],
+			}),
+		);
+
+		expect(gates.complaintableServices.map((s) => s.id)).toEqual([1]);
+		expect(gates.canOpenComplaint).toBe(true);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "type-check": "turbo type-check",
+    "test": "turbo test",
     "prepare": "husky"
   },
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,7 @@
     "build:types": "bun --bun tsdown",
     "lint": "biome check .",
     "type-check": "tsc -b",
+    "test": "bun test",
     "seed:dev": "bun run src/db/seed.ts",
     "pull:dev": "bun drizzle-kit pull --config=drizzle-dev.config.ts",
     "build:watch": "bun tsdown --watch",

--- a/packages/server/src/schema/discount.test.ts
+++ b/packages/server/src/schema/discount.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type CampaignDiscountInput,
+  computeCampaignContribution,
+  type DiscountLine,
+  stackCampaignDiscounts,
+} from "@/schema/discount";
+
+const fixed = (
+  value: number,
+  over: Partial<CampaignDiscountInput> = {}
+): CampaignDiscountInput => ({
+  discount_type: "fixed",
+  discount_value: String(value),
+  max_discount: null,
+  ...over,
+});
+
+const percentage = (
+  value: number,
+  over: Partial<CampaignDiscountInput> = {}
+): CampaignDiscountInput => ({
+  discount_type: "percentage",
+  discount_value: String(value),
+  max_discount: null,
+  ...over,
+});
+
+const bogo = (
+  over: Partial<CampaignDiscountInput> = {}
+): CampaignDiscountInput => ({
+  discount_type: "buy_n_get_m_free",
+  discount_value: "0",
+  max_discount: null,
+  buy_quantity: 1,
+  free_quantity: 1,
+  eligible_service_ids: [1],
+  ...over,
+});
+
+const line = (service_id: number, price: number): DiscountLine => ({
+  price,
+  service_id,
+});
+
+describe("computeCampaignContribution", () => {
+  it("returns the fixed value", () => {
+    expect(computeCampaignContribution(fixed(10_000), 100_000, 100_000)).toBe(
+      10_000
+    );
+  });
+
+  it("computes percentage of the remaining total, not the gross", () => {
+    expect(computeCampaignContribution(percentage(10), 200_000, 150_000)).toBe(
+      15_000
+    );
+  });
+
+  it("caps at max_discount", () => {
+    // The capped-voucher case: 10% of 210k is 21k, capped to 15k.
+    expect(
+      computeCampaignContribution(
+        percentage(10, { max_discount: "15000" }),
+        210_000,
+        210_000
+      )
+    ).toBe(15_000);
+  });
+
+  it("returns zero below min_order_total", () => {
+    expect(
+      computeCampaignContribution(
+        fixed(10_000, { min_order_total: "200000" }),
+        150_000,
+        150_000
+      )
+    ).toBe(0);
+  });
+
+  it("gates min_order_total on the gross total even when remaining is lower", () => {
+    expect(
+      computeCampaignContribution(
+        fixed(10_000, { min_order_total: "200000" }),
+        200_000,
+        50_000
+      )
+    ).toBe(10_000);
+  });
+
+  it("clamps to the remaining total", () => {
+    expect(computeCampaignContribution(fixed(50_000), 100_000, 20_000)).toBe(
+      20_000
+    );
+  });
+
+  it("returns zero when nothing remains", () => {
+    expect(computeCampaignContribution(fixed(10_000), 100_000, 0)).toBe(0);
+  });
+
+  it("rounds to whole rupiah", () => {
+    expect(computeCampaignContribution(percentage(10), 33_333, 33_333)).toBe(
+      3333
+    );
+  });
+
+  describe("buy_n_get_m_free", () => {
+    it("gives the cheapest eligible lines free", () => {
+      expect(
+        computeCampaignContribution(bogo(), 180_000, 180_000, [
+          line(1, 100_000),
+          line(1, 80_000),
+        ])
+      ).toBe(80_000);
+    });
+
+    it("ignores lines outside eligible_service_ids", () => {
+      expect(
+        computeCampaignContribution(bogo(), 180_000, 180_000, [
+          line(1, 100_000),
+          line(2, 80_000),
+        ])
+      ).toBe(0);
+    });
+
+    it("returns zero when the group quantity is not reached", () => {
+      expect(
+        computeCampaignContribution(
+          bogo({ buy_quantity: 2, free_quantity: 1 }),
+          180_000,
+          180_000,
+          [line(1, 100_000), line(1, 80_000)]
+        )
+      ).toBe(0);
+    });
+
+    it("returns zero without eligible_service_ids", () => {
+      expect(
+        computeCampaignContribution(
+          bogo({ eligible_service_ids: [] }),
+          180_000,
+          180_000,
+          [line(1, 100_000), line(1, 80_000)]
+        )
+      ).toBe(0);
+    });
+  });
+});
+
+describe("stackCampaignDiscounts", () => {
+  it("applies the biggest contribution first, later ones against the remainder", () => {
+    const { total, breakdown } = stackCampaignDiscounts(100_000, [
+      percentage(10),
+      fixed(20_000),
+    ]);
+
+    expect(breakdown.map((b) => b.amount)).toEqual([20_000, 8000]);
+    expect(total).toBe(28_000);
+  });
+
+  it("never exceeds the gross total", () => {
+    const { total, breakdown } = stackCampaignDiscounts(100_000, [
+      fixed(80_000),
+      fixed(50_000),
+    ]);
+
+    expect(breakdown.map((b) => b.amount)).toEqual([80_000, 20_000]);
+    expect(total).toBe(100_000);
+  });
+
+  it("sums the breakdown to the total", () => {
+    const { total, breakdown } = stackCampaignDiscounts(210_000, [
+      percentage(10, { max_discount: "15000" }),
+      fixed(5000),
+    ]);
+
+    expect(breakdown.reduce((sum, b) => sum + b.amount, 0)).toBe(total);
+  });
+
+  it("returns zero for no campaigns", () => {
+    const { total, breakdown } = stackCampaignDiscounts(100_000, []);
+
+    expect(total).toBe(0);
+    expect(breakdown).toEqual([]);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,9 @@
       "cache": false
     },
     "lint": {},
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "type-check": {
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
## Summary

Candidate 6 from the 2026-07-27 architecture review: the repo's two most consequential untested pure modules get direct tests, and the 12 pre-existing suites (which ran only by hand) join a real pipeline. Zero production code changes.

- `packages/server/src/schema/discount.test.ts` — 16 tests on `computeCampaignContribution` / `stackCampaignDiscounts`: fixed vs percentage-of-remaining, `max_discount` cap (including the 10%-capped-at-15k voucher case from the refund proration discussion), `min_order_total` gating on gross, clamp-to-remaining, whole-rupiah rounding, BOGO eligibility rules, stacking order and never-exceeds-gross
- `apps/web/src/features/orders/lib/order-action-gates.test.ts` — 14 tests on every role/state gate: money roles, pickup flag, ADR-0009 payment-precedes-pickup (both disabled-reason variants), ADR-0008 disjoint cancel/refund off-ramps, rework-line exclusions, ADR-0013 complaintable rules
- Pipeline: `test` task in `turbo.json` (depends on `^build`), `bun test` scripts in both packages, `bun run test` at the root, CLAUDE.md updated

## Verification

- `bun run test`: 3 tasks successful — server 141 pass, web 33 pass, 0 fail
- `bun run type-check` and `bun x ultracite check`: clean