### PR TITLE
test(server): cover money paths and Jakarta date boundaries

### DIFF
--- a/packages/server/src/modules/orders/order-payment.service.test.ts
+++ b/packages/server/src/modules/orders/order-payment.service.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { BadRequestException, ForbiddenException } from "@/errors";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+
+// updateOrderPayment is the pickup desk's cash moment: the customer collects
+// their laundry and the cashier taps "collect". Whatever lands in paid_amount
+// IS the recorded revenue for this order, so these tests pin the net-due
+// arithmetic (total minus discount minus already-refunded, never below zero)
+// and the gates that stop a garment leaving unpaid or being charged twice.
+//
+// Only "@/db" is doubled. assertCanProcessPayment stays real — its role matrix
+// is pinned in permissions.test.ts; here we only pin that the gate fires
+// before any database read.
+
+interface FakeOrderRow {
+  discount: string | null;
+  id: number;
+  payment_status: string;
+  refunded_amount: string | null;
+  status: string;
+  total: string | null;
+}
+
+const dbState = {
+  order: undefined as FakeOrderRow | undefined,
+  findFirstCalls: [] as unknown[],
+  setPayload: undefined as Record<string, unknown> | undefined,
+  updateCalls: 0,
+};
+
+mock.module("@/db", () => ({
+  db: {
+    query: {
+      ordersTable: {
+        findFirst: (args: unknown) => {
+          dbState.findFirstCalls.push(args);
+          return Promise.resolve(dbState.order);
+        },
+      },
+    },
+    update: () => ({
+      set: (payload: Record<string, unknown>) => {
+        dbState.updateCalls += 1;
+        dbState.setPayload = payload;
+        return {
+          where: () => ({
+            returning: () =>
+              Promise.resolve([
+                {
+                  id: dbState.order?.id,
+                  payment_status: payload.payment_status,
+                  paid_amount: payload.paid_amount,
+                },
+              ]),
+          }),
+        };
+      },
+    }),
+  },
+}));
+
+const { updateOrderPayment } = await import(
+  "@/modules/orders/order-payment.service"
+);
+
+const CASHIER = { id: 42, role: "cashier" } as unknown as JWTPayload;
+
+const makeOrder = (over: Partial<FakeOrderRow> = {}): FakeOrderRow => ({
+  discount: "0",
+  id: 10,
+  payment_status: "unpaid",
+  refunded_amount: "0",
+  status: "ready_for_pickup",
+  total: "100000",
+  ...over,
+});
+
+const collect = (user: JWTPayload = CASHIER) =>
+  updateOrderPayment({ orderId: 10, body: { payment_method_id: 3 }, user });
+
+beforeEach(() => {
+  dbState.order = makeOrder();
+  dbState.findFirstCalls = [];
+  dbState.setPayload = undefined;
+  dbState.updateCalls = 0;
+});
+
+describe("updateOrderPayment", () => {
+  it("collects total minus discount and stamps who took the money", async () => {
+    // Rp100.000 of laundry with a Rp10.000 promo: the customer hands over
+    // Rp90.000 and that exact figure becomes the order's recorded revenue,
+    // tagged with the cashier and payment method for the shift report.
+    dbState.order = makeOrder({ total: "100000", discount: "10000" });
+
+    const result = await collect();
+
+    expect(result).toEqual({
+      id: 10,
+      payment_status: "paid",
+      paid_amount: "90000",
+    });
+    expect(dbState.setPayload).toMatchObject({
+      paid_amount: "90000",
+      paid_by: 42,
+      payment_method_id: 3,
+      payment_status: "paid",
+      updated_by: 42,
+    });
+    expect(dbState.setPayload?.paid_at).toBeInstanceOf(Date);
+  });
+
+  it("deducts an earlier refund so the customer is not charged for a ruined item", async () => {
+    // A shirt was ruined in the wash and Rp25.000 already went back before
+    // pickup. Collecting the full Rp100.000 now would make the customer pay
+    // for the very line the shop refunded.
+    dbState.order = makeOrder({ total: "100000", refunded_amount: "25000" });
+
+    await collect();
+
+    expect(dbState.setPayload?.paid_amount).toBe("75000");
+  });
+
+  it("clamps at zero when refunds already exceed what is left to pay", async () => {
+    // Discounted Rp50.000 order, Rp10.000 promo, Rp60.000 refunded after a
+    // whole bag went missing. Nothing is owed — a negative paid_amount would
+    // poison the revenue report with money the till never saw.
+    dbState.order = makeOrder({
+      total: "50000",
+      discount: "10000",
+      refunded_amount: "60000",
+    });
+
+    await collect();
+
+    expect(dbState.setPayload?.paid_amount).toBe("0");
+  });
+
+  it("rejects a second collect so the same order is never charged twice", async () => {
+    // Cashier taps collect twice on a laggy screen. The second tap must bounce
+    // instead of overwriting paid_at/paid_by and double-counting revenue.
+    dbState.order = makeOrder({ payment_status: "paid" });
+
+    const error = await captureRejection(collect());
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Order has already been paid");
+    expect(dbState.updateCalls).toBe(0);
+  });
+
+  it("rejects collecting on a cancelled order", async () => {
+    // The order was cancelled before pickup — taking money for it would book
+    // revenue against laundry the shop never processed.
+    dbState.order = makeOrder({ status: "cancelled" });
+
+    const error = await captureRejection(collect());
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Cannot collect payment on a cancelled order"
+    );
+    expect(dbState.updateCalls).toBe(0);
+  });
+
+  it("returns null for an unknown order so the route can 404", async () => {
+    // Stale tab pointing at a deleted order: no throw, no write — the route
+    // turns null into a 404.
+    dbState.order = undefined;
+
+    const result = await collect();
+
+    expect(result).toBeNull();
+    expect(dbState.updateCalls).toBe(0);
+  });
+
+  it("books zero, not NaN, for a legacy row missing its total", async () => {
+    // Old rows imported before totals were mandatory carry total = null.
+    // paid_amount "NaN" would break every sum in the revenue report.
+    dbState.order = makeOrder({ total: null });
+
+    await collect();
+
+    expect(dbState.setPayload?.paid_amount).toBe("0");
+  });
+
+  it("blocks a worker before the order is even looked up", async () => {
+    // Only the counter roles handle money. A worker's attempt dies at the
+    // permission gate — the database is never touched, read or write.
+    const worker = { id: 7, role: "worker" } as unknown as JWTPayload;
+
+    const error = await captureRejection(collect(worker));
+
+    expect(error).toBeInstanceOf(ForbiddenException);
+    expect(dbState.findFirstCalls).toHaveLength(0);
+    expect(dbState.updateCalls).toBe(0);
+  });
+});

