### PR TITLE
refactor(transactions): make form state the voucher's only home

### DIFF
--- a/apps/web/src/features/transactions/cart/cart.test.ts
+++ b/apps/web/src/features/transactions/cart/cart.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	type AppliedVoucher,
 	buildActiveItemMap,
 	type CartCampaign,
 	enrichProductCart,
@@ -154,7 +155,7 @@ describe("toOrderPayload", () => {
 		customerName: " budi santoso ",
 		customerPhone: "081234567890",
 		selectedCampaignIds: ["3", "4"],
-		appliedVoucherCodes: [],
+		appliedVouchers: [],
 		selectedPaymentMethodId: "",
 		selectedCourierId: "",
 		manualDiscount: "",
@@ -235,7 +236,10 @@ describe("toOrderPayload", () => {
 	test("carries applied voucher codes into voucher_codes, trimmed", () => {
 		const payload = toOrderPayload({
 			...draft,
-			appliedVoucherCodes: ["  ABC123DE  ", "XYZ789FG"],
+			appliedVouchers: ["  ABC123DE  ", "XYZ789FG"].map((code) => ({
+				code,
+				campaign: { id: 1 } as AppliedVoucher["campaign"],
+			})),
 		});
 		expect(payload.voucher_codes).toEqual(["ABC123DE", "XYZ789FG"]);
 	});

--- a/apps/web/src/features/transactions/cart/cart.ts
+++ b/apps/web/src/features/transactions/cart/cart.ts
@@ -5,7 +5,12 @@ import {
 	stackCampaignDiscounts,
 } from "@fresclean/api/schema";
 import type { UseFormReturn } from "react-hook-form";
-import type { CreateOrderPayload, Product, Service } from "@/lib/api";
+import type {
+	CreateOrderPayload,
+	Product,
+	ResolvedVoucher,
+	Service,
+} from "@/lib/api";
 import { isValidPhoneNumber, normalizePhoneNumber } from "@/lib/phone-number";
 
 export type ProductCartLine = {
@@ -33,12 +38,20 @@ export type ServiceCartDisplayLine = ServiceCartLine & {
 	service: Service;
 };
 
+// A voucher the cashier has resolved (validated + previewed) but not yet
+// committed. The code string rides in the checkout payload's voucher_codes;
+// the campaign shape feeds the checkout pricing preview.
+export interface AppliedVoucher {
+	code: string;
+	campaign: ResolvedVoucher;
+}
+
 export type TransactionDraftValues = {
 	selectedStoreId: string;
 	customerName: string;
 	customerPhone: string;
 	selectedCampaignIds: string[];
-	appliedVoucherCodes: string[];
+	appliedVouchers: AppliedVoucher[];
 	selectedPaymentMethodId: string;
 	selectedCourierId: string;
 	manualDiscount: string;
@@ -52,7 +65,7 @@ export const defaultDraftValues: TransactionDraftValues = {
 	customerName: "",
 	customerPhone: "",
 	selectedCampaignIds: [],
-	appliedVoucherCodes: [],
+	appliedVouchers: [],
 	selectedPaymentMethodId: "",
 	selectedCourierId: "",
 	manualDiscount: "",
@@ -64,7 +77,6 @@ export const defaultDraftValues: TransactionDraftValues = {
 type TransactionResetActions = {
 	setSubmitError: (message: string) => void;
 	setDropoffPhoto: (file: File | null) => void;
-	clearResolvedVouchers: () => void;
 };
 
 // Single source of truth for clearing the POS draft — used by both the Reset
@@ -73,16 +85,11 @@ type TransactionResetActions = {
 // lived in two near-duplicate resets and the photo was missed on one path.
 export const resetTransactionDraft = (
 	form: UseFormReturn<TransactionDraftValues>,
-	{
-		setSubmitError,
-		setDropoffPhoto,
-		clearResolvedVouchers,
-	}: TransactionResetActions,
+	{ setSubmitError, setDropoffPhoto }: TransactionResetActions,
 ) => {
 	const selectedStoreId = form.getValues("selectedStoreId");
 	setSubmitError("");
 	setDropoffPhoto(null);
-	clearResolvedVouchers();
 	form.reset({ ...defaultDraftValues, selectedStoreId });
 };
 
@@ -184,7 +191,7 @@ export const toOrderPayload = ({
 	customerPhone,
 	selectedStoreId,
 	selectedCampaignIds,
-	appliedVoucherCodes,
+	appliedVouchers,
 	selectedPaymentMethodId,
 	selectedCourierId,
 	manualDiscount,
@@ -198,7 +205,7 @@ export const toOrderPayload = ({
 	},
 	store_id: Number(selectedStoreId),
 	campaign_ids: selectedCampaignIds.map((id) => Number(id)),
-	voucher_codes: appliedVoucherCodes.map((code) => code.trim()),
+	voucher_codes: appliedVouchers.map((entry) => entry.code.trim()),
 	discount: manualDiscount || "0",
 	payment_method_id: selectedPaymentMethodId
 		? Number(selectedPaymentMethodId)

--- a/apps/web/src/features/transactions/cart/useCart.ts
+++ b/apps/web/src/features/transactions/cart/useCart.ts
@@ -56,9 +56,6 @@ export function useCartOps(): CartOps {
 	const setDropoffPhoto = useTransactionsPageStore(
 		(state) => state.setDropoffPhoto,
 	);
-	const clearResolvedVouchers = useTransactionsPageStore(
-		(state) => state.clearResolvedVouchers,
-	);
 
 	const setProductCart = useCallback(
 		(nextCart: ProductCartLine[]) => {
@@ -81,12 +78,8 @@ export function useCartOps(): CartOps {
 	);
 
 	const resetCart = useCallback(() => {
-		resetTransactionDraft(form, {
-			setSubmitError,
-			setDropoffPhoto,
-			clearResolvedVouchers,
-		});
-	}, [form, setSubmitError, setDropoffPhoto, clearResolvedVouchers]);
+		resetTransactionDraft(form, { setSubmitError, setDropoffPhoto });
+	}, [form, setSubmitError, setDropoffPhoto]);
 
 	const removeProduct = useCallback(
 		(productId: number) => {

--- a/apps/web/src/features/transactions/components/checkout-payment-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-payment-step.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { formatIDRCurrency } from "@/shared/utils";
-import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 // Step ③ — money, kept together: campaign, manual discount, the running total
 // breakdown, and tender. Campaign eligibility ("Usable") and the discount it
@@ -32,12 +31,8 @@ export const CheckoutPaymentStep = () => {
 	const { visibleStores } = useTransactionsPageContext();
 	const { subtotal, pricing } = useCheckoutPricing();
 	const form = useFormContext<TransactionDraftValues>();
-	const resolvedVoucherEntries = useTransactionsPageStore(
-		(s) => s.resolvedVoucherEntries,
-	);
-	const removeResolvedVoucher = useTransactionsPageStore(
-		(s) => s.removeResolvedVoucher,
-	);
+	const appliedVouchers =
+		useWatch({ control: form.control, name: "appliedVouchers" }) ?? [];
 	const selectedStoreId =
 		useWatch({ control: form.control, name: "selectedStoreId" }) ?? "";
 
@@ -104,21 +99,6 @@ export const CheckoutPaymentStep = () => {
 		}
 	}, [eligibleCampaigns, selectedStoreNumber, campaignsQuery.isPending, form]);
 
-	// Applied vouchers live in the store (they drive the price preview via
-	// useCheckoutPricing). Mirror their codes into the form field so
-	// toOrderPayload submits exactly the codes the preview priced — the store is
-	// the single source of truth and the form field is its submit-time mirror.
-	useEffect(() => {
-		const codes = resolvedVoucherEntries.map((entry) => entry.code);
-		const current = form.getValues("appliedVoucherCodes");
-		if (
-			codes.length !== current.length ||
-			codes.some((code, index) => code !== current[index])
-		) {
-			form.setValue("appliedVoucherCodes", codes, { shouldValidate: true });
-		}
-	}, [resolvedVoucherEntries, form]);
-
 	// Drop any applied voucher that stopped being eligible (e.g. the cart total
 	// fell below its minimum). Mirrors the listed-campaign prune above: a silently
 	// zeroed code would otherwise ride to submit and hard-fail the whole order.
@@ -127,23 +107,18 @@ export const CheckoutPaymentStep = () => {
 			return;
 		}
 		const now = new Date();
-		for (const entry of resolvedVoucherEntries) {
-			const ineligible =
+		const eligible = appliedVouchers.filter(
+			(entry) =>
 				campaignIneligibilityReason(entry.campaign, {
 					now,
 					grossTotal: subtotal,
 					storeId: selectedStoreNumber,
-				}) !== null;
-			if (ineligible) {
-				removeResolvedVoucher(entry.code);
-			}
+				}) === null,
+		);
+		if (eligible.length !== appliedVouchers.length) {
+			form.setValue("appliedVouchers", eligible, { shouldValidate: true });
 		}
-	}, [
-		resolvedVoucherEntries,
-		subtotal,
-		selectedStoreNumber,
-		removeResolvedVoucher,
-	]);
+	}, [appliedVouchers, subtotal, selectedStoreNumber, form]);
 
 	return (
 		<div className="grid gap-5">

--- a/apps/web/src/features/transactions/components/voucher-code-entry.tsx
+++ b/apps/web/src/features/transactions/components/voucher-code-entry.tsx
@@ -2,11 +2,15 @@ import { TicketIcon, XIcon } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import { DetailedError } from "hono/client";
 import { useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import type {
+	AppliedVoucher,
+	TransactionDraftValues,
+} from "@/features/transactions/cart/cart";
 import { resolveVoucherCode } from "@/lib/api";
-import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 interface VoucherCodeEntryProps {
 	storeId: number | undefined;
@@ -34,15 +38,16 @@ export const VoucherCodeEntry = ({
 	subtotal,
 }: VoucherCodeEntryProps) => {
 	const [code, setCode] = useState("");
-	const addResolvedVoucher = useTransactionsPageStore(
-		(s) => s.addResolvedVoucher,
-	);
-	const removeResolvedVoucher = useTransactionsPageStore(
-		(s) => s.removeResolvedVoucher,
-	);
-	const resolvedVoucherEntries = useTransactionsPageStore(
-		(s) => s.resolvedVoucherEntries,
-	);
+	const form = useFormContext<TransactionDraftValues>();
+	const appliedVouchers =
+		useWatch({ control: form.control, name: "appliedVouchers" }) ?? [];
+
+	const setAppliedVouchers = (next: AppliedVoucher[]) => {
+		form.setValue("appliedVouchers", next, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+	};
 
 	const resolveMutation = useMutation({
 		mutationFn: (voucherCode: string) =>
@@ -52,7 +57,19 @@ export const VoucherCodeEntry = ({
 				gross_total: subtotal,
 			}),
 		onSuccess: (campaign, voucherCode) => {
-			addResolvedVoucher(voucherCode, campaign);
+			// One voucher per campaign per order (the server enforces the same via
+			// order_campaigns' unique constraint): drop any existing entry for this
+			// code OR this campaign before adding, so the same campaign can't be
+			// applied twice and double-count in the price preview.
+			setAppliedVouchers([
+				...form
+					.getValues("appliedVouchers")
+					.filter(
+						(entry) =>
+							entry.code !== voucherCode && entry.campaign.id !== campaign.id,
+					),
+				{ code: voucherCode, campaign },
+			]);
 			setCode("");
 		},
 	});
@@ -114,9 +131,9 @@ export const VoucherCodeEntry = ({
 				<FieldError>{getServerMessage(resolveMutation.error)}</FieldError>
 			) : null}
 
-			{resolvedVoucherEntries.length > 0 ? (
+			{appliedVouchers.length > 0 ? (
 				<ul className="flex flex-wrap gap-1.5">
-					{resolvedVoucherEntries.map((entry) => (
+					{appliedVouchers.map((entry) => (
 						<li key={entry.code}>
 							<span className="inline-flex items-center gap-1.5 border border-input bg-muted/40 pr-0 pl-2 text-xs">
 								<span className="font-medium">{entry.campaign.name}</span>
@@ -127,7 +144,13 @@ export const VoucherCodeEntry = ({
 									aria-label={`Remove voucher ${entry.code}`}
 									className="size-11"
 									icon={<XIcon />}
-									onClick={() => removeResolvedVoucher(entry.code)}
+									onClick={() =>
+										setAppliedVouchers(
+											form
+												.getValues("appliedVouchers")
+												.filter((applied) => applied.code !== entry.code),
+										)
+									}
 									size="icon-xs"
 									type="button"
 									variant="ghost"

--- a/apps/web/src/features/transactions/hooks/use-transactions-page.ts
+++ b/apps/web/src/features/transactions/hooks/use-transactions-page.ts
@@ -22,7 +22,7 @@ import {
 	toOrderPayload,
 } from "@/features/transactions/cart/cart";
 import type { TransactionsPageContextValue } from "@/features/transactions/lib/transactions-context";
-import { createOrder } from "@/lib/api";
+import { createOrder, type ResolvedVoucher } from "@/lib/api";
 import { isValidPhoneNumber } from "@/lib/phone-number";
 import { meQueryOptions, storesQueryOptions } from "@/lib/query-options";
 import { getCurrentUser } from "@/stores/auth-store";
@@ -42,7 +42,14 @@ const transactionDraftSchema = z
 			.min(1, "Phone number is required.")
 			.refine(isValidPhoneNumber, "Invalid phone number"),
 		selectedCampaignIds: z.array(z.string()),
-		appliedVoucherCodes: z.array(z.string()),
+		// The campaign shape comes straight from the resolve-code response; it is
+		// carried for the pricing preview, not re-validated here.
+		appliedVouchers: z.array(
+			z.object({
+				code: z.string(),
+				campaign: z.custom<ResolvedVoucher>(),
+			}),
+		),
 		selectedPaymentMethodId: z.string(),
 		selectedCourierId: z.string(),
 		manualDiscount: z
@@ -188,13 +195,9 @@ export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 	});
 
 	const resetCart = useCallback(() => {
-		const { setSubmitError, setDropoffPhoto, clearResolvedVouchers } =
+		const { setSubmitError, setDropoffPhoto } =
 			useTransactionsPageStore.getState();
-		resetTransactionDraft(form, {
-			setSubmitError,
-			setDropoffPhoto,
-			clearResolvedVouchers,
-		});
+		resetTransactionDraft(form, { setSubmitError, setDropoffPhoto });
 	}, [form]);
 
 	const onValidSubmit = useCallback(
@@ -309,14 +312,12 @@ export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 				shouldDirty: true,
 				shouldValidate: true,
 			});
-			// Clear the mirrored form field too, not just the store: the
-			// CheckoutPaymentStep mirror effect only runs while mounted, so switching
-			// store from another step would otherwise leave stale codes in the payload.
-			form.setValue("appliedVoucherCodes", [], {
+			// Vouchers were resolved against the previous store, so they must be
+			// re-entered.
+			form.setValue("appliedVouchers", [], {
 				shouldDirty: true,
 				shouldValidate: true,
 			});
-			useTransactionsPageStore.getState().clearResolvedVouchers();
 		},
 		[currentUserKey, form],
 	);

--- a/apps/web/src/features/transactions/hooks/useCheckoutPricing.ts
+++ b/apps/web/src/features/transactions/hooks/useCheckoutPricing.ts
@@ -8,7 +8,6 @@ import {
 } from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
 import { campaignsQueryOptions } from "@/lib/query-options";
-import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 // Shared checkout derivation — campaign eligibility + final pricing. Lives in a
 // hook (not the component) because both the payment step's breakdown and the
@@ -16,13 +15,27 @@ import { useTransactionsPageStore } from "@/stores/transactions-store";
 // by TanStack Query, so calling this in two places costs only the cheap memos.
 export function useCheckoutPricing() {
 	const { subtotal, serviceRows } = useCart();
-	const [selectedStoreId = "", selectedCampaignIds = [], manualDiscount = ""] =
-		useWatch<
-			TransactionDraftValues,
-			["selectedStoreId", "selectedCampaignIds", "manualDiscount"]
-		>({
-			name: ["selectedStoreId", "selectedCampaignIds", "manualDiscount"],
-		});
+	const [
+		selectedStoreId = "",
+		selectedCampaignIds = [],
+		manualDiscount = "",
+		appliedVouchers = [],
+	] = useWatch<
+		TransactionDraftValues,
+		[
+			"selectedStoreId",
+			"selectedCampaignIds",
+			"manualDiscount",
+			"appliedVouchers",
+		]
+	>({
+		name: [
+			"selectedStoreId",
+			"selectedCampaignIds",
+			"manualDiscount",
+			"appliedVouchers",
+		],
+	});
 
 	const selectedStoreNumber =
 		selectedStoreId && Number.isFinite(Number(selectedStoreId))
@@ -59,19 +72,15 @@ export function useCheckoutPricing() {
 		);
 	}, [availableCampaigns, selectedCampaignIds]);
 
-	const resolvedVoucherEntries = useTransactionsPageStore(
-		(state) => state.resolvedVoucherEntries,
-	);
-
 	// Applied vouchers are code-mode campaigns resolved via /resolve-code; they
 	// never appear in the tile list (selectedCampaigns), so merge them here so
 	// the client discount preview reflects them alongside listed campaigns.
 	const pricingCampaigns = useMemo(
 		() => [
 			...selectedCampaigns,
-			...resolvedVoucherEntries.map((entry) => entry.campaign),
+			...appliedVouchers.map((entry) => entry.campaign),
 		],
-		[selectedCampaigns, resolvedVoucherEntries],
+		[selectedCampaigns, appliedVouchers],
 	);
 
 	const serviceLines = useMemo(

--- a/apps/web/src/stores/transactions-store.ts
+++ b/apps/web/src/stores/transactions-store.ts
@@ -3,12 +3,6 @@ import type {
 	CatalogMode,
 	CategoryFilter,
 } from "@/features/transactions/lib/transactions";
-import type { ResolvedVoucher } from "@/lib/api";
-
-interface VoucherEntry {
-	code: string;
-	campaign: ResolvedVoucher;
-}
 
 type TransactionsPageUiState = {
 	mode: CatalogMode;
@@ -20,10 +14,6 @@ type TransactionsPageUiState = {
 	// checkout commits. Kept here (not in the page context) so a photo pick only
 	// re-renders the checkout field, not the whole catalog.
 	dropoffPhoto: File | null;
-	// Voucher codes the cashier has resolved (validated + previewed) but not yet
-	// committed. The code string rides in the checkout payload's voucher_codes;
-	// the campaign shape feeds the checkout pricing preview.
-	resolvedVoucherEntries: VoucherEntry[];
 };
 
 type TransactionsPageUiActions = {
@@ -33,9 +23,6 @@ type TransactionsPageUiActions = {
 	setActiveServiceCategory: (category: CategoryFilter) => void;
 	setSubmitError: (message: string) => void;
 	setDropoffPhoto: (file: File | null) => void;
-	addResolvedVoucher: (code: string, campaign: ResolvedVoucher) => void;
-	removeResolvedVoucher: (code: string) => void;
-	clearResolvedVouchers: () => void;
 	resetUi: () => void;
 };
 
@@ -49,7 +36,6 @@ const initialUiState: TransactionsPageUiState = {
 	activeServiceCategory: "all",
 	submitError: "",
 	dropoffPhoto: null,
-	resolvedVoucherEntries: [],
 };
 
 export const useTransactionsPageStore = create<TransactionsPageStore>()(
@@ -63,26 +49,6 @@ export const useTransactionsPageStore = create<TransactionsPageStore>()(
 			set({ activeServiceCategory }),
 		setSubmitError: (submitError) => set({ submitError }),
 		setDropoffPhoto: (dropoffPhoto) => set({ dropoffPhoto }),
-		addResolvedVoucher: (code, campaign) =>
-			set((s) => ({
-				// One voucher per campaign per order (the server enforces the same via
-				// order_campaigns' unique constraint): drop any existing entry for this
-				// code OR this campaign before adding, so the same campaign can't be
-				// applied twice and double-count in the price preview.
-				resolvedVoucherEntries: [
-					...s.resolvedVoucherEntries.filter(
-						(e) => e.code !== code && e.campaign.id !== campaign.id,
-					),
-					{ code, campaign },
-				],
-			})),
-		removeResolvedVoucher: (code) =>
-			set((s) => ({
-				resolvedVoucherEntries: s.resolvedVoucherEntries.filter(
-					(e) => e.code !== code,
-				),
-			})),
-		clearResolvedVouchers: () => set({ resolvedVoucherEntries: [] }),
 		resetUi: () => set(initialUiState),
 	}),
 );


### PR DESCRIPTION
Candidate 3 from the July architecture review: the applied voucher gets one home.

## Before

Vouchers lived in two places that had to be kept in sync by hand:

```
voucher-code-entry ──▶ Zustand resolvedVoucherEntries {code, campaign}
                              │                    │
                              │ mirror useEffect   │ read
                              ▼                    ▼
                     form.appliedVoucherCodes    useCheckoutPricing
                              │
                              ▼
                     toOrderPayload → voucher_codes
```

The mirror effect lived in `CheckoutPaymentStep` and only ran while that step was mounted, so every other write site had to clear **both** homes. `handleStoreChange` carried a comment documenting exactly that trap.

## After

One form field `appliedVouchers: {code, campaign}[]`:

- `voucher-code-entry` reads/writes the field directly; the one-voucher-per-campaign dedup moved here from the store
- `useCheckoutPricing` watches the field for the discount preview
- the mirror effect is deleted; the eligibility prune filters the field in place
- `resetTransactionDraft` no longer needs a voucher action (form.reset covers it), and store-change clearing is a single `setValue`
- the Zustand voucher slice (`resolvedVoucherEntries` + 3 actions) is deleted

Net −22 lines. No behavior change intended: preview, submit payload, dedup, and eligibility pruning all work as before, verified at type/test level (`bun run test`, 33 web tests pass; `toOrderPayload` voucher test updated to the new field shape).