### PR TITLE
refactor(server): let tsdown own dist, drop clean:false

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,7 @@
     "build": "bun --bun tsdown",
     "build:types": "bun --bun tsdown",
     "lint": "biome check .",
-    "type-check": "tsc -b",
+    "type-check": "tsc",
     "test": "bun test",
     "seed:dev": "bun run src/db/seed.ts",
     "pull:dev": "bun drizzle-kit pull --config=drizzle-dev.config.ts",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -10,18 +10,13 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "outDir": "dist",
-    "declaration": true,
-
-    // `tsc -b` is build mode, so it emits. Nothing consumes its JS — the
-    // server runs from src, the web imports tsdown's bundle — and emitting it
-    // dropped compiled copies of every *.test.ts into dist, where a bare
-    // `bun test` discovered and failed them. Declarations only keeps the type
-    // check (tests included) without the phantom test files.
-    "emitDeclarationOnly": true,
-
-    // composite true is only needed when it's being referenced in another tsconfig workspace
-    "composite": true
+    // tsc only checks here; tsdown owns dist and every package export. Emitting
+    // put tsc's output alongside tsdown's in one directory, which cost us a
+    // compiled copy of every *.test.ts for a bare `bun test` to find, and
+    // forced `clean: false` so neither tool could delete the other's files.
+    // Declared here rather than as a --noEmit flag so a stray `tsc` run cannot
+    // reintroduce either problem.
+    "noEmit": true
   },
   "exclude": ["node_modules", "drizzle", "dist", "bun.lock"]
 }

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -6,5 +6,4 @@ export default defineConfig({
   sourcemap: true,
   minify: true,
   fixedExtension: false,
-  clean: false,
 });


### PR DESCRIPTION
## What

Rebased — the receipt-logo feature and the first-pass tsc fix that were on this branch already landed on main via #70. What's left is the follow-up refactor that supersedes that first-pass fix.

`type-check` (`tsc -b`) and `tsdown build` both wrote into `packages/server/dist`, racing each other under turbo's topological `dependsOn: ["^build"]` (no ordering between `api#build` and `api#type-check`). The earlier fix (`emitDeclarationOnly`, landed via #70) stopped the phantom compiled `*.test.ts` files but left both tools sharing the directory, which is why `tsdown.config.ts` still carried `clean: false`.

This gives `dist` a single owner: `tsc` now only checks (`noEmit: true`, dropping `outDir`/`declaration`/`composite` — `composite` was vestigial, nothing references this tsconfig as a project reference). `tsdown` owns `dist` alone, so `clean: false` is no longer needed. `noEmit` lives in the tsconfig rather than a `--noEmit` flag so a stray `tsc` invocation can't reintroduce the shared-directory problem.

## Tests

Verified from an empty `dist`: 8 files, all tsdown's, no `*.test.js`. `tsc` still checks all server test files. Root `bun test` passing.