--- a/packages/server/src/modules/orders/order-pickup.service.test.ts
+++ b/packages/server/src/modules/orders/order-pickup.service.test.ts
@@ -1,0 +1,337 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { BadRequestException } from "@/errors";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+
+// The pickup desk handover: a customer reads out the receipt's 6-digit pickup
+// code, the cashier photographs the garments leaving the counter, and only then
+// do the selected items flip to picked_up. These tests pin the desk's hard
+// gates — full payment before anything leaves (ADR-0009), the per-order pickup
+// code as proof the person at the counter placed this order (ADR-0005) — and
+// the one-transaction guarantee that a concurrent double-pickup rolls the
+// photographed event back out. The DB, S3 (presign/optimize/CDN URL) and the
+// status machine's completePickup flip are doubled; the permission check and
+// every gate in between stay real.
+
+type AnyObj = Record<string, unknown>;
+
+interface CandidateService {
+  id: number;
+  item_code: string | null;
+  status: string;
+}
+
+const EVENT_ID = 77;
+
+const state = {
+  order: undefined as AnyObj | undefined,
+  services: [] as CandidateService[],
+  // undefined → the flip succeeds for every requested id (no concurrent race)
+  flippedIds: undefined as number[] | undefined,
+  // captured reads/writes
+  orderReads: [] as AnyObj[],
+  serviceReads: [] as AnyObj[],
+  insertedEvent: undefined as AnyObj | undefined,
+  transactionOutcome: undefined as "committed" | "rolled_back" | undefined,
+};
+
+const s3Calls = {
+  presigned: [] as { contentType: string; key: string }[],
+  optimized: [] as string[],
+};
+
+const flipCalls: { executor: unknown; input: AnyObj }[] = [];
+
+// Sentinel transaction handle threaded into completePickup — the flip must run
+// on the same transaction as the event insert or the rollback guarantee is gone.
+const TX = {
+  insert: () => ({
+    values: (values: AnyObj) => ({
+      returning: () => {
+        state.insertedEvent = values;
+        // id + picked_up_at are DB defaults the real insert hands back.
+        return Promise.resolve([{ id: EVENT_ID, picked_up_at: new Date() }]);
+      },
+    }),
+  }),
+};
+
+mock.module("@/db", () => ({
+  db: {
+    query: {
+      ordersTable: {
+        findFirst: (args: AnyObj) => {
+          state.orderReads.push(args);
+          return Promise.resolve(state.order);
+        },
+      },
+      ordersServicesTable: {
+        findMany: (args: AnyObj) => {
+          state.serviceReads.push(args);
+          return Promise.resolve(state.services);
+        },
+      },
+    },
+    transaction: async (cb: (tx: unknown) => Promise<unknown>) => {
+      try {
+        const result = await cb(TX);
+        state.transactionOutcome = "committed";
+        return result;
+      } catch (error) {
+        state.transactionOutcome = "rolled_back";
+        throw error;
+      }
+    },
+  },
+}));
+
+mock.module("@/utils/s3", () => ({
+  buildMediaUrl: (path: string) => `https://cdn.test/${path}`,
+  createPresignedUploadUrl: (input: { contentType: string; key: string }) => {
+    s3Calls.presigned.push(input);
+    return {
+      upload_url: `https://s3.test/${input.key}`,
+      key: input.key,
+      expires_in_seconds: 300,
+    };
+  },
+  optimizeUploadedImage: (key: string) => {
+    s3Calls.optimized.push(key);
+    return Promise.resolve();
+  },
+}));
+
+// Spread the real status machine and stub only completePickup: the machine's
+// own tests already pin that picked_up is reachable solely from
+// ready_for_pickup, so here the flip just reports which rows it won.
+const actualStatusMachine = await import(
+  "@/modules/orders/order-status-machine"
+);
+
+mock.module("@/modules/orders/order-status-machine", () => ({
+  ...actualStatusMachine,
+  completePickup: (executor: unknown, input: { serviceIds: number[] }) => {
+    flipCalls.push({ executor, input });
+    return Promise.resolve({
+      flippedIds: state.flippedIds ?? input.serviceIds,
+    });
+  },
+}));
+
+afterAll(() => {
+  mock.module(
+    "@/modules/orders/order-status-machine",
+    () => actualStatusMachine
+  );
+});
+
+const { createOrderPickupEvent, createOrderPickupEventPresign } = await import(
+  "@/modules/orders/order-pickup.service"
+);
+
+const ORDER_ID = 42;
+
+// A cashier passes assertCanProcessPickup (kept real; roles are pinned in
+// permissions.test.ts) without the can_process_pickup override flag.
+const CASHIER = {
+  id: 8,
+  role: "cashier",
+  can_process_pickup: false,
+} as unknown as JWTPayload;
+
+const makeOrder = (over: AnyObj = {}) => ({
+  id: ORDER_ID,
+  pickup_code: "483920",
+  payment_status: "paid",
+  ...over,
+});
+
+const pickup = (body: AnyObj = {}) =>
+  createOrderPickupEvent({
+    orderId: ORDER_ID,
+    body: {
+      image_path: `orders/${ORDER_ID}/pickup/proof.webp`,
+      pickup_code: "483920",
+      service_ids: [5, 6],
+      ...body,
+    } as never,
+    user: CASHIER,
+  });
+
+const presign = () =>
+  createOrderPickupEventPresign({
+    orderId: ORDER_ID,
+    body: { content_type: "image/jpeg" } as never,
+    user: CASHIER,
+  });
+
+beforeEach(() => {
+  state.order = makeOrder();
+  state.services = [
+    { id: 5, item_code: "ORD-042-001", status: "ready_for_pickup" },
+    { id: 6, item_code: "ORD-042-002", status: "ready_for_pickup" },
+  ];
+  state.flippedIds = undefined;
+  state.orderReads = [];
+  state.serviceReads = [];
+  state.insertedEvent = undefined;
+  state.transactionOutcome = undefined;
+  s3Calls.presigned = [];
+  s3Calls.optimized = [];
+  flipCalls.length = 0;
+});
+
+describe("createOrderPickupEventPresign", () => {
+  it("refuses to open the camera while money is still owed", async () => {
+    // ADR-0009: a half-paid customer at the counter gets sent to the till, not
+    // a photo slot — no upload URL may exist for garments that cannot leave.
+    state.order = makeOrder({ payment_status: "partial" });
+    const error = await captureRejection(presign());
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Order must be paid before pickup");
+    expect(s3Calls.presigned).toHaveLength(0);
+  });
+
+  it("issues an upload slot inside this order's own pickup folder", async () => {
+    // The folder prefix is what the image-path gate later trusts, so a proof
+    // photo can never be filed under another customer's order.
+    const result = await presign();
+    expect(s3Calls.presigned).toHaveLength(1);
+    expect(s3Calls.presigned[0].contentType).toBe("image/jpeg");
+    expect(s3Calls.presigned[0].key).toStartWith(`orders/${ORDER_ID}/pickup/`);
+    expect(result.key).toStartWith(`orders/${ORDER_ID}/pickup/`);
+  });
+});
+
+describe("createOrderPickupEvent", () => {
+  it("keeps garments behind the counter until the order is fully paid", async () => {
+    // ADR-0009: paid-before-pickup outranks everything else — even a wrong
+    // pickup code reports the money problem first, and nothing is written.
+    state.order = makeOrder({ payment_status: "partial" });
+    const error = await captureRejection(pickup({ pickup_code: "483921" }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Order must be paid before pickup");
+    expect(state.transactionOutcome).toBeUndefined();
+    expect(state.insertedEvent).toBeUndefined();
+    expect(s3Calls.optimized).toHaveLength(0);
+  });
+
+  it("rejects a pickup code that does not match this order's receipt", async () => {
+    // ADR-0005: the code proves the person at the counter placed this order.
+    // One digit off on a paid order still hands nothing over.
+    const error = await captureRejection(pickup({ pickup_code: "483921" }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Invalid pickup code");
+    expect(state.transactionOutcome).toBeUndefined();
+    expect(s3Calls.optimized).toHaveLength(0);
+  });
+
+  it("collapses a double-tapped line so one garment is only handed over once", async () => {
+    // The UI can send the same line twice on a double-tap; the desk must treat
+    // it as one garment everywhere — validation, the flip, and the receipt.
+    const result = await pickup({ service_ids: [5, 5, 6] });
+    expect(state.serviceReads[0].where).toEqual({
+      order_id: ORDER_ID,
+      id: { in: [5, 6] },
+    });
+    expect(flipCalls[0].input.serviceIds).toEqual([5, 6]);
+    expect(result.service_ids).toEqual([5, 6]);
+  });
+
+  it("rejects a handover with nothing selected before touching the database", async () => {
+    const error = await captureRejection(pickup({ service_ids: [] }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "At least one service must be picked up"
+    );
+    expect(state.orderReads).toHaveLength(0);
+    expect(state.serviceReads).toHaveLength(0);
+  });
+
+  it("refuses when a selected line belongs to another customer's order", async () => {
+    // A stale tab or mistyped id must never let order 42's code release a
+    // garment that lives on someone else's ticket.
+    state.services = [
+      { id: 5, item_code: "ORD-042-001", status: "ready_for_pickup" },
+    ];
+    const error = await captureRejection(pickup({ service_ids: [5, 6] }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "One or more services do not belong to this order"
+    );
+    expect(state.transactionOutcome).toBeUndefined();
+  });
+
+  it("holds the whole handover while one garment is still in the wash", async () => {
+    // Partial pickup is per-line, but every SELECTED line must be ready — a
+    // shirt still processing cannot leave beside a finished one. Lines coded
+    // before tagging fall back to their numeric id in the message.
+    state.services = [
+      { id: 5, item_code: "ORD-042-001", status: "ready_for_pickup" },
+      { id: 9, item_code: null, status: "processing" },
+    ];
+    const error = await captureRejection(pickup({ service_ids: [5, 9] }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Services not ready for pickup: 9");
+    expect(s3Calls.optimized).toHaveLength(0);
+    expect(state.transactionOutcome).toBeUndefined();
+  });
+
+  it("rejects a proof photo filed under another order's folder", async () => {
+    // The photo is the evidence of what left for THIS order — pointing at
+    // order 99's folder would let one photo vouch for two handovers.
+    const error = await captureRejection(
+      pickup({ image_path: "orders/99/pickup/x.jpg" })
+    );
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Invalid image path");
+    expect(s3Calls.optimized).toHaveLength(0);
+    expect(state.transactionOutcome).toBeUndefined();
+  });
+
+  it("rolls the pickup event back when another cashier beat this one to an item", async () => {
+    // Two counters serve the same order at once: the second flip comes up
+    // short. The event row already inserted in this transaction must vanish
+    // with the rollback, or the shop keeps a photo of a handover that never
+    // happened.
+    state.flippedIds = [5];
+    const error = await captureRejection(pickup({ service_ids: [5, 6] }));
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Another cashier already processed one of the selected items. Refresh and try again."
+    );
+    expect(state.insertedEvent).toBeDefined();
+    expect(state.transactionOutcome).toBe("rolled_back");
+  });
+
+  it("records the handover: photo optimized, event linked to the flip, receipt returned", async () => {
+    const result = await pickup();
+
+    expect(s3Calls.optimized).toEqual([`orders/${ORDER_ID}/pickup/proof.webp`]);
+    expect(state.insertedEvent).toEqual({
+      order_id: ORDER_ID,
+      image_path: `orders/${ORDER_ID}/pickup/proof.webp`,
+      picked_up_by: 8,
+    });
+    // The flip runs on the same transaction as the event insert and every
+    // flipped garment points back at this event's photo.
+    expect(flipCalls).toHaveLength(1);
+    expect(flipCalls[0].executor).toBe(TX);
+    expect(flipCalls[0].input).toEqual({
+      orderId: ORDER_ID,
+      serviceIds: [5, 6],
+      pickupEventId: EVENT_ID,
+      by: 8,
+      note: "Completed from order pickup desk",
+    });
+    expect(state.transactionOutcome).toBe("committed");
+
+    expect(result.id).toBe(EVENT_ID);
+    expect(result.image_url).toBe(
+      `https://cdn.test/orders/${ORDER_ID}/pickup/proof.webp`
+    );
+    expect(result.order_id).toBe(ORDER_ID);
+    expect(result.picked_up_at).toBeInstanceOf(Date);
+    expect(result.service_ids).toEqual([5, 6]);
+  });
+});

--- a/packages/server/src/modules/orders/order-queue.service.test.ts
+++ b/packages/server/src/modules/orders/order-queue.service.test.ts
@@ -1,0 +1,378 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { orderServiceHandlerLogsTable, ordersServicesTable } from "@/db/schema";
+import { BadRequestException, ForbiddenException } from "@/errors";
+import type { PatchOrderServiceStatusInput } from "@/modules/orders/order-admin.schema";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+
+// The workshop-floor queue: a worker scans a garment's tag to claim it and start
+// work, and staff nudge items between stations from the status dropdown. Two
+// invariants live here rather than in the status machine: an item already on a
+// colleague's rack cannot be grabbed mid-wash (two people handling one garment
+// is how garments get lost), and the terminal exits — picked_up / cancelled /
+// refunded — are blocked on this generic endpoint so a garment can only leave
+// the shop through the audited pickup, cancel, and refund desks that guard the
+// money. The DB is a fake row-lock transaction that captures writes;
+// transitionOrderService is stubbed (legality and the photo gate are already
+// pinned in order-status-machine.test.ts). The claim/guard logic stays real.
+type AnyObj = Record<string, unknown>;
+
+interface CapturedWrite {
+  table: unknown;
+  values: AnyObj;
+}
+
+const dbState = {
+  lockedRows: [] as AnyObj[],
+  transactions: 0,
+  updates: [] as CapturedWrite[],
+  inserts: [] as CapturedWrite[],
+};
+
+// The one transaction handle every test shares: select().for("update") hands
+// back whatever row the test locked, and writes are captured for assertions.
+const TX = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        for: () => Promise.resolve(dbState.lockedRows),
+      }),
+    }),
+  }),
+  update: (table: unknown) => ({
+    set: (values: AnyObj) => ({
+      where: () => {
+        dbState.updates.push({ table, values });
+        return Promise.resolve();
+      },
+    }),
+  }),
+  insert: (table: unknown) => ({
+    values: (values: AnyObj) => {
+      dbState.inserts.push({ table, values });
+      return Promise.resolve();
+    },
+  }),
+};
+
+mock.module("@/db", () => ({
+  db: {
+    // order-queue.service (and order.repository in its import graph) build
+    // prepared item-code lookups at module load — without this stub the
+    // import itself would dial the database.
+    query: {
+      ordersServicesTable: {
+        findFirst: () => ({
+          prepare: () => ({ execute: () => Promise.resolve(undefined) }),
+        }),
+      },
+    },
+    transaction: (cb: (tx: typeof TX) => unknown) => {
+      dbState.transactions += 1;
+      return cb(TX);
+    },
+    // The list queries need a live 3-join builder; the guard tests below must
+    // short-circuit before ever getting here, so reaching select() is a bug.
+    select: () => {
+      throw new Error("queue list query reached the database");
+    },
+  },
+}));
+
+const authz = {
+  storeIds: [] as number[],
+};
+
+mock.module("@/utils/authorization", () => ({
+  assertStoreAccess: () => Promise.resolve(),
+  getUserStoreIds: () => Promise.resolve(authz.storeIds),
+}));
+
+// Spread the real machine and stub only transitionOrderService: which moves are
+// legal is order-status-machine.test.ts's job; here we pin only what the queue
+// hands it. The actual module is restored in afterAll because that suite runs
+// the machine for real.
+const actualStatusMachine = await import(
+  "@/modules/orders/order-status-machine"
+);
+
+const machine = {
+  calls: [] as Array<{ executor: unknown; input: AnyObj }>,
+  from: "queued",
+};
+
+mock.module("@/modules/orders/order-status-machine", () => ({
+  ...actualStatusMachine,
+  transitionOrderService: (executor: unknown, input: AnyObj) => {
+    machine.calls.push({ executor, input });
+    return Promise.resolve({ from: machine.from, to: input.to });
+  },
+}));
+
+afterAll(() => {
+  mock.module(
+    "@/modules/orders/order-status-machine",
+    () => actualStatusMachine
+  );
+});
+
+const {
+  getMyOrderServices,
+  getOrderServiceQueue,
+  startOrderServiceWork,
+  updateOrderServiceStatus,
+} = await import("@/modules/orders/order-queue.service");
+
+// Sari, ironing staff — the one holding the barcode scanner.
+const WORKER = { id: 9, role: "worker" } as unknown as JWTPayload;
+const ADMIN = { id: 1, role: "admin" } as unknown as JWTPayload;
+
+const makeLockedRow = (over: AnyObj = {}) => ({
+  id: 501,
+  order_id: 88,
+  status: "queued",
+  handler_id: null,
+  ...over,
+});
+
+beforeEach(() => {
+  dbState.lockedRows = [makeLockedRow()];
+  dbState.transactions = 0;
+  dbState.updates = [];
+  dbState.inserts = [];
+  machine.calls = [];
+  machine.from = "queued";
+  authz.storeIds = [];
+});
+
+const scan = () =>
+  startOrderServiceWork({ orderId: 88, serviceId: 501, user: WORKER });
+
+describe("startOrderServiceWork", () => {
+  it("blocks scanning an item already on a colleague's rack", async () => {
+    // Budi (id 7) claimed this shirt an hour ago and it is mid-wash. Sari's
+    // scan must bounce — silently stealing the claim would leave two people
+    // working one garment and nobody accountable for it.
+    dbState.lockedRows = [makeLockedRow({ handler_id: 7, status: "queued" })];
+
+    const error = await captureRejection(scan());
+
+    expect(error).toBeInstanceOf(ForbiddenException);
+    expect((error as Error).message).toBe(
+      "This item is already assigned to another staff member"
+    );
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
+    expect(machine.calls).toEqual([]);
+  });
+
+  it("claims an unowned queued item: handler flips to the scanner and the claim is logged", async () => {
+    const result = await scan();
+
+    // The claim itself: the shirt now belongs to Sari's rack.
+    expect(dbState.updates).toEqual([
+      { table: ordersServicesTable, values: { handler_id: 9 } },
+    ]);
+    // The audit row: if the shirt goes missing, this log says who took it
+    // off the shelf and that nobody held it before.
+    expect(dbState.inserts).toEqual([
+      {
+        table: orderServiceHandlerLogsTable,
+        values: {
+          order_service_id: 501,
+          from_handler_id: null,
+          to_handler_id: 9,
+          changed_by: 9,
+          note: "Started from queue",
+        },
+      },
+    ]);
+    // Claim and status flip ride the same row-lock transaction, so a crash
+    // can never leave a claimed shirt still marked queued.
+    expect(machine.calls).toHaveLength(1);
+    expect(machine.calls[0]?.executor).toBe(TX);
+    expect(machine.calls[0]?.input).toEqual({
+      orderId: 88,
+      serviceId: 501,
+      to: "processing",
+      by: 9,
+      note: "Started from queue",
+    });
+    expect(result).toEqual({
+      from_status: "queued",
+      handler_id: 9,
+      order_service_id: 501,
+      to_status: "processing",
+    });
+  });
+
+  it("re-scanning your own item transitions without rewriting the claim", async () => {
+    // Sari scans the same tag twice (double beep at the shelf). The item is
+    // already hers — a second claim row would fake a hand-off in the audit log.
+    dbState.lockedRows = [makeLockedRow({ handler_id: 9 })];
+
+    const result = await scan();
+
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
+    expect(machine.calls).toHaveLength(1);
+    expect(result.to_status).toBe("processing");
+  });
+
+  it("rejects a scan whose tag belongs to a different order before any write", async () => {
+    // The scanned service id exists but hangs off another customer's order —
+    // starting work here would process the wrong customer's garment.
+    dbState.lockedRows = [];
+
+    const error = await captureRejection(scan());
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Order service not found for this order"
+    );
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
+    expect(machine.calls).toEqual([]);
+  });
+});
+
+const patchStatus = (body: PatchOrderServiceStatusInput) =>
+  updateOrderServiceStatus({ orderId: 88, serviceId: 501, body, user: WORKER });
+
+describe("updateOrderServiceStatus", () => {
+  it("refuses picked_up before even opening a transaction", async () => {
+    // A cashier trying to mark a shirt picked_up from the dropdown would skip
+    // the pickup desk's paid-before-pickup check — the garment could walk out
+    // unpaid. The gate fires before any transaction so there is no window to
+    // race past it.
+    const error = await captureRejection(patchStatus({ status: "picked_up" }));
+
+    expect(error).toBeInstanceOf(ForbiddenException);
+    expect((error as Error).message).toBe(
+      "Use the pickup endpoint to record pickups"
+    );
+    expect(dbState.transactions).toBe(0);
+  });
+
+  it("refuses cancelled and refunded — money-moving exits stay on audited endpoints", async () => {
+    // Cancel and refund adjust what the customer owes or gets back; letting
+    // the dropdown reach those states would move money with no audit trail.
+    for (const status of ["cancelled", "refunded"] as const) {
+      const error = await captureRejection(patchStatus({ status }));
+      expect(error).toBeInstanceOf(ForbiddenException);
+      expect((error as Error).message).toBe(
+        "Use the cancel or refund endpoint for terminal exit states"
+      );
+    }
+    expect(dbState.transactions).toBe(0);
+    expect(machine.calls).toEqual([]);
+  });
+
+  it("auto-assigns the acting user when pushing someone else's qc_reject back to processing", async () => {
+    // QC bounced Budi's ironing job, Budi went home, and Sari picks the redo
+    // up from the reject shelf. Restarting the work must move the claim to
+    // her — otherwise the redo would still show on Budi's rack.
+    dbState.lockedRows = [
+      makeLockedRow({ status: "qc_reject", handler_id: 7 }),
+    ];
+    machine.from = "qc_reject";
+
+    const result = await patchStatus({ status: "processing" });
+
+    expect(dbState.updates).toEqual([
+      { table: ordersServicesTable, values: { handler_id: 9 } },
+    ]);
+    expect(dbState.inserts).toEqual([
+      {
+        table: orderServiceHandlerLogsTable,
+        values: {
+          order_service_id: 501,
+          from_handler_id: 7,
+          to_handler_id: 9,
+          changed_by: 9,
+          note: "Auto-assigned on status update",
+        },
+      },
+    ]);
+    expect(machine.calls).toHaveLength(1);
+    expect(machine.calls[0]?.input).toMatchObject({ to: "processing" });
+    expect(result).toEqual({
+      from_status: "qc_reject",
+      order_service_id: 501,
+      to_status: "processing",
+    });
+  });
+
+  it("leaves the handler untouched on a non-claim transition", async () => {
+    // Sari sends Budi's finished shirt to quality check for him. Passing an
+    // item along is not taking it over — the wash stays credited to Budi.
+    dbState.lockedRows = [
+      makeLockedRow({ status: "processing", handler_id: 7 }),
+    ];
+    machine.from = "processing";
+
+    await patchStatus({ status: "quality_check" });
+
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
+    expect(machine.calls).toHaveLength(1);
+  });
+
+  it("trims a whitespace-only cancel note to null before it reaches the transition", async () => {
+    // A stray spacebar in the cancel-note box must not persist as a "filled"
+    // note — blank means blank. The item is already on Sari's rack, so this
+    // claim transition also writes no redundant hand-off log.
+    dbState.lockedRows = [makeLockedRow({ status: "queued", handler_id: 9 })];
+
+    await patchStatus({ status: "processing", cancel_note: "   " });
+
+    expect(machine.calls).toHaveLength(1);
+    expect(machine.calls[0]?.input).toMatchObject({
+      to: "processing",
+      cancelNote: null,
+    });
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
+  });
+});
+
+// Only the pre-query guards are pinned for the two list endpoints; the fake
+// db.select throws, so each passing test proves the guard short-circuited
+// before the database.
+describe("getOrderServiceQueue", () => {
+  it("requires admins to pick a store before the queue query runs", async () => {
+    // An admin sees every store; an unscoped queue would dump the whole
+    // company's floor into one list nobody can work from.
+    const error = await captureRejection(getOrderServiceQueue(ADMIN));
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Store is required for admin queue access"
+    );
+  });
+
+  it("hands a worker with no store memberships an empty page, not the company queue", async () => {
+    // A just-created account not yet assigned to a branch must see nothing —
+    // an empty membership list is not permission to see everything.
+    authz.storeIds = [];
+
+    const result = await getOrderServiceQueue(WORKER);
+
+    expect(result).toEqual({
+      items: [],
+      meta: { limit: 25, offset: 0, total: 0 },
+    });
+  });
+});
+
+describe("getMyOrderServices", () => {
+  it("hands a worker with no store memberships an empty rack list", async () => {
+    authz.storeIds = [];
+
+    const result = await getMyOrderServices(WORKER, {
+      include_terminal: false,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/server/src/modules/orders/order-refund-status.test.ts
+++ b/packages/server/src/modules/orders/order-refund-status.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { deriveOrderRefundStatus } from "@/modules/orders/order-refund-status";
+
+// deriveOrderRefundStatus paints the refund badge staff see on the orders
+// dashboard: "none" means the money is untouched, "partial" means some went
+// back, "full" means the customer already has everything — attempting another
+// refund would hand out cash twice. Pure derivation over Postgres numeric
+// strings; nothing is mocked.
+
+describe("deriveOrderRefundStatus", () => {
+  it("shows no badge on an order whose money is untouched", () => {
+    expect(
+      deriveOrderRefundStatus({ paid_amount: "150000", refunded_amount: "0" })
+    ).toBe("none");
+  });
+
+  it("flags partial when one ruined garment of a bigger order was refunded", () => {
+    expect(
+      deriveOrderRefundStatus({
+        paid_amount: "150000",
+        refunded_amount: "50000",
+      })
+    ).toBe("partial");
+  });
+
+  it("flags full at exact payback and beyond so staff never refund again", () => {
+    // Whether the payback matched the payment or overshot it (goodwill top-up,
+    // fat-fingered amount), the customer holds all their money — the badge must
+    // say full either way or someone at the desk will issue a second refund.
+    expect(
+      deriveOrderRefundStatus({
+        paid_amount: "150000",
+        refunded_amount: "150000",
+      })
+    ).toBe("full");
+    expect(
+      deriveOrderRefundStatus({
+        paid_amount: "150000",
+        refunded_amount: "160000",
+      })
+    ).toBe("full");
+  });
+
+  it("treats decimal-formatted numerics as the same rupiah", () => {
+    // Postgres numeric columns can arrive as "90000.00" — same money, and the
+    // badge must not downgrade full to partial over formatting.
+    expect(
+      deriveOrderRefundStatus({
+        paid_amount: "90000.00",
+        refunded_amount: "90000.00",
+      })
+    ).toBe("full");
+  });
+
+  it("shows no badge on a legacy row that was never paid nor refunded", () => {
+    expect(
+      deriveOrderRefundStatus({ paid_amount: null, refunded_amount: null })
+    ).toBe("none");
+  });
+
+  it("never claims full when nothing was actually paid", () => {
+    // Goodwill payout on an order the till never collected: "full" would imply
+    // the payment cycle is closed, hiding that this order earned nothing.
+    expect(
+      deriveOrderRefundStatus({ paid_amount: "0", refunded_amount: "10000" })
+    ).toBe("partial");
+  });
+
+  it("ignores a corrupted negative refund instead of showing a phantom badge", () => {
+    // A bad import wrote refunded_amount "-5000". No money ever left the till,
+    // so staff must not see a refund badge that sends them auditing nothing.
+    expect(
+      deriveOrderRefundStatus({
+        paid_amount: "100000",
+        refunded_amount: "-5000",
+      })
+    ).toBe("none");
+  });
+});

--- a/packages/server/src/modules/orders/order-reversal.service.test.ts
+++ b/packages/server/src/modules/orders/order-reversal.service.test.ts
@@ -1,0 +1,603 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  orderRefundItemsTable,
+  orderRefundsTable,
+  ordersProductsTable,
+  ordersTable,
+} from "@/db/schema";
+import { BadRequestException } from "@/errors";
+import type {
+  PostOrderCancelInput,
+  PostOrderRefundInput,
+} from "@/modules/orders/order-admin.schema";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+
+// The reversal desk: refund hands cash back on a PAID order line by line;
+// cancel voids lines on an UNPAID order, putting products back on the shelf
+// and freeing any voucher the order had spent (ADR-0008 / ADR-0015). These
+// tests pin the wiring from DB rows through per-line caps to the money writes,
+// and the exactly-once voucher release on a full cancel. The cap/allocation
+// arithmetic stays real (refund-allocation.test.ts owns it), as does the
+// permission gate; the DB, status machine, stock repository, and redemption
+// release are doubled at their seams and only their invocations asserted.
+
+type AnyObj = Record<string, unknown>;
+
+interface UpdateCall {
+  set: AnyObj;
+  table: unknown;
+}
+
+interface InsertCall {
+  table: unknown;
+  values: AnyObj | AnyObj[];
+}
+
+const state = {
+  order: undefined as AnyObj | undefined, // db.query.ordersTable.findFirst
+  serviceRows: [] as AnyObj[], // db.query.ordersServicesTable.findMany
+  productRows: [] as AnyObj[], // db.query.ordersProductsTable.findMany
+  refundedRows: [] as AnyObj[], // prior-refund SUM rows (db.select chain)
+  postCancelStatus: undefined as string | undefined, // tx re-read after cancel
+  casResults: [] as { id: number }[][], // queued CAS update outcomes, in order
+};
+
+const reads = { orderLookups: 0 };
+
+const writes = {
+  updates: [] as UpdateCall[],
+  inserts: [] as InsertCall[],
+  transactionCount: 0,
+};
+
+const updateBuilder = (table: unknown) => ({
+  set: (values: AnyObj) => {
+    writes.updates.push({ set: values, table });
+    return {
+      // Drizzle's builder is awaitable mid-chain AND continuable via
+      // .returning() — a real Promise with the method attached mirrors that.
+      where: () =>
+        Object.assign(Promise.resolve(undefined), {
+          returning: () =>
+            Promise.resolve(state.casResults.shift() ?? [{ id: 1 }]),
+        }),
+    };
+  },
+});
+
+const insertBuilder = (table: unknown) => ({
+  values: (values: AnyObj | AnyObj[]) => {
+    writes.inserts.push({ table, values });
+    return Object.assign(Promise.resolve(undefined), {
+      returning: () => Promise.resolve([{ id: 900, ...(values as AnyObj) }]),
+    });
+  },
+});
+
+const fakeTx = {
+  update: updateBuilder,
+  insert: insertBuilder,
+  query: {
+    ordersTable: {
+      findFirst: () =>
+        Promise.resolve(
+          state.postCancelStatus == null
+            ? undefined
+            : { status: state.postCancelStatus }
+        ),
+    },
+  },
+};
+
+mock.module("@/db", () => ({
+  db: {
+    query: {
+      ordersTable: {
+        findFirst: () => {
+          reads.orderLookups += 1;
+          return Promise.resolve(state.order);
+        },
+      },
+      ordersServicesTable: {
+        findMany: () => Promise.resolve(state.serviceRows),
+      },
+      ordersProductsTable: {
+        findMany: () => Promise.resolve(state.productRows),
+      },
+      // The real product.repository (captured below for the spread mock)
+      // builds a prepared statement at module scope; give it something inert
+      // to chain on so the import does not explode.
+      productsTable: {
+        findFirst: () => ({
+          prepare: () => ({ execute: () => Promise.resolve(undefined) }),
+        }),
+      },
+    },
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            groupBy: () => Promise.resolve(state.refundedRows),
+          }),
+        }),
+      }),
+    }),
+    transaction: (cb: (tx: unknown) => unknown) => {
+      writes.transactionCount += 1;
+      return cb(fakeTx);
+    },
+  },
+}));
+
+// Spread the real modules so only the seams under observation are replaced,
+// and restore the actuals in afterAll — other test files pin these modules'
+// internals for real and must not inherit the stubs (mock.module is
+// process-global for the whole run).
+const machine = {
+  refundTransitions: [] as { executor: unknown; input: AnyObj }[],
+  serviceTransitions: [] as { executor: unknown; input: AnyObj }[],
+  rollupCalls: [] as { executor: unknown; orderId: number; userId: number }[],
+};
+
+const actualStatusMachine = await import(
+  "@/modules/orders/order-status-machine"
+);
+
+mock.module("@/modules/orders/order-status-machine", () => ({
+  ...actualStatusMachine,
+  applyRefundTransition: (executor: unknown, input: AnyObj) => {
+    machine.refundTransitions.push({ executor, input });
+    return Promise.resolve();
+  },
+  transitionOrderService: (executor: unknown, input: AnyObj) => {
+    machine.serviceTransitions.push({ executor, input });
+    return Promise.resolve();
+  },
+  recomputeOrderRollup: (
+    executor: unknown,
+    orderId: number,
+    userId: number
+  ) => {
+    machine.rollupCalls.push({ executor, orderId, userId });
+    return Promise.resolve();
+  },
+}));
+
+const redemption = {
+  releaseCalls: [] as { executor: unknown; orderId: number }[],
+};
+
+const actualRedemption = await import(
+  "@/modules/campaigns/campaign-redemption.service"
+);
+
+mock.module("@/modules/campaigns/campaign-redemption.service", () => ({
+  ...actualRedemption,
+  releaseRedemptions: (executor: unknown, orderId: number) => {
+    redemption.releaseCalls.push({ executor, orderId });
+    return Promise.resolve();
+  },
+}));
+
+const stock = {
+  calls: [] as { executor: unknown; productId: number; qty: number }[],
+};
+
+const actualProductRepo = await import("@/modules/products/product.repository");
+
+mock.module("@/modules/products/product.repository", () => ({
+  ...actualProductRepo,
+  incrementProductStock: (
+    executor: unknown,
+    productId: number,
+    qty: number
+  ) => {
+    stock.calls.push({ executor, productId, qty });
+    return Promise.resolve([{ id: productId }]);
+  },
+}));
+
+afterAll(() => {
+  mock.module(
+    "@/modules/orders/order-status-machine",
+    () => actualStatusMachine
+  );
+  mock.module(
+    "@/modules/campaigns/campaign-redemption.service",
+    () => actualRedemption
+  );
+  mock.module("@/modules/products/product.repository", () => actualProductRepo);
+});
+
+const { cancelOrder, createOrderRefund } = await import(
+  "@/modules/orders/order-reversal.service"
+);
+
+// Refund is admin-only and cancel admits admin too, so one user covers both
+// desks; the role matrix itself is pinned in permissions tests.
+const ADMIN = { id: 42, role: "admin" } as unknown as JWTPayload;
+
+// The refunded_amount increment is written as a SQL template ("refunded_amount
+// + N"); the interpolated amount sits in queryChunks as a plain number, so dig
+// it out to pin what actually lands in the ledger.
+const sqlNumberChunks = (value: unknown): number[] => {
+  const chunks = (value as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return chunks.filter((chunk): chunk is number => typeof chunk === "number");
+};
+
+const refund = (items: AnyObj[]) =>
+  createOrderRefund({
+    orderId: 1,
+    body: { items } as unknown as PostOrderRefundInput,
+    user: ADMIN,
+  });
+
+const cancel = (items: AnyObj[]) =>
+  cancelOrder({
+    orderId: 5,
+    body: { items } as unknown as PostOrderCancelInput,
+    user: ADMIN,
+  });
+
+// Postgres numerics arrive as strings — fixtures feed strings so the service's
+// Number() coercion stays under test.
+const makePaidOrder = (over: AnyObj = {}) => ({
+  id: 1,
+  payment_status: "paid",
+  paid_amount: "90000",
+  refunded_amount: "0",
+  total: "100000",
+  discount: "10000",
+  ...over,
+});
+
+const makeUnpaidOrder = (over: AnyObj = {}) => ({
+  id: 5,
+  status: "processing",
+  payment_status: "unpaid",
+  ...over,
+});
+
+beforeEach(() => {
+  state.order = undefined;
+  state.serviceRows = [];
+  state.productRows = [];
+  state.refundedRows = [];
+  state.postCancelStatus = undefined;
+  state.casResults = [];
+  reads.orderLookups = 0;
+  writes.updates = [];
+  writes.inserts = [];
+  writes.transactionCount = 0;
+  machine.refundTransitions = [];
+  machine.serviceTransitions = [];
+  machine.rollupCalls = [];
+  redemption.releaseCalls = [];
+  stock.calls = [];
+});
+
+describe("createOrderRefund", () => {
+  it("returns exactly what the customer paid for a whole wash on a discounted order", async () => {
+    // Rp100.000 wash bought with a Rp10.000 promo: the customer paid 90.000.
+    // Returning the sticker price would hand the shop's discount back in cash;
+    // the ledger, the refund record, and the status flip must all say 90.000.
+    state.order = makePaidOrder();
+    state.serviceRows = [{ id: 10, subtotal: "100000" }];
+
+    const result = await refund([{ order_service_id: 10, reason: "damaged" }]);
+
+    expect(result.total_refund_amount).toBe(90_000);
+    expect(result.refund.id).toBe(900);
+    expect(writes.transactionCount).toBe(1);
+
+    const orderUpdate = writes.updates.find((u) => u.table === ordersTable);
+    expect(orderUpdate?.set.updated_by).toBe(42);
+    expect(sqlNumberChunks(orderUpdate?.set.refunded_amount)).toEqual([90_000]);
+
+    const refundInsert = writes.inserts.find(
+      (i) => i.table === orderRefundsTable
+    );
+    expect(refundInsert?.values).toEqual({
+      order_id: 1,
+      refunded_by: 42,
+      total_amount: "90000",
+    });
+
+    const itemsInsert = writes.inserts.find(
+      (i) => i.table === orderRefundItemsTable
+    );
+    expect(itemsInsert?.values).toEqual([
+      {
+        order_refund_id: 900,
+        order_service_id: 10,
+        order_product_id: null,
+        amount: "90000",
+        reason: "damaged",
+        note: undefined,
+      },
+    ]);
+
+    // The garment itself must flip to refunded so it cannot be handed out.
+    expect(machine.refundTransitions).toEqual([
+      {
+        executor: fakeTx,
+        input: {
+          orderId: 1,
+          by: 42,
+          items: [{ serviceId: 10, note: undefined }],
+        },
+      },
+    ]);
+  });
+
+  it("refuses a refund larger than the cash still held for the order", async () => {
+    // Two Rp50.000 washes; the customer paid 60.000 up front and already got
+    // 20.000 back. The line's cap says 50.000 is returnable, but the till only
+    // holds 40.000 of their money — paying out would refund cash never received.
+    state.order = makePaidOrder({
+      paid_amount: "60000",
+      refunded_amount: "20000",
+      discount: "0",
+    });
+    state.serviceRows = [
+      { id: 10, subtotal: "50000" },
+      { id: 11, subtotal: "50000" },
+    ];
+
+    const error = await captureRejection(
+      refund([{ order_service_id: 10, reason: "damaged" }])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Refund exceeds remaining paid amount for this order"
+    );
+    // No transaction means no partial money writes to unwind.
+    expect(writes.transactionCount).toBe(0);
+    expect(writes.updates).toHaveLength(0);
+    expect(writes.inserts).toHaveLength(0);
+  });
+
+  it("pays out only the remainder on a second refund of the same shirt", async () => {
+    // The shirt already got Rp40.000 back last week. Its discounted worth is
+    // 45.000 (50.000 gross minus its share of the 10.000 promo), so a second
+    // visit can only claim the 5.000 still outstanding — the prior-refund SUM
+    // row arrives as a string and must land on the right line.
+    state.order = makePaidOrder({ refunded_amount: "40000" });
+    state.serviceRows = [
+      { id: 10, subtotal: "50000" },
+      { id: 11, subtotal: "50000" },
+    ];
+    state.refundedRows = [
+      { order_service_id: 10, order_product_id: null, refunded_total: "40000" },
+    ];
+
+    const result = await refund([{ order_service_id: 10, reason: "damaged" }]);
+
+    expect(result.total_refund_amount).toBe(5000);
+    const refundInsert = writes.inserts.find(
+      (i) => i.table === orderRefundsTable
+    );
+    expect(refundInsert?.values).toMatchObject({ total_amount: "5000" });
+  });
+
+  it("stamps the bottle refunded so no later cancel can restock it", async () => {
+    // Rp30.000 detergent bottle refunded in full. Beyond moving the cash, the
+    // row must be stamped refunded_at — that stamp is the only thing later
+    // gates trust (no second refund, no cancel-after-refund putting a
+    // paid-out bottle back on the shelf). Cash out without the stamp quietly
+    // re-arms both double-outs.
+    state.order = makePaidOrder({
+      discount: "0",
+      total: "30000",
+      paid_amount: "30000",
+    });
+    state.productRows = [
+      { id: 20, subtotal: "30000", refunded_at: null, cancelled_at: null },
+    ];
+
+    const result = await refund([{ order_product_id: 20, reason: "damaged" }]);
+
+    expect(result.total_refund_amount).toBe(30_000);
+
+    const stamp = writes.updates.find((u) => u.table === ordersProductsTable);
+    expect(stamp?.set.refunded_at).toBeInstanceOf(Date);
+
+    // A bottle refund never flips any garment's status.
+    expect(machine.refundTransitions).toHaveLength(0);
+  });
+
+  it("never refunds a product line that already took an off-ramp", async () => {
+    // The detergent bottle was refunded on a previous visit and its row is
+    // stamped refunded_at. Arithmetic would still show Rp30.000 of headroom,
+    // but the stamp is authoritative — paying again is double cash out.
+    state.order = makePaidOrder({ discount: "0", total: "30000" });
+    state.productRows = [
+      {
+        id: 20,
+        subtotal: "30000",
+        refunded_at: new Date("2026-07-01T00:00:00Z"),
+        cancelled_at: null,
+      },
+    ];
+
+    const error = await captureRejection(
+      refund([{ order_product_id: 20, reason: "damaged" }])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Order product 20 has no refundable amount remaining"
+    );
+    expect(writes.transactionCount).toBe(0);
+  });
+
+  it("rejects a double-tapped line before touching the order", async () => {
+    // A cashier double-taps submit and the same shirt arrives twice in one
+    // request — paying it out twice is straight money lost. Rejected before
+    // any lookup or write.
+    const error = await captureRejection(
+      refund([
+        { order_service_id: 10, reason: "damaged" },
+        { order_service_id: 10, reason: "damaged" },
+      ])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Duplicate refund line entries are not allowed"
+    );
+    expect(reads.orderLookups).toBe(0);
+    expect(writes.transactionCount).toBe(0);
+  });
+
+  it("rejects an item that points at no line at all", async () => {
+    // An item naming neither a service nor a product could only pay out
+    // against nothing; rejected before any lookup or write.
+    const error = await captureRejection(refund([{ reason: "damaged" }]));
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Each refund item must reference a service or product line"
+    );
+    expect(reads.orderLookups).toBe(0);
+    expect(writes.transactionCount).toBe(0);
+  });
+});
+
+describe("cancelOrder", () => {
+  it("restores stock, recomputes the rollup, and frees the voucher when the last line dies", async () => {
+    // Unpaid order whose only live line is 3 detergent bottles. Cancelling it
+    // puts the 3 bottles back on the shelf, folds the void into the order
+    // rollup, and — because the whole order is now cancelled — releases the
+    // campaign redemption so the customer's voucher is spendable again
+    // (ADR-0015).
+    state.order = makeUnpaidOrder();
+    state.productRows = [
+      { id: 30, qty: 3, product_id: 12, refunded_at: null, cancelled_at: null },
+    ];
+    state.postCancelStatus = "cancelled";
+
+    const result = await cancel([
+      { order_product_id: 30, reason: "customer_request" },
+    ]);
+
+    expect(result).toEqual({
+      cancelled_service_ids: [],
+      cancelled_product_ids: [30],
+      order_id: 5,
+    });
+
+    expect(stock.calls).toEqual([{ executor: fakeTx, productId: 12, qty: 3 }]);
+    expect(machine.rollupCalls).toEqual([
+      { executor: fakeTx, orderId: 5, userId: 42 },
+    ]);
+    expect(redemption.releaseCalls).toEqual([{ executor: fakeTx, orderId: 5 }]);
+
+    const casUpdate = writes.updates.find(
+      (u) => u.table === ordersProductsTable
+    );
+    expect(casUpdate?.set.cancelled_at).toBeInstanceOf(Date);
+    expect(casUpdate?.set.cancel_reason).toBe("customer_request");
+    expect(casUpdate?.set.cancel_note).toBeNull();
+  });
+
+  it("does not release the voucher again when the order was already cancelled", async () => {
+    // The order arrived at the desk already cancelled; a straggler line gets
+    // voided after the fact. The post-tx status still reads "cancelled", but
+    // the redemption was released the first time — releasing again would mint
+    // the customer a second free voucher use.
+    state.order = makeUnpaidOrder({ status: "cancelled" });
+    state.productRows = [
+      { id: 30, qty: 1, product_id: 12, refunded_at: null, cancelled_at: null },
+    ];
+    state.postCancelStatus = "cancelled";
+
+    await cancel([{ order_product_id: 30, reason: "customer_request" }]);
+
+    expect(redemption.releaseCalls).toHaveLength(0);
+  });
+
+  it("keeps the voucher locked while other lines are still in the wash", async () => {
+    // Multi-line ticket: the customer drops one detergent bottle but their
+    // wash stays in the machine, so the order re-reads as "processing" after
+    // the void. The voucher still funds the surviving lines — releasing it
+    // now would let the customer spend it a second time on top of this order.
+    state.order = makeUnpaidOrder();
+    state.productRows = [
+      { id: 30, qty: 1, product_id: 12, refunded_at: null, cancelled_at: null },
+    ];
+    state.postCancelStatus = "processing";
+
+    await cancel([{ order_product_id: 30, reason: "customer_request" }]);
+
+    // The dropped bottle still goes back on the shelf...
+    expect(stock.calls).toEqual([{ executor: fakeTx, productId: 12, qty: 1 }]);
+    // ...but the redemption stays attached to the still-live order.
+    expect(redemption.releaseCalls).toHaveLength(0);
+  });
+
+  it("lets the loser of a concurrent cancel fail before touching stock", async () => {
+    // Two staff cancel the same bottle at once. The pre-check saw it live, but
+    // the winner stamped it first, so the loser's CAS update matches nothing.
+    // Restoring stock anyway would count the same bottle back in twice.
+    state.order = makeUnpaidOrder();
+    state.productRows = [
+      { id: 31, qty: 2, product_id: 12, refunded_at: null, cancelled_at: null },
+    ];
+    state.casResults = [[]];
+
+    const error = await captureRejection(
+      cancel([{ order_product_id: 31, reason: "customer_request" }])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Product line 31 was already cancelled or refunded"
+    );
+    expect(stock.calls).toHaveLength(0);
+  });
+
+  it("refuses to cancel a line the shop already refunded", async () => {
+    // Refund means money moved; a cancel on top would also restore stock for a
+    // bottle whose cash already went back. Rejected before any write.
+    state.order = makeUnpaidOrder();
+    state.productRows = [
+      {
+        id: 32,
+        qty: 1,
+        product_id: 9,
+        refunded_at: new Date("2026-07-01T00:00:00Z"),
+        cancelled_at: null,
+      },
+    ];
+
+    const error = await captureRejection(
+      cancel([{ order_product_id: 32, reason: "customer_request" }])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Product line 32 is refunded and cannot be cancelled"
+    );
+    expect(writes.transactionCount).toBe(0);
+  });
+
+  it("refuses a line that does not belong to this order", async () => {
+    // A stale tab submits a line id from another order; voiding it here would
+    // restore stock against the wrong ticket. Rejected before any write.
+    state.order = makeUnpaidOrder();
+    state.productRows = [];
+
+    const error = await captureRejection(
+      cancel([{ order_product_id: 33, reason: "customer_request" }])
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Product line 33 not found on this order"
+    );
+    expect(writes.transactionCount).toBe(0);
+  });
+});

