### PR TITLE
docs: point repo references at fc-pos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ cd packages/server && bunx tsdown
 
 ### Issue tracker
 
-GitHub issues on `jovanhartono/fc-bun-api` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub issues on `jovanhartono/fc-pos` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues on `jovanhartono/fc-bun-api`. Use the `gh` CLI for all operations.
+Issues and PRDs for this repo live as GitHub issues on `jovanhartono/fc-pos`. Use the `gh` CLI for all operations.
 
 ## Conventions
 


### PR DESCRIPTION
Repo was renamed `fc-bun-api` → `fc-pos`. Updates the two live references (CLAUDE.md issue-tracker section, `docs/agents/issue-tracker.md`). The archived v1-ship audit keeps the old name — it's a frozen historical reference.