### PR TITLE
perf(web): preload on intent, add pending UI, flatten loaders

### DIFF
--- a/apps/web/src/components/route-pending.tsx
+++ b/apps/web/src/components/route-pending.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const RoutePending = () => (
+	<output
+		aria-busy
+		className="grid animate-in gap-4 duration-500 fade-in motion-reduce:animate-none"
+	>
+		<Skeleton className="h-8 w-48 motion-reduce:animate-none" />
+		<Skeleton className="h-28 w-full motion-reduce:animate-none" />
+		<Skeleton className="h-64 w-full motion-reduce:animate-none" />
+	</output>
+);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { DetailedError } from "hono/client";
 import { lazy, StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { toast } from "sonner";
+import { RoutePending } from "@/components/route-pending";
 import { ThemeProvider } from "@/components/theme-provider";
 import { routeTree } from "@/routeTree.gen";
 
@@ -56,6 +57,12 @@ const router = createRouter({
 	context: {
 		queryClient,
 	},
+	defaultPreload: "intent",
+	// Loaders delegate freshness to React Query's staleTime; without this the
+	// router's own 30s preload window would shadow it.
+	defaultPreloadStaleTime: 0,
+	defaultPendingComponent: RoutePending,
+	defaultViewTransition: true,
 });
 
 declare module "@tanstack/react-router" {

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -76,17 +76,26 @@ export const Route = createFileRoute("/_admin/orders/")({
 	loaderDeps: ({ search }) => search,
 	loader: async ({ context, deps }) => {
 		const currentUser = getCurrentUser();
-		await context.queryClient.ensureQueryData(storesQueryOptions());
-
 		// DB-fresh role — JWT claim goes stale on mid-session role changes.
-		const me = currentUser
-			? await context.queryClient.ensureQueryData(meQueryOptions())
+		const mePromise = currentUser
+			? context.queryClient.ensureQueryData(meQueryOptions())
 			: undefined;
-
-		if (me?.role === "admin" || deps.storeId !== undefined) {
-			await context.queryClient.ensureQueryData(
+		const ensureOrders = () =>
+			context.queryClient.ensureQueryData(
 				ordersPageQueryOptions(buildOrdersListParams(deps, deps.storeId)),
 			);
+
+		await Promise.all([
+			context.queryClient.ensureQueryData(storesQueryOptions()),
+			mePromise,
+			// A storeId in the URL already satisfies the fetch gate.
+			deps.storeId !== undefined ? ensureOrders() : undefined,
+		]);
+
+		const me = await mePromise;
+
+		if (deps.storeId === undefined && me?.role === "admin") {
+			await ensureOrders();
 		}
 	},
 	component: OrdersPage,

--- a/apps/web/src/routes/_admin/transactions.tsx
+++ b/apps/web/src/routes/_admin/transactions.tsx
@@ -18,6 +18,9 @@ import { getCurrentUser } from "@/stores/auth-store";
 export const Route = createFileRoute("/_admin/transactions")({
 	loader: async ({ context }) => {
 		const currentUser = getCurrentUser();
+		const mePromise = currentUser
+			? context.queryClient.ensureQueryData(meQueryOptions())
+			: undefined;
 
 		await Promise.all([
 			context.queryClient.ensureQueryData(storesQueryOptions()),
@@ -25,15 +28,12 @@ export const Route = createFileRoute("/_admin/transactions")({
 			context.queryClient.ensureQueryData(productsQueryOptions()),
 			context.queryClient.ensureQueryData(servicesQueryOptions()),
 			context.queryClient.ensureQueryData(paymentMethodsQueryOptions()),
+			mePromise,
 		]);
 
-		if (!currentUser) {
-			return;
-		}
+		const me = await mePromise;
 
-		const me = await context.queryClient.ensureQueryData(meQueryOptions());
-
-		if (me.role !== "admin") {
+		if (me && me.role !== "admin") {
 			const firstStoreId = me.userStores[0]?.store_id;
 
 			if (firstStoreId) {

--- a/apps/web/src/routes/_admin/worker.index.tsx
+++ b/apps/web/src/routes/_admin/worker.index.tsx
@@ -126,11 +126,13 @@ export const Route = createFileRoute("/_admin/worker/")({
 	validateSearch: (search) => workerSearchSchema.parse(search),
 	loader: async ({ context }) => {
 		const currentUser = getCurrentUser();
-		await context.queryClient.ensureQueryData(storesQueryOptions());
 
-		if (currentUser) {
-			await context.queryClient.ensureQueryData(meQueryOptions());
-		}
+		await Promise.all([
+			context.queryClient.ensureQueryData(storesQueryOptions()),
+			currentUser
+				? context.queryClient.ensureQueryData(meQueryOptions())
+				: undefined,
+		]);
 	},
 	component: WorkerQueuePage,
 });


### PR DESCRIPTION
## Summary
- Enable `defaultPreload: "intent"` with `defaultPreloadStaleTime: 0` so route loaders start on hover/focus and React Query's `staleTime` owns freshness (the router's 30s preload window no longer shadows it)
- Add `defaultPendingComponent` (skeleton stack, appears only past the 1s pending threshold, reduced-motion safe) and `defaultViewTransition: true` so route swaps cross-fade instead of freezing on the old page
- Flatten loader waterfalls in `worker.index`, `orders.index`, and `transactions`: independent `ensureQueryData` calls now run in one `Promise.all` wave; only genuinely dependent fetches remain sequential (unscoped orders needs `me.role`, campaigns key embeds `me.userStores[0].store_id`)

Fetch conditions are unchanged in all three loaders — auth, admin-role, and `storeId` gates behave identically; only the scheduling changed. Motivated by Vercel log analysis showing the API container cold-starts (~750ms+ first request) on each session's first navigation, which these blocking waterfalls amplified.

## Test plan
- [x] `bun x ultracite check` clean
- [x] `bun run type-check` (web) clean
- [ ] Manual: navigate with the orders filter popover / StoreAutocomplete open to check for view-transition snapshot artifacts
- [ ] Manual: throttle network in dev and confirm skeleton fades in after ~1s on a slow navigation