--- a/packages/server/src/modules/orders/order.service.test.ts
+++ b/packages/server/src/modules/orders/order.service.test.ts
@@ -1,0 +1,687 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
+import { ordersTable } from "@/db/schema";
+import { BadRequestException } from "@/errors";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+import type { Store } from "@/types/entity";
+
+// createOrder is the counter checkout in a single transaction: the daily order
+// number, the customer record, price/COGS snapshots, retail stock, the discount
+// desk, voucher burns, and the final paid/unpaid money state commit — or roll
+// back — together. These tests pin that orchestration: which gates fire before
+// an order number is consumed, and what lands on the order row.
+// Every collaborator seam (repositories, customer resolution, discount desk,
+// redemption claims, courier check, authorization) is doubled — each has its
+// own contract pinned elsewhere. The checkout logic itself stays real.
+
+type AnyObj = Record<string, unknown>;
+
+interface CatalogService {
+  cogs: string;
+  id: number;
+  is_priority: boolean;
+  price: string;
+}
+
+interface CatalogProduct {
+  cogs: string;
+  id: number;
+  is_active: boolean;
+  name: string;
+  price: string;
+}
+
+const catalog = {
+  products: [] as CatalogProduct[],
+  services: [] as CatalogService[],
+};
+
+const repo = {
+  sequence: 1,
+  reserveCalls: [] as { tx: unknown; storeCode: string; dateStr: string }[],
+  orderId: 501,
+  insertedOrder: undefined as AnyObj | undefined,
+  serviceRows: [] as AnyObj[],
+  productRows: [] as AnyObj[],
+  findOrdersCalls: [] as { filters: AnyObj; scopedStoreIds?: number[] }[],
+};
+
+const stock = {
+  calls: [] as { productId: number; qty: number }[],
+  emptyFor: new Set<number>(),
+};
+
+const customers = { calls: [] as AnyObj[], id: 77 };
+
+const discount = {
+  calls: [] as AnyObj[],
+  result: {
+    campaignRows: [] as AnyObj[],
+    discountAmount: 0,
+    discountSource: "none",
+  },
+};
+
+const redemptions = {
+  calls: [] as { tx: unknown; rows: unknown; orderId: number }[],
+};
+
+const courier = { calls: [] as number[] };
+
+const authz = {
+  assertCalls: [] as { userId: number; storeId: number }[],
+  listCalls: [] as number[],
+  storeIds: [] as number[],
+};
+
+const finalize = { writes: [] as { table: unknown; set: AnyObj }[] };
+
+const detail = { row: undefined as AnyObj | undefined };
+
+// The one direct tx use in createOrder is the finalizing money write on the
+// order row; everything else reaches the tx through doubled repositories.
+const TX = {
+  update: (table: unknown) => ({
+    set: (set: AnyObj) => {
+      finalize.writes.push({ table, set });
+      return { where: () => Promise.resolve() };
+    },
+  }),
+};
+
+// Real repositories create prepared statements at import time, so the fake db
+// must let any db.query.<table>.findFirst/findMany chain into .prepare() — and
+// still resolve when awaited (getOrderDetailById reads the order this way).
+const relationalQuery = (first: () => unknown) => ({
+  findFirst: () =>
+    Object.assign(Promise.resolve().then(first), {
+      prepare: () => ({ execute: () => Promise.resolve(undefined) }),
+    }),
+  findMany: () =>
+    Object.assign(Promise.resolve([] as unknown[]), {
+      prepare: () => ({ execute: () => Promise.resolve([]) }),
+    }),
+});
+
+mock.module("@/db", () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => cb(TX),
+    query: new Proxy(
+      {},
+      {
+        get: (_target, tableName) =>
+          relationalQuery(() =>
+            tableName === "ordersTable" ? detail.row : undefined
+          ),
+      }
+    ),
+  },
+}));
+
+mock.module("@/utils/authorization", () => ({
+  assertStoreAccess: (user: { id: number }, storeId: number) => {
+    authz.assertCalls.push({ userId: user.id, storeId });
+    return Promise.resolve();
+  },
+  getUserStoreIds: (userId: number) => {
+    authz.listCalls.push(userId);
+    return Promise.resolve(authz.storeIds);
+  },
+  assertOrderAccess: () => Promise.resolve({ id: 0, store_id: 0 }),
+}));
+
+// Capture the real modules before stubbing so afterAll can hand them back to
+// test files that exercise them for real (their own suites pin the internals).
+const actualOrderRepository = {
+  ...(await import("@/modules/orders/order.repository")),
+};
+const actualCustomerService = {
+  ...(await import("@/modules/customers/customer.service")),
+};
+const actualRedemptionService = {
+  ...(await import("@/modules/campaigns/campaign-redemption.service")),
+};
+const actualCourierService = {
+  ...(await import("@/modules/orders/order-courier.service")),
+};
+const actualDiscountService = {
+  ...(await import("@/modules/orders/order-discount.service")),
+};
+const actualProductRepository = {
+  ...(await import("@/modules/products/product.repository")),
+};
+const actualServiceRepository = {
+  ...(await import("@/modules/services/service.repository")),
+};
+
+mock.module("@/modules/orders/order.repository", () => ({
+  ...actualOrderRepository,
+  reserveNextOrderNumber: (tx: unknown, storeCode: string, dateStr: string) => {
+    repo.reserveCalls.push({ tx, storeCode, dateStr });
+    return Promise.resolve(repo.sequence);
+  },
+  insertOrder: (_tx: unknown, values: AnyObj) => {
+    repo.insertedOrder = values;
+    return Promise.resolve(repo.orderId);
+  },
+  // Mirrors the DB's generated subtotal: price per garment, price × qty per
+  // retail line — so the gross total under test is what a live checkout sums.
+  insertOrderServices: (_tx: unknown, rows: AnyObj[]) => {
+    repo.serviceRows = rows;
+    return Promise.resolve(
+      rows.reduce((sum, row) => sum + Number(row.price), 0)
+    );
+  },
+  insertOrderProducts: (_tx: unknown, rows: AnyObj[]) => {
+    repo.productRows = rows;
+    return Promise.resolve(
+      rows.reduce((sum, row) => sum + Number(row.price) * Number(row.qty), 0)
+    );
+  },
+  findOrders: (filters: AnyObj, scopedStoreIds?: number[]) => {
+    repo.findOrdersCalls.push({ filters, scopedStoreIds });
+    return Promise.resolve({ items: [], total: 0 });
+  },
+}));
+
+mock.module("@/modules/customers/customer.service", () => ({
+  ...actualCustomerService,
+  resolveOrCreateCustomer: (input: AnyObj) => {
+    customers.calls.push(input);
+    return Promise.resolve(customers.id);
+  },
+}));
+
+mock.module("@/modules/campaigns/campaign-redemption.service", () => ({
+  ...actualRedemptionService,
+  claimRedemptions: (tx: unknown, rows: unknown, orderId: number) => {
+    redemptions.calls.push({ tx, rows, orderId });
+    return Promise.resolve();
+  },
+}));
+
+mock.module("@/modules/orders/order-courier.service", () => ({
+  ...actualCourierService,
+  assertActiveCourier: (courierId: number) => {
+    courier.calls.push(courierId);
+    return Promise.resolve();
+  },
+}));
+
+mock.module("@/modules/orders/order-discount.service", () => ({
+  ...actualDiscountService,
+  resolveDiscount: (input: AnyObj) => {
+    discount.calls.push(input);
+    return Promise.resolve(discount.result);
+  },
+}));
+
+mock.module("@/modules/products/product.repository", () => ({
+  ...actualProductRepository,
+  findProducts: (ids: number[]) =>
+    Promise.resolve(catalog.products.filter((p) => ids.includes(p.id))),
+  decrementProductStock: (_tx: unknown, productId: number, qty: number) => {
+    stock.calls.push({ productId, qty });
+    return Promise.resolve(
+      stock.emptyFor.has(productId) ? [] : [{ id: productId }]
+    );
+  },
+}));
+
+mock.module("@/modules/services/service.repository", () => ({
+  ...actualServiceRepository,
+  findServices: (ids: number[]) =>
+    Promise.resolve(catalog.services.filter((s) => ids.includes(s.id))),
+}));
+
+const { createOrder, getOrderDetailById, listOrders } = await import(
+  "@/modules/orders/order.service"
+);
+
+// Freeze the till clock at 00:30 in Jakarta on 2 Aug — still 17:30 on 1 Aug
+// in UTC. A shop open past midnight must stamp receipts with the new Jakarta
+// business date; a UTC-clocked server would keep yesterday's date and hand
+// out duplicate tag numbers against yesterday's counter sequence.
+const JAKARTA_DATE = "02082026";
+setSystemTime(new Date("2026-08-01T17:30:00Z"));
+
+afterAll(() => {
+  setSystemTime();
+  mock.module("@/modules/orders/order.repository", () => actualOrderRepository);
+  mock.module(
+    "@/modules/customers/customer.service",
+    () => actualCustomerService
+  );
+  mock.module(
+    "@/modules/campaigns/campaign-redemption.service",
+    () => actualRedemptionService
+  );
+  mock.module(
+    "@/modules/orders/order-courier.service",
+    () => actualCourierService
+  );
+  mock.module(
+    "@/modules/orders/order-discount.service",
+    () => actualDiscountService
+  );
+  mock.module(
+    "@/modules/products/product.repository",
+    () => actualProductRepository
+  );
+  mock.module(
+    "@/modules/services/service.repository",
+    () => actualServiceRepository
+  );
+});
+
+const CASHIER_ID = 42;
+const STORE = { id: 1, code: "JKT" } as unknown as Store;
+
+const checkout = (over: AnyObj = {}) =>
+  createOrder(CASHIER_ID, STORE, {
+    customer: { name: "Budi", phone_number: "081234567890" },
+    store_id: 1,
+    campaign_ids: [],
+    voucher_codes: [],
+    discount: "0",
+    payment_status: "unpaid",
+    ...over,
+  } as never);
+
+beforeEach(() => {
+  catalog.products = [];
+  catalog.services = [];
+  repo.sequence = 1;
+  repo.reserveCalls = [];
+  repo.insertedOrder = undefined;
+  repo.serviceRows = [];
+  repo.productRows = [];
+  repo.findOrdersCalls = [];
+  stock.calls = [];
+  stock.emptyFor = new Set();
+  customers.calls = [];
+  discount.calls = [];
+  discount.result = {
+    campaignRows: [],
+    discountAmount: 0,
+    discountSource: "none",
+  };
+  redemptions.calls = [];
+  courier.calls = [];
+  authz.assertCalls = [];
+  authz.listCalls = [];
+  authz.storeIds = [];
+  finalize.writes = [];
+  detail.row = undefined;
+});
+
+describe("createOrder", () => {
+  it("books a walk-in drop-off as an open, unpaid order under today's counter number", async () => {
+    // Wash Rp30.000 + iron Rp15.000, customer pays at pickup. The clock is
+    // frozen just past midnight Jakarta (still 1 Aug in UTC), so the receipt
+    // must literally read 02082026 — the Jakarta business date — and no
+    // rupiah may land in paid_amount before money actually changes hands.
+    catalog.services = [
+      { id: 10, price: "30000", cogs: "12000", is_priority: false },
+      { id: 11, price: "15000", cogs: "4000", is_priority: false },
+    ];
+
+    const result = await checkout({ services: [{ id: 10 }, { id: 11 }] });
+
+    expect(result).toEqual({
+      code: `#JKT/${JAKARTA_DATE}/1`,
+      id: 501,
+      total: 45_000,
+      total_after_discount: 45_000,
+    });
+    expect(repo.reserveCalls).toHaveLength(1);
+    expect(repo.reserveCalls[0].tx).toBe(TX);
+    expect(repo.reserveCalls[0]).toMatchObject({
+      storeCode: "JKT",
+      dateStr: JAKARTA_DATE,
+    });
+    expect(repo.insertedOrder).toMatchObject({
+      status: "created",
+      completed_at: null,
+      customer_id: 77,
+      created_by: CASHIER_ID,
+    });
+    expect(finalize.writes).toHaveLength(1);
+    expect(finalize.writes[0].table).toBe(ordersTable);
+    expect(finalize.writes[0].set).toEqual({
+      total: "45000",
+      discount: "0",
+      discount_source: "none",
+      paid_amount: "0",
+      paid_at: null,
+      paid_by: null,
+    });
+  });
+
+  it("births a retail-only sale as completed so detergent never sits in the wash queue", async () => {
+    // A customer buying a bottle of detergent walks out with it immediately —
+    // there is no garment for the workers to process, so an open order would
+    // clog the queue board forever.
+    catalog.products = [
+      {
+        id: 20,
+        name: "Detergent 1L",
+        price: "25000",
+        cogs: "10000",
+        is_active: true,
+      },
+    ];
+
+    await checkout({ products: [{ id: 20, qty: 1 }] });
+
+    expect(repo.insertedOrder?.status).toBe("completed");
+    expect(repo.insertedOrder?.completed_at).toBeInstanceOf(Date);
+  });
+
+  it("routes the net amount into the paid fields when the customer pays at drop-off", async () => {
+    // Rp50.000 order with a Rp5.000 promo, settled at the counter. The till
+    // holds Rp45.000 — booking the gross would overstate revenue by the
+    // discount, and the promo's redemption must be burned in the same breath.
+    catalog.services = [
+      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+    ];
+    discount.result = {
+      campaignRows: [{ campaign_id: 3, kind: "listed" }],
+      discountAmount: 5000,
+      discountSource: "campaign",
+    };
+
+    const result = await checkout({
+      services: [{ id: 10 }],
+      campaign_ids: [3],
+      payment_status: "paid",
+      payment_method_id: 1,
+    });
+
+    expect(result.total).toBe(50_000);
+    expect(result.total_after_discount).toBe(45_000);
+
+    // The discount desk judges the GROSS order, not the running balance.
+    expect(discount.calls[0]).toMatchObject({
+      campaignIds: [3],
+      voucherCodes: [],
+      grossTotal: 50_000,
+      manualDiscount: 0,
+      storeId: 1,
+      storeCode: "JKT",
+    });
+
+    const set = finalize.writes[0].set;
+    expect(set.total).toBe("50000");
+    expect(set.discount).toBe("5000");
+    expect(set.paid_amount).toBe("45000");
+    expect(set.paid_at).toBeInstanceOf(Date);
+    expect(set.paid_by).toBe(CASHIER_ID);
+
+    expect(redemptions.calls).toHaveLength(1);
+    expect(redemptions.calls[0].tx).toBe(TX);
+    expect(redemptions.calls[0].rows).toBe(discount.result.campaignRows);
+    expect(redemptions.calls[0].orderId).toBe(501);
+  });
+
+  it("rejects a discount larger than the order without spending the voucher", async () => {
+    // Stacked promos worth Rp60.000 against a Rp50.000 basket. A negative
+    // total is nonsense at the till — and the customer's slip must survive the
+    // failed checkout so they can retry, not lose the code to a dead order.
+    catalog.services = [
+      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+    ];
+    discount.result = {
+      campaignRows: [
+        { campaign_id: 5, kind: "voucher", voucherCode: "VIP12345" },
+      ],
+      discountAmount: 60_000,
+      discountSource: "campaign",
+    };
+
+    const error = await captureRejection(
+      checkout({ services: [{ id: 10 }], voucher_codes: ["VIP12345"] })
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Order discount cannot exceed order total"
+    );
+    expect(redemptions.calls).toHaveLength(0);
+  });
+
+  it("honors a voucher worth exactly the basket as a free wash", async () => {
+    // A Rp50.000 comp voucher against a Rp50.000 wash is a legitimate 100%
+    // giveaway — the shop hands the wash out free all the time for complaints.
+    // The gate must reject only discounts LARGER than the order; turning away
+    // the exact-match comp would strand the manager's apology voucher. And the
+    // voucher still burns, or the customer washes free twice.
+    catalog.services = [
+      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+    ];
+    discount.result = {
+      campaignRows: [
+        { campaign_id: 5, kind: "voucher", voucherCode: "SORRY123" },
+      ],
+      discountAmount: 50_000,
+      discountSource: "campaign",
+    };
+
+    const result = await checkout({
+      services: [{ id: 10 }],
+      voucher_codes: ["SORRY123"],
+    });
+
+    expect(result.total).toBe(50_000);
+    expect(result.total_after_discount).toBe(0);
+    expect(redemptions.calls).toHaveLength(1);
+    expect(redemptions.calls[0].rows).toBe(discount.result.campaignRows);
+    expect(finalize.writes[0].set).toMatchObject({
+      total: "50000",
+      discount: "50000",
+    });
+  });
+
+  it("turns away a discontinued product before consuming a daily order number", async () => {
+    // The counter sequence resets daily and numbers the physical laundry tags;
+    // burning one on a sale that can never complete leaves a hole in the day's
+    // paper trail.
+    catalog.products = [
+      {
+        id: 20,
+        name: "Old Softener",
+        price: "10000",
+        cogs: "4000",
+        is_active: false,
+      },
+    ];
+
+    const error = await captureRejection(
+      checkout({ products: [{ id: 20, qty: 1 }] })
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Product is not active: 20");
+    expect(repo.reserveCalls).toHaveLength(0);
+    expect(repo.insertedOrder).toBeUndefined();
+  });
+
+  it("lets an out-of-stock failure escape the transaction so no half-created order survives", async () => {
+    // Two cashiers race for the last bottle. The loser's order row was already
+    // written inside the transaction — the thrown error is what rolls it back;
+    // swallowing it would leave a ghost order that was never sellable.
+    catalog.products = [
+      {
+        id: 20,
+        name: "Detergent 1L",
+        price: "25000",
+        cogs: "10000",
+        is_active: true,
+      },
+    ];
+    stock.emptyFor.add(20);
+
+    const error = await captureRejection(
+      checkout({ products: [{ id: 20, qty: 5 }] })
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe(
+      "Insufficient stock for product Detergent 1L"
+    );
+    // The shelf was asked for all five bottles at once — an atomic take-5, not
+    // five take-1s a racing cashier could interleave with.
+    expect(stock.calls).toEqual([{ productId: 20, qty: 5 }]);
+    // The order row went in before the stock check; the finalizing money write
+    // never ran — proof the rejection cut the checkout short mid-transaction.
+    expect(repo.insertedOrder).toBeDefined();
+    expect(finalize.writes).toHaveLength(0);
+  });
+
+  it("snapshots catalog prices and COGS onto the lines and tags each garment", async () => {
+    // Margins are reported from these snapshots months later, when catalog
+    // prices have moved on. 3 detergents at COGS 1250.50 must book 3751.50;
+    // each garment gets a sequential tag off the receipt code; a line without
+    // an explicit priority takes the service's default, an explicit choice
+    // beats it.
+    catalog.services = [
+      { id: 10, price: "30000", cogs: "12000", is_priority: true },
+      { id: 11, price: "15000", cogs: "4000", is_priority: true },
+    ];
+    catalog.products = [
+      {
+        id: 20,
+        name: "Detergent 1L",
+        price: "25000",
+        cogs: "1250.50",
+        is_active: true,
+      },
+    ];
+
+    const result = await checkout({
+      services: [{ id: 10 }, { id: 11, is_priority: false }],
+      products: [{ id: 20, qty: 3 }],
+    });
+
+    const code = `#JKT/${JAKARTA_DATE}/1`;
+    expect(result.total).toBe(120_000);
+
+    // Three bottles sold must leave the shelf count as three — a decrement of
+    // one would let the system keep selling detergent that is no longer there.
+    expect(stock.calls).toEqual([{ productId: 20, qty: 3 }]);
+
+    expect(repo.productRows).toEqual([
+      {
+        order_id: 501,
+        product_id: 20,
+        price: "25000",
+        cogs_snapshot: "3751.50",
+        qty: 3,
+      },
+    ]);
+
+    expect(repo.serviceRows).toHaveLength(2);
+    expect(repo.serviceRows[0]).toMatchObject({
+      item_code: `${code}-S001`,
+      is_priority: true,
+      order_id: 501,
+      service_id: 10,
+      price: "30000",
+      cogs_snapshot: "12000",
+      status: "queued",
+    });
+    expect(repo.serviceRows[1]).toMatchObject({
+      item_code: `${code}-S002`,
+      is_priority: false,
+      service_id: 11,
+      price: "15000",
+    });
+  });
+
+  it("verifies the courier only when the bag arrived with one", async () => {
+    // Most orders are handed over the counter; only courier-collected bags
+    // must name an active courier, so the check must not fire for walk-ins.
+    catalog.services = [
+      { id: 10, price: "30000", cogs: "12000", is_priority: false },
+    ];
+
+    await checkout({ services: [{ id: 10 }] });
+    expect(courier.calls).toEqual([]);
+    expect(repo.insertedOrder?.collected_by).toBeNull();
+
+    await checkout({ services: [{ id: 10 }], collected_by: 9 });
+    expect(courier.calls).toEqual([9]);
+    expect(repo.insertedOrder?.collected_by).toBe(9);
+  });
+});
+
+describe("listOrders", () => {
+  const cashier = { id: CASHIER_ID, role: "cashier" } as unknown as JWTPayload;
+  const admin = { id: 1, role: "admin" } as unknown as JWTPayload;
+
+  it("fences a cashier without a store filter into their own stores", async () => {
+    // A cashier browsing "all orders" must still only see the branches they
+    // work at — an open list would leak every store's revenue to any staff.
+    authz.storeIds = [1, 2];
+
+    await listOrders(undefined, cashier);
+
+    expect(authz.listCalls).toEqual([CASHIER_ID]);
+    expect(repo.findOrdersCalls[0].scopedStoreIds).toEqual([1, 2]);
+    expect(authz.assertCalls).toHaveLength(0);
+  });
+
+  it("checks access for an explicit store filter instead of scoping", async () => {
+    // Asking for store 3 by name is an access question, not a scoping one:
+    // either the cashier works there and sees exactly that store, or the
+    // request is refused outright.
+    await listOrders(
+      { store_id: 3, sort_by: "id" as const, sort_order: "desc" as const },
+      cashier
+    );
+
+    expect(authz.assertCalls).toEqual([{ userId: CASHIER_ID, storeId: 3 }]);
+    expect(authz.listCalls).toHaveLength(0);
+    expect(repo.findOrdersCalls[0].scopedStoreIds).toBeUndefined();
+  });
+
+  it("lets an admin see everything without any store gate", async () => {
+    await listOrders(undefined, admin);
+
+    expect(authz.listCalls).toHaveLength(0);
+    expect(authz.assertCalls).toHaveLength(0);
+    expect(repo.findOrdersCalls[0].scopedStoreIds).toBeUndefined();
+  });
+});
+
+describe("getOrderDetailById", () => {
+  it("strips the pickup code from the detail response", async () => {
+    // The pickup code is the bearer secret that releases the laundry — it
+    // lives only on the printed receipt (ADR-0005/0016). Any API surface that
+    // echoes it would let staff or a shoulder-surfer release someone else's
+    // clothes.
+    detail.row = {
+      id: 9,
+      pickup_code: "AB12",
+      paid_amount: "50000",
+      refunded_amount: "0",
+      dropoff_photo_path: null,
+      pickupEvents: [],
+      services: [],
+    };
+
+    const result = await getOrderDetailById(9);
+
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("pickup_code");
+    expect(result?.id).toBe(9);
+  });
+});

--- a/packages/server/src/modules/reports/report-range.util.test.ts
+++ b/packages/server/src/modules/reports/report-range.util.test.ts
@@ -1,0 +1,153 @@
+// Pins the pure date math every revenue report leans on: Jakarta day
+// attribution, the previous-period comparison window, granularity picking,
+// and gap-free bucket enumeration. A one-day drift moves money between
+// business days; an ISO-week mismatch with Postgres to_char('IYYY-IW') dumps
+// New Year revenue into a phantom week. Everything runs real — no mocks.
+// jakartaBucketExpr is deliberately untested (it needs a live PgColumn);
+// its drift risk is pinned via the bucketFormat contract and the ISO-week
+// agreement tests instead.
+import { describe, expect, it } from "bun:test";
+import {
+  bucketFormat,
+  daysBetween,
+  dayToBucket,
+  deltaPct,
+  derivePreviousRange,
+  enumerateBuckets,
+  enumerateDays,
+  getJakartaDayRange,
+  getJakartaRange,
+  pickGranularity,
+  shiftDate,
+} from "@/modules/reports/report-range.util";
+
+describe("getJakartaDayRange", () => {
+  it("bounds Aug 1 so a 23:30-on-Jul-31 payment stays in July", () => {
+    const { start, end } = getJakartaDayRange("2026-08-01");
+    expect(start).toEqual(new Date("2026-07-31T17:00:00.000Z"));
+    // Half-open: the boundary instant belongs to the next day, never both.
+    expect(end).toEqual(new Date("2026-08-01T17:00:00.000Z"));
+  });
+});
+
+describe("getJakartaRange", () => {
+  it("keeps a 23:59 payment on the report's last day inside the month", () => {
+    const { start, end } = getJakartaRange("2026-07-01", "2026-07-31");
+    expect(start).toEqual(new Date("2026-06-30T17:00:00.000Z"));
+    expect(end).toEqual(new Date("2026-07-31T17:00:00.000Z"));
+  });
+});
+
+describe("daysBetween", () => {
+  it("counts a single-day report as one day, not zero", () => {
+    expect(daysBetween("2026-08-01", "2026-08-01")).toBe(1);
+  });
+});
+
+describe("derivePreviousRange", () => {
+  it("compares July against the equal-length window ending right before it", () => {
+    // No gap, no overlap — otherwise growth vs last period double-counts
+    // or silently drops days.
+    expect(derivePreviousRange("2026-07-01", "2026-07-31")).toEqual({
+      from: "2026-05-31",
+      to: "2026-06-30",
+    });
+  });
+
+  it("compares today against yesterday for a single-day report", () => {
+    expect(derivePreviousRange("2026-08-01", "2026-08-01")).toEqual({
+      from: "2026-07-31",
+      to: "2026-07-31",
+    });
+  });
+});
+
+describe("pickGranularity", () => {
+  it("switches day to week just past a full month", () => {
+    expect(pickGranularity("2026-07-01", "2026-07-31")).toBe("day");
+    expect(pickGranularity("2026-07-01", "2026-08-01")).toBe("week");
+  });
+
+  it("switches week to month just past 120 days", () => {
+    expect(pickGranularity("2026-01-01", "2026-04-30")).toBe("week");
+    expect(pickGranularity("2026-01-01", "2026-05-01")).toBe("month");
+  });
+
+  it("switches month to year just past two years", () => {
+    expect(pickGranularity("2025-01-01", "2026-12-31")).toBe("month");
+    expect(pickGranularity("2025-01-01", "2027-01-01")).toBe("year");
+  });
+});
+
+describe("dayToBucket", () => {
+  // JS must agree with Postgres to_char(IYYY-IW), or the New Year's rush
+  // lands in a week the report never enumerates and vanishes from the chart.
+  it("files Dec 29 2025 under 2026 week 1", () => {
+    expect(dayToBucket("2025-12-29", "week")).toBe("2026-01");
+  });
+
+  it("files Jan 1 2027 under 2026 week 53", () => {
+    expect(dayToBucket("2027-01-01", "week")).toBe("2026-53");
+  });
+
+  it("keeps Sunday Jan 4 2026 in week 1 with the rest of its week", () => {
+    // Sunday closes the ISO week. Treat it as the week's opener instead and
+    // every Sunday's takings slide into the next week's bar while Postgres
+    // keeps them here — the busiest laundry day vanishes from its own week.
+    expect(dayToBucket("2026-01-04", "week")).toBe("2026-01");
+  });
+});
+
+describe("enumerateBuckets", () => {
+  it("lists every month the range touches, partial months included", () => {
+    // A quarter opened mid-January must still chart January's tail revenue.
+    expect(enumerateBuckets("2026-01-15", "2026-04-02", "month")).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+  });
+});
+
+describe("enumerateDays", () => {
+  it("does not skip Feb 29 revenue in a leap year", () => {
+    expect(enumerateDays("2028-02-28", "2028-03-01")).toEqual([
+      "2028-02-28",
+      "2028-02-29",
+      "2028-03-01",
+    ]);
+  });
+});
+
+describe("shiftDate", () => {
+  it("steps onto the leap day instead of jumping past it", () => {
+    expect(shiftDate("2028-02-28", 1)).toBe("2028-02-29");
+  });
+
+  it("rolls across month and year boundaries", () => {
+    expect(shiftDate("2028-02-29", 1)).toBe("2028-03-01");
+    expect(shiftDate("2026-12-31", 1)).toBe("2027-01-01");
+  });
+});
+
+describe("deltaPct", () => {
+  it("reports 20% growth as exactly 0.2", () => {
+    expect(deltaPct(120_000, 100_000)).toBe(0.2);
+  });
+
+  it("returns null when the previous period had no sales", () => {
+    // A store's first month must never show Infinity% growth on the card.
+    expect(deltaPct(50_000, 0)).toBeNull();
+  });
+});
+
+describe("bucketFormat", () => {
+  it("matches the to_char formats the SQL side groups by", () => {
+    // These strings keep DB rows joinable to the enumerated buckets.
+    expect(bucketFormat("day")).toBe("YYYY-MM-DD");
+    expect(bucketFormat("week")).toBe("IYYY-IW");
+    expect(bucketFormat("month")).toBe("YYYY-MM");
+    expect(bucketFormat("year")).toBe("YYYY");
+  });
+});

--- a/packages/server/src/utils/date.test.ts
+++ b/packages/server/src/utils/date.test.ts
@@ -1,0 +1,90 @@
+// Pins the Jakarta business-day boundary behind order numbering (the DDMMYYYY
+// stamp on every receipt) and the created_at day filters on shifts and daily
+// reports. If this boundary drifts, a 23:30 drop-off lands in the wrong day's
+// revenue and tonight's order numbers restart a day early or late.
+// Everything runs real — no mocks; only jakartaNow's wall clock is faked via
+// setSystemTime, and it is reset in afterAll. The process TZ is pinned to UTC
+// for the whole file: on a machine that already lives in WIB (like the shop's
+// own laptop), dropping the timezone plugin changes nothing and every test
+// here would stay green while production servers drift a day.
+import { afterAll, describe, expect, it, setSystemTime } from "bun:test";
+import dayjs from "dayjs";
+import {
+  JAKARTA_TZ,
+  jakartaDayEnd,
+  jakartaDayStart,
+  jakartaNow,
+} from "@/utils/date";
+
+const originalTz = process.env.TZ;
+process.env.TZ = "UTC";
+
+afterAll(() => {
+  if (originalTz === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTz;
+  }
+});
+
+describe("jakartaDayStart", () => {
+  it("keeps a 23:30 drop-off inside the same business day", () => {
+    // 2026-08-01T16:30Z is 23:30 in Jakarta — still Aug 1 at the counter.
+    expect(jakartaDayStart(new Date("2026-08-01T16:30:00Z"))).toEqual(
+      new Date("2026-07-31T17:00:00.000Z")
+    );
+  });
+
+  it("rolls an exactly-midnight order into the next business day", () => {
+    // 17:00Z is the stroke of Jakarta midnight — the register has flipped.
+    expect(jakartaDayStart(new Date("2026-08-01T17:00:00Z"))).toEqual(
+      new Date("2026-08-01T17:00:00.000Z")
+    );
+  });
+
+  it("lands on Jakarta midnight for Date and plain-date inputs alike", () => {
+    // String inputs first parse in the process-local timezone, so the only
+    // safe promise across deploy environments is the Jakarta wall clock.
+    const inputs: (Date | string)[] = [
+      new Date("2026-08-01T16:30:00Z"),
+      "2026-08-01",
+    ];
+    for (const input of inputs) {
+      expect(
+        dayjs(jakartaDayStart(input)).tz(JAKARTA_TZ).format("HH:mm:ss.SSS")
+      ).toBe("00:00:00.000");
+    }
+  });
+});
+
+describe("jakartaDayEnd", () => {
+  it("closes the day at the last millisecond before Jakarta midnight", () => {
+    expect(jakartaDayEnd(new Date("2026-08-01T16:30:00Z"))).toEqual(
+      new Date("2026-08-01T16:59:59.999Z")
+    );
+  });
+
+  it("spans exactly one civil day together with jakartaDayStart", () => {
+    // Anything shorter drops orders; anything longer double-counts them.
+    const input = new Date("2026-08-01T02:00:00Z");
+    expect(
+      jakartaDayEnd(input).getTime() - jakartaDayStart(input).getTime()
+    ).toBe(86_399_999);
+  });
+});
+
+describe("jakartaNow", () => {
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  it("stamps order numbers with tomorrow's date once Jakarta passes midnight", () => {
+    // 20:00Z on Aug 1 is 03:00 Aug 2 at the shop — receipts must say 02.
+    setSystemTime(new Date("2026-08-01T20:00:00Z"));
+    expect(jakartaNow().format("DDMMYYYY")).toBe("02082026");
+  });
+
+  it("carries the WIB offset — fails loudly if the timezone plugin is dropped", () => {
+    expect(jakartaNow().utcOffset()).toBe(420);
+  });
+});


### PR DESCRIPTION
## What

89 new unit tests (248 total, up from 159) for the highest-criticality server logic that had no coverage — everything that moves money or decides which business day revenue lands in. Server only; no source files touched.

| File under test | Pins |
| --- | --- |
| `order-reversal.service` | Refund caps (gross − prorated discount − prior refunds), refund never exceeds remaining paid, refunded/cancelled lines can't be re-refunded, cancel restores stock exactly once, voucher released exactly once — and **not** released on partial cancel |
| `order.service` (`createOrder`, `listOrders`) | Order-number date flips at Jakarta midnight (clock frozen where UTC and WIB dates differ), retail-only orders born `completed`, paid branch records **net** not gross, over-discount guard fires **before** voucher burn, 100%-off voucher still checks out, stock decremented by line qty, COGS snapshots, store scoping by role |
| `order-payment.service` | Net due = total − discount − refunded, clamped at zero; double-collect and cancelled-order guards; permission gate runs before any DB read |
| `order-pickup.service` | Paid-before-pickup (ADR-0009), pickup-code proof (ADR-0005), cross-order ids rejected, not-ready items named, concurrent double-pickup rolls the event back |
| `order-queue.service` | Claim races (item already assigned), idempotent re-claim, terminal statuses only exit through the audited pickup/cancel/refund endpoints |
| `order-refund-status` | none/partial/full badge, incl. over-refund → `full` and zero-paid → never `full` |
| `utils/date`, `report-range.util` | Jakarta day boundaries (23:30 WIB stays on its day), ISO-week New Year agreement with Postgres `IYYY-IW`, leap day, period-over-period windows, granularity thresholds, `deltaPct` never `Infinity` |

## How

- House pattern throughout: `mock.module` doubles for `@/db`/repositories/collaborating services registered before a dynamic import; arithmetic and guards under test kept real; money fixtures fed as Postgres numeric strings.
- Tests that stub shared pure modules (status machine, discount service) restore the real module in `afterAll`, so the full suite stays clean in one `bun test` process.
- Each file was adversarially reviewed against mutations (dropped guards, flipped boundaries, mock-echo tests); the gaps that review found — unpinned voucher-release gate on partial cancel, unasserted stock quantity, a self-referential Jakarta date assertion — are closed in the final version.

## Deliberately not covered here

- `utils/authorization.ts` — real branching worth testing, but the existing complaint test stubs this module process-globally; testing the real thing needs a small refactor of that stub first (follow-up).
- `report.service.ts` / `report-range.service.ts` — pending the report-stack merge in TODO.md; only the pure range util is pinned since it survives that merge.
- Receipt/shift/customer services — thin or query-mirror code; low unit-test value.

## Verification

- `bun test` (packages/server): 248 pass, 0 fail
- `tsc -b`: clean
- `bun x ultracite check`: clean