### PR TITLE
feat: raise audit photo fidelity, add lightbox pinch-zoom

### DIFF
--- a/apps/web/src/features/orders/components/order-attachments-card.tsx
+++ b/apps/web/src/features/orders/components/order-attachments-card.tsx
@@ -10,7 +10,7 @@ import {
 import { OrderSectionHeader } from "@/features/orders/components/order-section-header";
 import { SinglePhotoUploadDialog } from "@/features/orders/components/photo-upload-dialog";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
-import { uploadOrderDropoffPhoto } from "@/features/orders/utils/photo-upload";
+import { orderDropoffPhotoUploader } from "@/features/orders/utils/photo-upload";
 import type { OrderDetail } from "@/lib/api";
 
 type PickupEvent = OrderDetail["pickup_events"][number];
@@ -125,7 +125,7 @@ const DropoffAttachment = ({
 				onUploaded={onUploaded}
 				open={isDialogOpen}
 				title="Upload drop-off photo"
-				uploadPhoto={(input) => uploadOrderDropoffPhoto(order.id, input)}
+				uploader={orderDropoffPhotoUploader(order.id)}
 			/>
 		</section>
 	);

--- a/apps/web/src/features/orders/components/order-attachments-card.tsx
+++ b/apps/web/src/features/orders/components/order-attachments-card.tsx
@@ -1,13 +1,18 @@
-import { CameraIcon } from "@phosphor-icons/react";
+import { CameraIcon, DownloadSimpleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
+	getPhotoDownloadName,
 	OrderPhotoGallery,
 	type OrderPhotoGalleryItem,
 } from "@/features/orders/components/order-photo-gallery";
 import { OrderSectionHeader } from "@/features/orders/components/order-section-header";
+import {
+	PhotoLightbox,
+	type PhotoLightboxItem,
+} from "@/features/orders/components/photo-lightbox";
 import { SinglePhotoUploadDialog } from "@/features/orders/components/photo-upload-dialog";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
 import { orderDropoffPhotoUploader } from "@/features/orders/utils/photo-upload";
@@ -65,20 +70,8 @@ const DropoffAttachment = ({
 }: DropoffAttachmentProps) => {
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-	const isSaved = Boolean(order.dropoff_photo_url);
-
-	// Single drop-off photo rendered through the shared gallery so its tile
-	// matches the pickup thumbnails exactly (size, border, hover, lightbox).
-	const items: OrderPhotoGalleryItem[] = order.dropoff_photo_url
-		? [
-				{
-					alt: "Order drop-off",
-					created_at: order.dropoff_photo_uploaded_at ?? order.created_at,
-					id: order.id,
-					image_url: order.dropoff_photo_url,
-				},
-			]
-		: [];
+	const photoUrl = order.dropoff_photo_url;
+	const isSaved = Boolean(photoUrl);
 
 	return (
 		<section className="grid content-start gap-3">
@@ -89,18 +82,18 @@ const DropoffAttachment = ({
 				</Badge>
 			</div>
 
-			<OrderPhotoGallery
-				emptyState={
-					<div className="flex aspect-16/10 flex-col items-center justify-center gap-2 border bg-muted px-4 text-center text-muted-foreground">
-						<CameraIcon className="size-8 opacity-50" />
-						<p className="text-sm">No drop-off photo yet</p>
-					</div>
-				}
-				gridClassName="grid-cols-1"
-				items={items}
-				thumbnailImageClassName="aspect-16/10"
-				title="Drop-off photo"
-			/>
+			{photoUrl ? (
+				<DropoffPhoto
+					capturedAt={order.dropoff_photo_uploaded_at ?? order.created_at}
+					imageUrl={photoUrl}
+					orderId={order.id}
+				/>
+			) : (
+				<div className="flex aspect-16/10 flex-col items-center justify-center gap-2 border bg-muted px-4 text-center text-muted-foreground">
+					<CameraIcon className="size-8 opacity-50" />
+					<p className="text-sm">No drop-off photo yet</p>
+				</div>
+			)}
 
 			{order.dropoff_photo_uploaded_at ? (
 				<p className="text-muted-foreground text-xs">
@@ -128,6 +121,75 @@ const DropoffAttachment = ({
 				uploader={orderDropoffPhotoUploader(order.id)}
 			/>
 		</section>
+	);
+};
+
+interface DropoffPhotoProps {
+	capturedAt: string;
+	imageUrl: string;
+	orderId: number;
+}
+
+// An order has exactly one drop-off photo, so it gets a full-width hero tile
+// rather than a seat in the pickup thumbnail strip — the counter staff open this
+// to check what came in before the complaint desk argues about it.
+const DropoffPhoto = ({ capturedAt, imageUrl, orderId }: DropoffPhotoProps) => {
+	const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+
+	const item: PhotoLightboxItem = {
+		alt: "Order drop-off",
+		created_at: capturedAt,
+		id: orderId,
+		image_url: imageUrl,
+		primaryLabel: "Drop-off photo",
+	};
+
+	return (
+		<div className="group relative">
+			<button
+				aria-label="Open drop-off photo"
+				className="block w-full overflow-hidden border border-border bg-muted transition-[border-color,box-shadow] hover:border-ring focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50"
+				onClick={() => setIsLightboxOpen(true)}
+				type="button"
+			>
+				<img
+					alt={item.alt}
+					className="aspect-16/10 w-full bg-muted object-cover"
+					decoding="async"
+					height={400}
+					loading="lazy"
+					src={imageUrl}
+					width={640}
+				/>
+			</button>
+
+			<div className="pointer-events-none absolute inset-x-0 top-0 flex justify-end p-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+				<Button
+					className="pointer-events-auto border-black/10 bg-background/90 text-foreground hover:bg-background"
+					nativeButton={false}
+					render={
+						<a
+							aria-label="Save drop-off photo"
+							download={getPhotoDownloadName(item)}
+							href={imageUrl}
+						>
+							<DownloadSimpleIcon aria-hidden="true" className="size-4" />
+							<span className="sr-only">Save drop-off photo</span>
+						</a>
+					}
+					size="icon-sm"
+					title="Save image"
+					variant="outline"
+				/>
+			</div>
+
+			<PhotoLightbox
+				items={[item]}
+				onOpenChange={setIsLightboxOpen}
+				open={isLightboxOpen}
+				title="Drop-off photo"
+			/>
+		</div>
 	);
 };
 

--- a/apps/web/src/features/orders/components/order-photo-gallery.tsx
+++ b/apps/web/src/features/orders/components/order-photo-gallery.tsx
@@ -30,7 +30,10 @@ type OrderPhotoGalleryProps = {
 	title?: string;
 };
 
-function getPhotoDownloadName(item: OrderPhotoGalleryItem) {
+export function getPhotoDownloadName(item: {
+	id: number | string;
+	image_url: string;
+}) {
 	const pathname = new URL(item.image_url, "https://fresclean.local").pathname;
 	const extension = pathname.split(".").pop()?.toLowerCase();
 	const resolvedExtension =

--- a/apps/web/src/features/orders/components/order-photo-gallery.tsx
+++ b/apps/web/src/features/orders/components/order-photo-gallery.tsx
@@ -77,7 +77,13 @@ export function OrderPhotoGallery({
 	return (
 		<>
 			<div
-				className={cn("grid grid-cols-3 gap-2 sm:grid-cols-4", gridClassName)}
+				className={cn(
+					// Keep this default variant-free: tailwind-merge only resolves
+					// conflicts inside a variant, so a `sm:` here would outrank every
+					// unprefixed grid-cols-* a caller passes.
+					"grid grid-cols-3 gap-2",
+					gridClassName,
+				)}
 			>
 				{items.map((item, index) => (
 					<div className="group relative" key={item.id}>

--- a/apps/web/src/features/orders/components/order-pickup-event-dialog.tsx
+++ b/apps/web/src/features/orders/components/order-pickup-event-dialog.tsx
@@ -381,7 +381,7 @@ const PickupPhotoField = memo(() => {
 			</button>
 
 			<SinglePhotoCaptureDialog
-				cameraOnly={false}
+				autoOpenCamera={false}
 				onCapture={setFile}
 				onOpenChange={setIsCameraOpen}
 				open={isCameraOpen}

--- a/apps/web/src/features/orders/components/order-service-detail.tsx
+++ b/apps/web/src/features/orders/components/order-service-detail.tsx
@@ -122,7 +122,6 @@ export const OrderServiceDetail = ({
 		(nextStatus): nextStatus is NonTerminalServiceStatus =>
 			!TERMINAL_SERVICE_STATUSES.has(nextStatus),
 	);
-	const itemLabel = service.item_code ?? `Service #${service.id}`;
 	// ADR-0012: a pair cannot start processing without a photo.
 	const needsPhotoToStart =
 		service.status === "queued" && service.images.length === 0;
@@ -211,7 +210,7 @@ export const OrderServiceDetail = ({
 					Add item photo
 				</Button>
 				<PhotoUploadDialog
-					badgeLabel={itemLabel}
+					badgeLabel={service.item_code ?? undefined}
 					onOpenChange={setIsPhotoUploadOpen}
 					onUploaded={refreshOrder}
 					open={isPhotoUploadOpen}

--- a/apps/web/src/features/orders/components/order-service-detail.tsx
+++ b/apps/web/src/features/orders/components/order-service-detail.tsx
@@ -225,7 +225,7 @@ export const OrderServiceDetail = ({
 				</p>
 				{service.images.length > 0 ? (
 					<OrderPhotoGallery
-						gridClassName="@md:grid-cols-2 @2xl:grid-cols-3"
+						gridClassName="grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3"
 						items={service.images.map((image) => ({
 							...image,
 							alt:

--- a/apps/web/src/features/orders/components/order-service-detail.tsx
+++ b/apps/web/src/features/orders/components/order-service-detail.tsx
@@ -18,7 +18,7 @@ import {
 	useRefreshOrder,
 	useUpdateServiceStatusMutation,
 } from "@/features/orders/hooks/useOrderMutations";
-import { uploadOrderServicePhoto } from "@/features/orders/utils/photo-upload";
+import { orderServicePhotoUploader } from "@/features/orders/utils/photo-upload";
 import { deleteOrderServicePhoto } from "@/lib/api";
 import { formatOrderServiceItemDetails } from "@/lib/order-service-item-details";
 import { orderDetailQueryOptions } from "@/lib/query-options";
@@ -216,9 +216,7 @@ export const OrderServiceDetail = ({
 					onUploaded={refreshOrder}
 					open={isPhotoUploadOpen}
 					title="Add item photo"
-					uploadPhoto={(input) =>
-						uploadOrderServicePhoto(orderId, service.id, input)
-					}
+					uploader={orderServicePhotoUploader(orderId, service.id)}
 				/>
 			</div>
 

--- a/apps/web/src/features/orders/components/photo-lightbox.tsx
+++ b/apps/web/src/features/orders/components/photo-lightbox.tsx
@@ -1,13 +1,6 @@
-import {
-	ArrowLeftIcon,
-	ArrowRightIcon,
-	ImageSquareIcon,
-	XIcon,
-} from "@phosphor-icons/react";
+import { ImageSquareIcon, XIcon } from "@phosphor-icons/react";
 import dayjs from "dayjs";
-import type * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { useEffect, useMemo, useState } from "react";
 import {
 	Dialog,
 	DialogContent,
@@ -65,31 +58,6 @@ export const PhotoLightbox = ({
 	const canNavigate = imageCount > 1;
 	const activeItem = items[activeIndex];
 
-	const showPrevious = useCallback(() => {
-		setActiveIndex((currentIndex) =>
-			currentIndex === 0 ? imageCount - 1 : currentIndex - 1,
-		);
-	}, [imageCount]);
-
-	const showNext = useCallback(() => {
-		setActiveIndex((currentIndex) =>
-			currentIndex === imageCount - 1 ? 0 : currentIndex + 1,
-		);
-	}, [imageCount]);
-
-	const handleKeyDown = (event: React.KeyboardEvent) => {
-		if (!canNavigate) {
-			return;
-		}
-		if (event.key === "ArrowLeft") {
-			event.preventDefault();
-			showPrevious();
-		} else if (event.key === "ArrowRight") {
-			event.preventDefault();
-			showNext();
-		}
-	};
-
 	useEffect(() => {
 		if (open) {
 			setActiveIndex(initialIndex);
@@ -112,7 +80,6 @@ export const PhotoLightbox = ({
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
 				className="inset-0 z-[60] flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden rounded-none border-0 bg-black p-0 text-white ring-0 sm:max-w-none"
-				onKeyDown={handleKeyDown}
 				overlayClassName="z-[60] bg-black"
 				overlayForceRender
 				showCloseButton={false}
@@ -128,7 +95,7 @@ export const PhotoLightbox = ({
 					{activeItem ? (
 						<PhotoStage
 							activeIndex={activeIndex}
-							className="bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))] sm:px-14"
+							className="bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))]"
 							items={items}
 							onIndexChange={setActiveIndex}
 						>
@@ -140,33 +107,6 @@ export const PhotoLightbox = ({
 							>
 								<XIcon className="size-5" aria-hidden="true" />
 							</button>
-
-							{canNavigate ? (
-								<>
-									<Button
-										type="button"
-										variant="outline"
-										size="icon-lg"
-										className="absolute top-1/2 left-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-										onClick={showPrevious}
-										aria-label="Show previous image"
-										icon={
-											<ArrowLeftIcon className="size-5" aria-hidden="true" />
-										}
-									/>
-									<Button
-										type="button"
-										variant="outline"
-										size="icon-lg"
-										className="absolute top-1/2 right-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-										onClick={showNext}
-										aria-label="Show next image"
-										icon={
-											<ArrowRightIcon className="size-5" aria-hidden="true" />
-										}
-									/>
-								</>
-							) : null}
 						</PhotoStage>
 					) : (
 						<div className="relative flex min-h-0 flex-1 items-center justify-center">

--- a/apps/web/src/features/orders/components/photo-lightbox.tsx
+++ b/apps/web/src/features/orders/components/photo-lightbox.tsx
@@ -14,8 +14,38 @@ import {
 	DialogDescription,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import {
+	clampOffset,
+	doubleTapZoom,
+	fittedSize,
+	MIN_SCALE,
+	type Point,
+	panBy,
+	pinchZoom,
+	resetTransform,
+	type Size,
+	toCssTransform,
+	type ZoomTransform,
+} from "@/features/orders/lib/photo-zoom";
 
 const SWIPE_THRESHOLD = 56;
+const DOUBLE_TAP_WINDOW_MS = 350;
+const TAP_SLOP = 24;
+const WHEEL_ZOOM_DIVISOR = 180;
+const WHEEL_COMMIT_DELAY_MS = 120;
+const SUPPRESSED_UA_GESTURES = [
+	"contextmenu",
+	"gesturestart",
+	"gesturechange",
+	"gestureend",
+];
+
+/** The untransformed photo box, measured once when the first finger lands. */
+interface Stage {
+	centreX: number;
+	centreY: number;
+	viewport: Size;
+}
 
 export interface PhotoLightboxItem {
 	alt: string;
@@ -61,6 +91,26 @@ export const PhotoLightbox = ({
 	title = "Attachment Viewer",
 }: PhotoLightboxProps) => {
 	const [activeIndex, setActiveIndex] = useState(initialIndex);
+	const [transform, setTransform] = useState<ZoomTransform>(resetTransform);
+	const transformRef = useRef(transform);
+	const frameRef = useRef(0);
+	// The dialog popup mounts in a later commit than the one that flips `open`, so a ref
+	// read inside an effect is still null and the gesture listeners would never attach —
+	// pinch was dead on every freshly opened lightbox. State makes the node a dependency.
+	const [surfaceNode, setSurfaceNode] = useState<HTMLDivElement | null>(null);
+	const stageRef = useRef<HTMLDivElement>(null);
+	const contentRef = useRef<HTMLDivElement>(null);
+	const naturalRef = useRef<{ id: number | string; size: Size } | null>(null);
+	const pointersRef = useRef(new Map<number, Point>());
+	const gestureRef = useRef({
+		pinchDist: 0,
+		pinchMid: { x: 0, y: 0 } as Point,
+		pinched: false,
+		stage: null as Stage | null,
+		startX: 0,
+		startY: 0,
+	});
+	const lastTapRef = useRef<{ at: number; x: number; y: number } | null>(null);
 	const pointerStateRef = useRef<{
 		deltaX: number;
 		deltaY: number;
@@ -75,33 +125,67 @@ export const PhotoLightbox = ({
 		startY: 0,
 	});
 
-	useEffect(() => {
-		if (open) {
-			setActiveIndex(initialIndex);
-		}
-	}, [open, initialIndex]);
-
 	const imageCount = items.length;
 	const canNavigate = imageCount > 1;
 	const activeItem = items[activeIndex];
+	const activeId = activeItem?.id;
+
+	const commitTransform = useCallback((next: ZoomTransform) => {
+		transformRef.current = next;
+		if (frameRef.current !== 0) {
+			cancelAnimationFrame(frameRef.current);
+			frameRef.current = 0;
+		}
+		// React skips the style write when the string matches its last render, but a pinch
+		// may have already put a different one on the node — without this the photo stays
+		// zoomed while state says fitted, and the next garment opens inside that zoom.
+		if (contentRef.current) {
+			contentRef.current.style.transform = toCssTransform(next);
+		}
+		setTransform(next);
+	}, []);
+
+	// Coalesced into one write per frame: a React render per pointermove drops frames on
+	// the mid-range phones the counter uses.
+	const applyTransform = useCallback((next: ZoomTransform) => {
+		transformRef.current = next;
+		if (frameRef.current !== 0) {
+			return;
+		}
+		frameRef.current = requestAnimationFrame(() => {
+			frameRef.current = 0;
+			if (contentRef.current) {
+				contentRef.current.style.transform = toCssTransform(
+					transformRef.current,
+				);
+			}
+		});
+	}, []);
+
+	const resetZoom = useCallback(() => {
+		commitTransform(resetTransform());
+		lastTapRef.current = null;
+	}, [commitTransform]);
 
 	const showPrevious = useCallback(() => {
 		if (!canNavigate) {
 			return;
 		}
+		resetZoom();
 		setActiveIndex((currentIndex) =>
 			currentIndex === 0 ? imageCount - 1 : currentIndex - 1,
 		);
-	}, [canNavigate, imageCount]);
+	}, [canNavigate, imageCount, resetZoom]);
 
 	const showNext = useCallback(() => {
 		if (!canNavigate) {
 			return;
 		}
+		resetZoom();
 		setActiveIndex((currentIndex) =>
 			currentIndex === imageCount - 1 ? 0 : currentIndex + 1,
 		);
-	}, [canNavigate, imageCount]);
+	}, [canNavigate, imageCount, resetZoom]);
 
 	const handleKeyDown = (event: React.KeyboardEvent) => {
 		if (event.key === "ArrowLeft") {
@@ -113,7 +197,7 @@ export const PhotoLightbox = ({
 		}
 	};
 
-	const resetPointerState = () => {
+	const resetPointerState = useCallback(() => {
 		pointerStateRef.current = {
 			deltaX: 0,
 			deltaY: 0,
@@ -121,56 +205,400 @@ export const PhotoLightbox = ({
 			startX: 0,
 			startY: 0,
 		};
-	};
+	}, []);
 
-	const handlePointerDown: React.PointerEventHandler<HTMLDivElement> = (
+	const handleImageLoad: React.ReactEventHandler<HTMLImageElement> = (
 		event,
 	) => {
-		if (!canNavigate || event.pointerType === "mouse") {
+		const { naturalHeight, naturalWidth } = event.currentTarget;
+		if (activeId === undefined || naturalWidth === 0 || naturalHeight === 0) {
 			return;
 		}
-
-		pointerStateRef.current = {
-			deltaX: 0,
-			deltaY: 0,
-			id: event.pointerId,
-			startX: event.clientX,
-			startY: event.clientY,
+		naturalRef.current = {
+			id: activeId,
+			size: { height: naturalHeight, width: naturalWidth },
 		};
 	};
 
-	const handlePointerMove: React.PointerEventHandler<HTMLDivElement> = (
-		event,
-	) => {
-		if (pointerStateRef.current.id !== event.pointerId) {
+	useEffect(() => {
+		if (open) {
+			setActiveIndex(initialIndex);
+			resetZoom();
+		}
+	}, [open, initialIndex, resetZoom]);
+
+	useEffect(() => {
+		const surface = surfaceNode;
+		if (!(open && surface)) {
 			return;
 		}
 
-		pointerStateRef.current.deltaX =
-			event.clientX - pointerStateRef.current.startX;
-		pointerStateRef.current.deltaY =
-			event.clientY - pointerStateRef.current.startY;
-	};
+		const pointers = pointersRef.current;
+		const gesture = gestureRef.current;
+		// A dialog closed mid-touch can leave a finger behind; a fresh surface starts empty
+		// so the next single tap is never mistaken for a pinch.
+		pointers.clear();
+		gesture.stage = null;
+		gesture.pinched = false;
 
-	const commitSwipe = () => {
-		const { deltaX, deltaY, id } = pointerStateRef.current;
-		if (id === null) {
-			return;
-		}
-
-		if (
-			Math.abs(deltaX) >= SWIPE_THRESHOLD &&
-			Math.abs(deltaX) > Math.abs(deltaY)
-		) {
-			if (deltaX < 0) {
-				showNext();
-			} else {
-				showPrevious();
+		const measureStage = (): Stage | null => {
+			const rect = stageRef.current?.getBoundingClientRect();
+			if (!rect || rect.width === 0 || rect.height === 0) {
+				return null;
 			}
-		}
+			return {
+				centreX: rect.left + rect.width / 2,
+				centreY: rect.top + rect.height / 2,
+				viewport: { height: rect.height, width: rect.width },
+			};
+		};
 
-		resetPointerState();
-	};
+		const photoBox = (stage: Stage) => {
+			const loaded = naturalRef.current;
+			if (!loaded || loaded.id !== activeId) {
+				return null;
+			}
+			const fitted = fittedSize(stage.viewport, loaded.size);
+			return fitted.width > 0 && fitted.height > 0 ? fitted : null;
+		};
+
+		const pinchGeometry = (stage: Stage) => {
+			const [first, second] = [...pointers.values()];
+			if (!(first && second)) {
+				return null;
+			}
+			return {
+				dist: Math.hypot(first.x - second.x, first.y - second.y),
+				mid: {
+					x: (first.x + second.x) / 2 - stage.centreX,
+					y: (first.y + second.y) / 2 - stage.centreY,
+				},
+			};
+		};
+
+		// Every finger added or lifted re-baselines the pinch, otherwise the next frame
+		// computes a huge delta and the photo snaps away from the spot under discussion.
+		const rebasePinch = (stage: Stage | null) => {
+			const geometry = stage ? pinchGeometry(stage) : null;
+			gesture.pinchDist = geometry?.dist ?? 0;
+			gesture.pinchMid = geometry?.mid ?? { x: 0, y: 0 };
+		};
+
+		const handleDown = (event: PointerEvent) => {
+			if ((event.target as Element | null)?.closest("button")) {
+				return;
+			}
+			if (pointers.size === 0) {
+				gesture.stage = measureStage();
+				gesture.pinched = false;
+				gesture.startX = event.clientX;
+				gesture.startY = event.clientY;
+			}
+			const stage = gesture.stage;
+			if (!stage) {
+				return;
+			}
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+			if (pointers.size >= 2) {
+				gesture.pinched = true;
+				lastTapRef.current = null;
+				resetPointerState();
+				rebasePinch(stage);
+				return;
+			}
+			if (transformRef.current.scale > MIN_SCALE) {
+				return;
+			}
+			if (!canNavigate || event.pointerType === "mouse") {
+				return;
+			}
+			pointerStateRef.current = {
+				deltaX: 0,
+				deltaY: 0,
+				id: event.pointerId,
+				startX: event.clientX,
+				startY: event.clientY,
+			};
+		};
+
+		const handlePinchMove = (event: PointerEvent, stage: Stage) => {
+			event.preventDefault();
+			const geometry = pinchGeometry(stage);
+			const fitted = photoBox(stage);
+			if (!(geometry && fitted) || gesture.pinchDist < 1 || geometry.dist < 1) {
+				rebasePinch(stage);
+				return;
+			}
+			const zoomed = pinchZoom(
+				transformRef.current,
+				gesture.pinchMid,
+				geometry.dist / gesture.pinchDist,
+				stage.viewport,
+				fitted,
+			);
+			applyTransform(
+				panBy(
+					zoomed,
+					geometry.mid.x - gesture.pinchMid.x,
+					geometry.mid.y - gesture.pinchMid.y,
+					stage.viewport,
+					fitted,
+				),
+			);
+			gesture.pinchDist = geometry.dist;
+			gesture.pinchMid = geometry.mid;
+		};
+
+		const handleMove = (event: PointerEvent) => {
+			const previous = pointers.get(event.pointerId);
+			const stage = gesture.stage;
+			if (!(previous && stage)) {
+				return;
+			}
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+			if (pointers.size >= 2) {
+				handlePinchMove(event, stage);
+				return;
+			}
+
+			if (transformRef.current.scale > MIN_SCALE) {
+				const fitted = photoBox(stage);
+				if (!fitted) {
+					return;
+				}
+				event.preventDefault();
+				applyTransform(
+					panBy(
+						transformRef.current,
+						event.clientX - previous.x,
+						event.clientY - previous.y,
+						stage.viewport,
+						fitted,
+					),
+				);
+				return;
+			}
+
+			const swipe = pointerStateRef.current;
+			if (swipe.id !== event.pointerId) {
+				return;
+			}
+			swipe.deltaX = event.clientX - swipe.startX;
+			swipe.deltaY = event.clientY - swipe.startY;
+		};
+
+		const commitSwipe = () => {
+			const { deltaX, deltaY, id } = pointerStateRef.current;
+			if (id === null) {
+				return;
+			}
+
+			if (
+				Math.abs(deltaX) >= SWIPE_THRESHOLD &&
+				Math.abs(deltaX) > Math.abs(deltaY)
+			) {
+				if (deltaX < 0) {
+					showNext();
+				} else {
+					showPrevious();
+				}
+			}
+
+			resetPointerState();
+		};
+
+		const handleTap = (event: PointerEvent, stage: Stage | null) => {
+			const travelled = Math.hypot(
+				event.clientX - gesture.startX,
+				event.clientY - gesture.startY,
+			);
+			if (travelled > TAP_SLOP) {
+				lastTapRef.current = null;
+				commitSwipe();
+				return;
+			}
+
+			const at = Date.now();
+			const firstTap = lastTapRef.current;
+			lastTapRef.current = { at, x: event.clientX, y: event.clientY };
+			const isDoubleTap =
+				firstTap !== null &&
+				at - firstTap.at <= DOUBLE_TAP_WINDOW_MS &&
+				Math.hypot(event.clientX - firstTap.x, event.clientY - firstTap.y) <=
+					TAP_SLOP;
+			if (!isDoubleTap) {
+				commitSwipe();
+				return;
+			}
+
+			lastTapRef.current = null;
+			resetPointerState();
+			const fitted = stage ? photoBox(stage) : null;
+			if (!(stage && fitted)) {
+				return;
+			}
+			commitTransform(
+				doubleTapZoom(
+					transformRef.current,
+					{
+						x: event.clientX - stage.centreX,
+						y: event.clientY - stage.centreY,
+					},
+					stage.viewport,
+					fitted,
+				),
+			);
+		};
+
+		const dropPointer = (event: PointerEvent, tapEligible: boolean) => {
+			if (!pointers.delete(event.pointerId)) {
+				return;
+			}
+			const stage = gesture.stage;
+			const pinched = gesture.pinched;
+
+			if (pointers.size >= 2) {
+				rebasePinch(stage);
+				return;
+			}
+			// The finger still down carries on as a pan from its own last position.
+			if (pointers.size === 1) {
+				gesture.pinchDist = 0;
+				return;
+			}
+
+			gesture.stage = null;
+			gesture.pinched = false;
+			gesture.pinchDist = 0;
+			commitTransform(transformRef.current);
+
+			if (!tapEligible || pinched) {
+				lastTapRef.current = null;
+				resetPointerState();
+				return;
+			}
+			handleTap(event, stage);
+		};
+
+		const handleUp = (event: PointerEvent) => dropPointer(event, true);
+		// A stolen touch — Control Centre swipe, incoming call — drops the finger but keeps
+		// the operator's place on the tear.
+		const handleAbort = (event: PointerEvent) => dropPointer(event, false);
+
+		let wheelCommit: ReturnType<typeof setTimeout> | undefined;
+		const handleWheel = (event: WheelEvent) => {
+			if (!event.ctrlKey) {
+				return;
+			}
+			// Trackpad pinch arrives as ctrl+wheel; unprevented it zooms the whole admin.
+			event.preventDefault();
+			const stage = measureStage();
+			const fitted = stage ? photoBox(stage) : null;
+			if (!(stage && fitted)) {
+				return;
+			}
+			applyTransform(
+				pinchZoom(
+					transformRef.current,
+					{
+						x: event.clientX - stage.centreX,
+						y: event.clientY - stage.centreY,
+					},
+					Math.exp(-event.deltaY / WHEEL_ZOOM_DIVISOR),
+					stage.viewport,
+					fitted,
+				),
+			);
+			// A wheel burst has no finger to lift, so nothing else would ever commit it.
+			clearTimeout(wheelCommit);
+			wheelCommit = setTimeout(
+				() => commitTransform(transformRef.current),
+				WHEEL_COMMIT_DELAY_MS,
+			);
+		};
+
+		surface.addEventListener("pointerdown", handleDown, { passive: false });
+		surface.addEventListener("pointermove", handleMove, { passive: false });
+		surface.addEventListener("pointerup", handleUp, { passive: false });
+		surface.addEventListener("pointercancel", handleAbort, { passive: false });
+		surface.addEventListener("lostpointercapture", handleAbort, {
+			passive: false,
+		});
+		surface.addEventListener("wheel", handleWheel, { passive: false });
+
+		return () => {
+			clearTimeout(wheelCommit);
+			surface.removeEventListener("pointerdown", handleDown);
+			surface.removeEventListener("pointermove", handleMove);
+			surface.removeEventListener("pointerup", handleUp);
+			surface.removeEventListener("pointercancel", handleAbort);
+			surface.removeEventListener("lostpointercapture", handleAbort);
+			surface.removeEventListener("wheel", handleWheel);
+			// Re-attaching mid-gesture drops the fingers, so publish whatever the last frame
+			// wrote to the node — otherwise state and the photo disagree from here on.
+			commitTransform(transformRef.current);
+		};
+	}, [
+		activeId,
+		applyTransform,
+		canNavigate,
+		commitTransform,
+		open,
+		resetPointerState,
+		showNext,
+		showPrevious,
+		surfaceNode,
+	]);
+
+	// The browser defaults that fight a pinch on the evidence: iOS Safari page-zooms on any
+	// two-finger touch whatever touch-action says, and a long press pops "Save image" over the
+	// photo. Scoped to this surface so the rest of the admin keeps accessibility zoom.
+	useEffect(() => {
+		if (!(open && surfaceNode)) {
+			return;
+		}
+		const suppress = (event: Event) => event.preventDefault();
+		for (const name of SUPPRESSED_UA_GESTURES) {
+			surfaceNode.addEventListener(name, suppress, { passive: false });
+		}
+		return () => {
+			for (const name of SUPPRESSED_UA_GESTURES) {
+				surfaceNode.removeEventListener(name, suppress);
+			}
+		};
+	}, [open, surfaceNode]);
+
+	// Turning the phone to show the customer resizes the stage under a zoomed photo, and the
+	// offsets it was panned to can now sit entirely outside it — a blank screen mid-dispute.
+	useEffect(() => {
+		if (!surfaceNode) {
+			return;
+		}
+		const observer = new ResizeObserver(() => {
+			const current = transformRef.current;
+			const rect = stageRef.current?.getBoundingClientRect();
+			const loaded = naturalRef.current;
+			if (current.scale === MIN_SCALE || !rect || !loaded) {
+				return;
+			}
+			const viewport = { height: rect.height, width: rect.width };
+			const offset = clampOffset(
+				current.scale,
+				{ x: current.offsetX, y: current.offsetY },
+				viewport,
+				fittedSize(viewport, loaded.size),
+			);
+			commitTransform({
+				offsetX: offset.x,
+				offsetY: offset.y,
+				scale: current.scale,
+			});
+		});
+		observer.observe(surfaceNode);
+		return () => observer.disconnect();
+	}, [commitTransform, surfaceNode]);
 
 	const activeCaption = useMemo(() => {
 		if (!activeItem) {
@@ -195,26 +623,36 @@ export const PhotoLightbox = ({
 			>
 				<DialogTitle className="sr-only">{title}</DialogTitle>
 				<DialogDescription className="sr-only">
-					Browse order attachments and swipe between images.
+					{canNavigate
+						? "Pinch or double-tap to zoom. Swipe or use the arrow keys to move between attachments."
+						: "Pinch or double-tap to zoom."}
 				</DialogDescription>
 
 				<div className="flex min-h-0 flex-1 flex-col bg-black">
 					<div
-						className="relative flex min-h-0 flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))] px-3 sm:px-14 [touch-action:pan-y]"
-						onPointerDown={handlePointerDown}
-						onPointerMove={handlePointerMove}
-						onPointerUp={commitSwipe}
-						onPointerCancel={resetPointerState}
+						ref={setSurfaceNode}
+						className="relative flex min-h-0 flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))] sm:px-14 [touch-action:none]"
 					>
 						{activeItem ? (
-							<img
-								key={activeItem.id}
-								src={activeItem.image_url}
-								alt={activeItem.alt}
-								width={1600}
-								height={1200}
-								className="pointer-events-none max-h-full w-auto max-w-full object-contain select-none"
-							/>
+							<div
+								ref={stageRef}
+								className="relative h-full w-full overflow-hidden"
+							>
+								<div
+									ref={contentRef}
+									className="h-full w-full"
+									style={{ transform: toCssTransform(transform) }}
+								>
+									<img
+										key={activeItem.id}
+										src={activeItem.image_url}
+										alt={activeItem.alt}
+										draggable={false}
+										onLoad={handleImageLoad}
+										className="pointer-events-none h-full w-full object-contain select-none [-webkit-touch-callout:none]"
+									/>
+								</div>
+							</div>
 						) : (
 							<div className="grid place-items-center gap-2 px-6 py-12 text-center text-sm text-white/72">
 								<ImageSquareIcon className="size-6" aria-hidden="true" />
@@ -238,7 +676,6 @@ export const PhotoLightbox = ({
 									variant="outline"
 									size="icon-lg"
 									className="absolute top-1/2 left-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-									onPointerDown={(event) => event.stopPropagation()}
 									onClick={showPrevious}
 									aria-label="Show previous image"
 									icon={<ArrowLeftIcon className="size-5" aria-hidden="true" />}
@@ -248,7 +685,6 @@ export const PhotoLightbox = ({
 									variant="outline"
 									size="icon-lg"
 									className="absolute top-1/2 right-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-									onPointerDown={(event) => event.stopPropagation()}
 									onClick={showNext}
 									aria-label="Show next image"
 									icon={

--- a/apps/web/src/features/orders/components/photo-lightbox.tsx
+++ b/apps/web/src/features/orders/components/photo-lightbox.tsx
@@ -6,7 +6,7 @@ import {
 } from "@phosphor-icons/react";
 import dayjs from "dayjs";
 import type * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -14,38 +14,7 @@ import {
 	DialogDescription,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import {
-	clampOffset,
-	doubleTapZoom,
-	fittedSize,
-	MIN_SCALE,
-	type Point,
-	panBy,
-	pinchZoom,
-	resetTransform,
-	type Size,
-	toCssTransform,
-	type ZoomTransform,
-} from "@/features/orders/lib/photo-zoom";
-
-const SWIPE_THRESHOLD = 56;
-const DOUBLE_TAP_WINDOW_MS = 350;
-const TAP_SLOP = 24;
-const WHEEL_ZOOM_DIVISOR = 180;
-const WHEEL_COMMIT_DELAY_MS = 120;
-const SUPPRESSED_UA_GESTURES = [
-	"contextmenu",
-	"gesturestart",
-	"gesturechange",
-	"gestureend",
-];
-
-/** The untransformed photo box, measured once when the first finger lands. */
-interface Stage {
-	centreX: number;
-	centreY: number;
-	viewport: Size;
-}
+import { PhotoStage } from "@/features/orders/components/photo-stage";
 
 export interface PhotoLightboxItem {
 	alt: string;
@@ -91,103 +60,27 @@ export const PhotoLightbox = ({
 	title = "Attachment Viewer",
 }: PhotoLightboxProps) => {
 	const [activeIndex, setActiveIndex] = useState(initialIndex);
-	const [transform, setTransform] = useState<ZoomTransform>(resetTransform);
-	const transformRef = useRef(transform);
-	const frameRef = useRef(0);
-	// The dialog popup mounts in a later commit than the one that flips `open`, so a ref
-	// read inside an effect is still null and the gesture listeners would never attach —
-	// pinch was dead on every freshly opened lightbox. State makes the node a dependency.
-	const [surfaceNode, setSurfaceNode] = useState<HTMLDivElement | null>(null);
-	const stageRef = useRef<HTMLDivElement>(null);
-	const contentRef = useRef<HTMLDivElement>(null);
-	const naturalRef = useRef<{ id: number | string; size: Size } | null>(null);
-	const pointersRef = useRef(new Map<number, Point>());
-	const gestureRef = useRef({
-		pinchDist: 0,
-		pinchMid: { x: 0, y: 0 } as Point,
-		pinched: false,
-		stage: null as Stage | null,
-		startX: 0,
-		startY: 0,
-	});
-	const lastTapRef = useRef<{ at: number; x: number; y: number } | null>(null);
-	const pointerStateRef = useRef<{
-		deltaX: number;
-		deltaY: number;
-		id: number | null;
-		startX: number;
-		startY: number;
-	}>({
-		deltaX: 0,
-		deltaY: 0,
-		id: null,
-		startX: 0,
-		startY: 0,
-	});
 
 	const imageCount = items.length;
 	const canNavigate = imageCount > 1;
 	const activeItem = items[activeIndex];
-	const activeId = activeItem?.id;
-
-	const commitTransform = useCallback((next: ZoomTransform) => {
-		transformRef.current = next;
-		if (frameRef.current !== 0) {
-			cancelAnimationFrame(frameRef.current);
-			frameRef.current = 0;
-		}
-		// React skips the style write when the string matches its last render, but a pinch
-		// may have already put a different one on the node — without this the photo stays
-		// zoomed while state says fitted, and the next garment opens inside that zoom.
-		if (contentRef.current) {
-			contentRef.current.style.transform = toCssTransform(next);
-		}
-		setTransform(next);
-	}, []);
-
-	// Coalesced into one write per frame: a React render per pointermove drops frames on
-	// the mid-range phones the counter uses.
-	const applyTransform = useCallback((next: ZoomTransform) => {
-		transformRef.current = next;
-		if (frameRef.current !== 0) {
-			return;
-		}
-		frameRef.current = requestAnimationFrame(() => {
-			frameRef.current = 0;
-			if (contentRef.current) {
-				contentRef.current.style.transform = toCssTransform(
-					transformRef.current,
-				);
-			}
-		});
-	}, []);
-
-	const resetZoom = useCallback(() => {
-		commitTransform(resetTransform());
-		lastTapRef.current = null;
-	}, [commitTransform]);
 
 	const showPrevious = useCallback(() => {
-		if (!canNavigate) {
-			return;
-		}
-		resetZoom();
 		setActiveIndex((currentIndex) =>
 			currentIndex === 0 ? imageCount - 1 : currentIndex - 1,
 		);
-	}, [canNavigate, imageCount, resetZoom]);
+	}, [imageCount]);
 
 	const showNext = useCallback(() => {
-		if (!canNavigate) {
-			return;
-		}
-		resetZoom();
 		setActiveIndex((currentIndex) =>
 			currentIndex === imageCount - 1 ? 0 : currentIndex + 1,
 		);
-	}, [canNavigate, imageCount, resetZoom]);
+	}, [imageCount]);
 
 	const handleKeyDown = (event: React.KeyboardEvent) => {
+		if (!canNavigate) {
+			return;
+		}
 		if (event.key === "ArrowLeft") {
 			event.preventDefault();
 			showPrevious();
@@ -197,408 +90,11 @@ export const PhotoLightbox = ({
 		}
 	};
 
-	const resetPointerState = useCallback(() => {
-		pointerStateRef.current = {
-			deltaX: 0,
-			deltaY: 0,
-			id: null,
-			startX: 0,
-			startY: 0,
-		};
-	}, []);
-
-	const handleImageLoad: React.ReactEventHandler<HTMLImageElement> = (
-		event,
-	) => {
-		const { naturalHeight, naturalWidth } = event.currentTarget;
-		if (activeId === undefined || naturalWidth === 0 || naturalHeight === 0) {
-			return;
-		}
-		naturalRef.current = {
-			id: activeId,
-			size: { height: naturalHeight, width: naturalWidth },
-		};
-	};
-
 	useEffect(() => {
 		if (open) {
 			setActiveIndex(initialIndex);
-			resetZoom();
 		}
-	}, [open, initialIndex, resetZoom]);
-
-	useEffect(() => {
-		const surface = surfaceNode;
-		if (!(open && surface)) {
-			return;
-		}
-
-		const pointers = pointersRef.current;
-		const gesture = gestureRef.current;
-		// A dialog closed mid-touch can leave a finger behind; a fresh surface starts empty
-		// so the next single tap is never mistaken for a pinch.
-		pointers.clear();
-		gesture.stage = null;
-		gesture.pinched = false;
-
-		const measureStage = (): Stage | null => {
-			const rect = stageRef.current?.getBoundingClientRect();
-			if (!rect || rect.width === 0 || rect.height === 0) {
-				return null;
-			}
-			return {
-				centreX: rect.left + rect.width / 2,
-				centreY: rect.top + rect.height / 2,
-				viewport: { height: rect.height, width: rect.width },
-			};
-		};
-
-		const photoBox = (stage: Stage) => {
-			const loaded = naturalRef.current;
-			if (!loaded || loaded.id !== activeId) {
-				return null;
-			}
-			const fitted = fittedSize(stage.viewport, loaded.size);
-			return fitted.width > 0 && fitted.height > 0 ? fitted : null;
-		};
-
-		const pinchGeometry = (stage: Stage) => {
-			const [first, second] = [...pointers.values()];
-			if (!(first && second)) {
-				return null;
-			}
-			return {
-				dist: Math.hypot(first.x - second.x, first.y - second.y),
-				mid: {
-					x: (first.x + second.x) / 2 - stage.centreX,
-					y: (first.y + second.y) / 2 - stage.centreY,
-				},
-			};
-		};
-
-		// Every finger added or lifted re-baselines the pinch, otherwise the next frame
-		// computes a huge delta and the photo snaps away from the spot under discussion.
-		const rebasePinch = (stage: Stage | null) => {
-			const geometry = stage ? pinchGeometry(stage) : null;
-			gesture.pinchDist = geometry?.dist ?? 0;
-			gesture.pinchMid = geometry?.mid ?? { x: 0, y: 0 };
-		};
-
-		const handleDown = (event: PointerEvent) => {
-			if ((event.target as Element | null)?.closest("button")) {
-				return;
-			}
-			if (pointers.size === 0) {
-				gesture.stage = measureStage();
-				gesture.pinched = false;
-				gesture.startX = event.clientX;
-				gesture.startY = event.clientY;
-			}
-			const stage = gesture.stage;
-			if (!stage) {
-				return;
-			}
-			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-
-			if (pointers.size >= 2) {
-				gesture.pinched = true;
-				lastTapRef.current = null;
-				resetPointerState();
-				rebasePinch(stage);
-				return;
-			}
-			if (transformRef.current.scale > MIN_SCALE) {
-				return;
-			}
-			if (!canNavigate || event.pointerType === "mouse") {
-				return;
-			}
-			pointerStateRef.current = {
-				deltaX: 0,
-				deltaY: 0,
-				id: event.pointerId,
-				startX: event.clientX,
-				startY: event.clientY,
-			};
-		};
-
-		const handlePinchMove = (event: PointerEvent, stage: Stage) => {
-			event.preventDefault();
-			const geometry = pinchGeometry(stage);
-			const fitted = photoBox(stage);
-			if (!(geometry && fitted) || gesture.pinchDist < 1 || geometry.dist < 1) {
-				rebasePinch(stage);
-				return;
-			}
-			const zoomed = pinchZoom(
-				transformRef.current,
-				gesture.pinchMid,
-				geometry.dist / gesture.pinchDist,
-				stage.viewport,
-				fitted,
-			);
-			applyTransform(
-				panBy(
-					zoomed,
-					geometry.mid.x - gesture.pinchMid.x,
-					geometry.mid.y - gesture.pinchMid.y,
-					stage.viewport,
-					fitted,
-				),
-			);
-			gesture.pinchDist = geometry.dist;
-			gesture.pinchMid = geometry.mid;
-		};
-
-		const handleMove = (event: PointerEvent) => {
-			const previous = pointers.get(event.pointerId);
-			const stage = gesture.stage;
-			if (!(previous && stage)) {
-				return;
-			}
-			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-
-			if (pointers.size >= 2) {
-				handlePinchMove(event, stage);
-				return;
-			}
-
-			if (transformRef.current.scale > MIN_SCALE) {
-				const fitted = photoBox(stage);
-				if (!fitted) {
-					return;
-				}
-				event.preventDefault();
-				applyTransform(
-					panBy(
-						transformRef.current,
-						event.clientX - previous.x,
-						event.clientY - previous.y,
-						stage.viewport,
-						fitted,
-					),
-				);
-				return;
-			}
-
-			const swipe = pointerStateRef.current;
-			if (swipe.id !== event.pointerId) {
-				return;
-			}
-			swipe.deltaX = event.clientX - swipe.startX;
-			swipe.deltaY = event.clientY - swipe.startY;
-		};
-
-		const commitSwipe = () => {
-			const { deltaX, deltaY, id } = pointerStateRef.current;
-			if (id === null) {
-				return;
-			}
-
-			if (
-				Math.abs(deltaX) >= SWIPE_THRESHOLD &&
-				Math.abs(deltaX) > Math.abs(deltaY)
-			) {
-				if (deltaX < 0) {
-					showNext();
-				} else {
-					showPrevious();
-				}
-			}
-
-			resetPointerState();
-		};
-
-		const handleTap = (event: PointerEvent, stage: Stage | null) => {
-			const travelled = Math.hypot(
-				event.clientX - gesture.startX,
-				event.clientY - gesture.startY,
-			);
-			if (travelled > TAP_SLOP) {
-				lastTapRef.current = null;
-				commitSwipe();
-				return;
-			}
-
-			const at = Date.now();
-			const firstTap = lastTapRef.current;
-			lastTapRef.current = { at, x: event.clientX, y: event.clientY };
-			const isDoubleTap =
-				firstTap !== null &&
-				at - firstTap.at <= DOUBLE_TAP_WINDOW_MS &&
-				Math.hypot(event.clientX - firstTap.x, event.clientY - firstTap.y) <=
-					TAP_SLOP;
-			if (!isDoubleTap) {
-				commitSwipe();
-				return;
-			}
-
-			lastTapRef.current = null;
-			resetPointerState();
-			const fitted = stage ? photoBox(stage) : null;
-			if (!(stage && fitted)) {
-				return;
-			}
-			commitTransform(
-				doubleTapZoom(
-					transformRef.current,
-					{
-						x: event.clientX - stage.centreX,
-						y: event.clientY - stage.centreY,
-					},
-					stage.viewport,
-					fitted,
-				),
-			);
-		};
-
-		const dropPointer = (event: PointerEvent, tapEligible: boolean) => {
-			if (!pointers.delete(event.pointerId)) {
-				return;
-			}
-			const stage = gesture.stage;
-			const pinched = gesture.pinched;
-
-			if (pointers.size >= 2) {
-				rebasePinch(stage);
-				return;
-			}
-			// The finger still down carries on as a pan from its own last position.
-			if (pointers.size === 1) {
-				gesture.pinchDist = 0;
-				return;
-			}
-
-			gesture.stage = null;
-			gesture.pinched = false;
-			gesture.pinchDist = 0;
-			commitTransform(transformRef.current);
-
-			if (!tapEligible || pinched) {
-				lastTapRef.current = null;
-				resetPointerState();
-				return;
-			}
-			handleTap(event, stage);
-		};
-
-		const handleUp = (event: PointerEvent) => dropPointer(event, true);
-		// A stolen touch — Control Centre swipe, incoming call — drops the finger but keeps
-		// the operator's place on the tear.
-		const handleAbort = (event: PointerEvent) => dropPointer(event, false);
-
-		let wheelCommit: ReturnType<typeof setTimeout> | undefined;
-		const handleWheel = (event: WheelEvent) => {
-			if (!event.ctrlKey) {
-				return;
-			}
-			// Trackpad pinch arrives as ctrl+wheel; unprevented it zooms the whole admin.
-			event.preventDefault();
-			const stage = measureStage();
-			const fitted = stage ? photoBox(stage) : null;
-			if (!(stage && fitted)) {
-				return;
-			}
-			applyTransform(
-				pinchZoom(
-					transformRef.current,
-					{
-						x: event.clientX - stage.centreX,
-						y: event.clientY - stage.centreY,
-					},
-					Math.exp(-event.deltaY / WHEEL_ZOOM_DIVISOR),
-					stage.viewport,
-					fitted,
-				),
-			);
-			// A wheel burst has no finger to lift, so nothing else would ever commit it.
-			clearTimeout(wheelCommit);
-			wheelCommit = setTimeout(
-				() => commitTransform(transformRef.current),
-				WHEEL_COMMIT_DELAY_MS,
-			);
-		};
-
-		surface.addEventListener("pointerdown", handleDown, { passive: false });
-		surface.addEventListener("pointermove", handleMove, { passive: false });
-		surface.addEventListener("pointerup", handleUp, { passive: false });
-		surface.addEventListener("pointercancel", handleAbort, { passive: false });
-		surface.addEventListener("lostpointercapture", handleAbort, {
-			passive: false,
-		});
-		surface.addEventListener("wheel", handleWheel, { passive: false });
-
-		return () => {
-			clearTimeout(wheelCommit);
-			surface.removeEventListener("pointerdown", handleDown);
-			surface.removeEventListener("pointermove", handleMove);
-			surface.removeEventListener("pointerup", handleUp);
-			surface.removeEventListener("pointercancel", handleAbort);
-			surface.removeEventListener("lostpointercapture", handleAbort);
-			surface.removeEventListener("wheel", handleWheel);
-			// Re-attaching mid-gesture drops the fingers, so publish whatever the last frame
-			// wrote to the node — otherwise state and the photo disagree from here on.
-			commitTransform(transformRef.current);
-		};
-	}, [
-		activeId,
-		applyTransform,
-		canNavigate,
-		commitTransform,
-		open,
-		resetPointerState,
-		showNext,
-		showPrevious,
-		surfaceNode,
-	]);
-
-	// The browser defaults that fight a pinch on the evidence: iOS Safari page-zooms on any
-	// two-finger touch whatever touch-action says, and a long press pops "Save image" over the
-	// photo. Scoped to this surface so the rest of the admin keeps accessibility zoom.
-	useEffect(() => {
-		if (!(open && surfaceNode)) {
-			return;
-		}
-		const suppress = (event: Event) => event.preventDefault();
-		for (const name of SUPPRESSED_UA_GESTURES) {
-			surfaceNode.addEventListener(name, suppress, { passive: false });
-		}
-		return () => {
-			for (const name of SUPPRESSED_UA_GESTURES) {
-				surfaceNode.removeEventListener(name, suppress);
-			}
-		};
-	}, [open, surfaceNode]);
-
-	// Turning the phone to show the customer resizes the stage under a zoomed photo, and the
-	// offsets it was panned to can now sit entirely outside it — a blank screen mid-dispute.
-	useEffect(() => {
-		if (!surfaceNode) {
-			return;
-		}
-		const observer = new ResizeObserver(() => {
-			const current = transformRef.current;
-			const rect = stageRef.current?.getBoundingClientRect();
-			const loaded = naturalRef.current;
-			if (current.scale === MIN_SCALE || !rect || !loaded) {
-				return;
-			}
-			const viewport = { height: rect.height, width: rect.width };
-			const offset = clampOffset(
-				current.scale,
-				{ x: current.offsetX, y: current.offsetY },
-				viewport,
-				fittedSize(viewport, loaded.size),
-			);
-			commitTransform({
-				offsetX: offset.x,
-				offsetY: offset.y,
-				scale: current.scale,
-			});
-		});
-		observer.observe(surfaceNode);
-		return () => observer.disconnect();
-	}, [commitTransform, surfaceNode]);
+	}, [open, initialIndex]);
 
 	const activeCaption = useMemo(() => {
 		if (!activeItem) {
@@ -629,71 +125,57 @@ export const PhotoLightbox = ({
 				</DialogDescription>
 
 				<div className="flex min-h-0 flex-1 flex-col bg-black">
-					<div
-						ref={setSurfaceNode}
-						className="relative flex min-h-0 flex-1 items-center justify-center bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))] sm:px-14 [touch-action:none]"
-					>
-						{activeItem ? (
-							<div
-								ref={stageRef}
-								className="relative h-full w-full overflow-hidden"
+					{activeItem ? (
+						<PhotoStage
+							activeIndex={activeIndex}
+							className="bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_52%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))] sm:px-14"
+							items={items}
+							onIndexChange={setActiveIndex}
+						>
+							<button
+								aria-label="Close"
+								className="absolute top-[calc(env(safe-area-inset-top)_+_1rem)] right-4 z-10 grid size-9 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+								onClick={() => onOpenChange(false)}
+								type="button"
 							>
-								<div
-									ref={contentRef}
-									className="h-full w-full"
-									style={{ transform: toCssTransform(transform) }}
-								>
-									<img
-										key={activeItem.id}
-										src={activeItem.image_url}
-										alt={activeItem.alt}
-										draggable={false}
-										onLoad={handleImageLoad}
-										className="pointer-events-none h-full w-full object-contain select-none [-webkit-touch-callout:none]"
+								<XIcon className="size-5" aria-hidden="true" />
+							</button>
+
+							{canNavigate ? (
+								<>
+									<Button
+										type="button"
+										variant="outline"
+										size="icon-lg"
+										className="absolute top-1/2 left-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
+										onClick={showPrevious}
+										aria-label="Show previous image"
+										icon={
+											<ArrowLeftIcon className="size-5" aria-hidden="true" />
+										}
 									/>
-								</div>
-							</div>
-						) : (
+									<Button
+										type="button"
+										variant="outline"
+										size="icon-lg"
+										className="absolute top-1/2 right-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
+										onClick={showNext}
+										aria-label="Show next image"
+										icon={
+											<ArrowRightIcon className="size-5" aria-hidden="true" />
+										}
+									/>
+								</>
+							) : null}
+						</PhotoStage>
+					) : (
+						<div className="relative flex min-h-0 flex-1 items-center justify-center">
 							<div className="grid place-items-center gap-2 px-6 py-12 text-center text-sm text-white/72">
 								<ImageSquareIcon className="size-6" aria-hidden="true" />
 								<p>No image selected.</p>
 							</div>
-						)}
-
-						<button
-							aria-label="Close"
-							className="absolute top-[calc(env(safe-area-inset-top)_+_1rem)] right-4 z-10 grid size-9 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
-							onClick={() => onOpenChange(false)}
-							type="button"
-						>
-							<XIcon className="size-5" aria-hidden="true" />
-						</button>
-
-						{canNavigate ? (
-							<>
-								<Button
-									type="button"
-									variant="outline"
-									size="icon-lg"
-									className="absolute top-1/2 left-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-									onClick={showPrevious}
-									aria-label="Show previous image"
-									icon={<ArrowLeftIcon className="size-5" aria-hidden="true" />}
-								/>
-								<Button
-									type="button"
-									variant="outline"
-									size="icon-lg"
-									className="absolute top-1/2 right-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
-									onClick={showNext}
-									aria-label="Show next image"
-									icon={
-										<ArrowRightIcon className="size-5" aria-hidden="true" />
-									}
-								/>
-							</>
-						) : null}
-					</div>
+						</div>
+					)}
 
 					<div className="grid gap-2 border-t border-white/10 bg-zinc-950 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom)_+_0.75rem)] text-white sm:grid-cols-[1fr_auto] sm:items-end">
 						<div className="grid gap-1">

--- a/apps/web/src/features/orders/components/photo-stage.tsx
+++ b/apps/web/src/features/orders/components/photo-stage.tsx
@@ -1,0 +1,591 @@
+import type * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	clampOffset,
+	doubleTapZoom,
+	fittedSize,
+	MIN_SCALE,
+	type Point,
+	panBy,
+	pinchZoom,
+	resetTransform,
+	type Size,
+	toCssTransform,
+	type ZoomTransform,
+} from "@/features/orders/lib/photo-zoom";
+import { cn } from "@/lib/utils";
+
+const SWIPE_THRESHOLD = 56;
+const DOUBLE_TAP_WINDOW_MS = 350;
+const TAP_SLOP = 24;
+const WHEEL_ZOOM_DIVISOR = 180;
+const WHEEL_COMMIT_DELAY_MS = 120;
+const SUPPRESSED_UA_GESTURES = [
+	"contextmenu",
+	"gesturestart",
+	"gesturechange",
+	"gestureend",
+];
+
+/** The untransformed photo box, measured once when the first finger lands. */
+interface Stage {
+	centreX: number;
+	centreY: number;
+	viewport: Size;
+}
+
+export interface PhotoStageItem {
+	alt: string;
+	id: number | string;
+	image_url: string;
+}
+
+interface PhotoStageProps {
+	activeIndex: number;
+	/**
+	 * Overlay chrome, absolutely positioned inside the gesture surface. Anything
+	 * interactive here must be a real `<button>` — that is what the surface tests for
+	 * before claiming a touch as a gesture.
+	 */
+	children?: React.ReactNode;
+	className?: string;
+	items: PhotoStageItem[];
+	onIndexChange: (index: number) => void;
+}
+
+/**
+ * The photo surface an operator argues over with a customer: pinch or double-tap to put
+ * a torn thread under a finger, drag to move around it, swipe to the next shot. Shared
+ * by the saved-photo lightbox and the review step of the capture dialog so a shot behaves
+ * the same before and after it is uploaded.
+ */
+export const PhotoStage = ({
+	activeIndex,
+	children,
+	className,
+	items,
+	onIndexChange,
+}: PhotoStageProps) => {
+	const [transform, setTransform] = useState<ZoomTransform>(resetTransform);
+	const transformRef = useRef(transform);
+	const frameRef = useRef(0);
+	// The dialog popup mounts in a later commit than the one that flips `open`, so a ref
+	// read inside an effect is still null and the gesture listeners would never attach —
+	// pinch was dead on every freshly opened lightbox. State makes the node a dependency.
+	const [surfaceNode, setSurfaceNode] = useState<HTMLDivElement | null>(null);
+	const stageRef = useRef<HTMLDivElement>(null);
+	const contentRef = useRef<HTMLDivElement>(null);
+	const naturalRef = useRef<{ id: number | string; size: Size } | null>(null);
+	const pointersRef = useRef(new Map<number, Point>());
+	const gestureRef = useRef({
+		pinchDist: 0,
+		pinchMid: { x: 0, y: 0 } as Point,
+		pinched: false,
+		stage: null as Stage | null,
+		startX: 0,
+		startY: 0,
+	});
+	const lastTapRef = useRef<{ at: number; x: number; y: number } | null>(null);
+	const pointerStateRef = useRef<{
+		deltaX: number;
+		deltaY: number;
+		id: number | null;
+		startX: number;
+		startY: number;
+	}>({
+		deltaX: 0,
+		deltaY: 0,
+		id: null,
+		startX: 0,
+		startY: 0,
+	});
+
+	const imageCount = items.length;
+	const canNavigate = imageCount > 1;
+	const activeItem = items[activeIndex];
+	const activeId = activeItem?.id;
+
+	const commitTransform = useCallback((next: ZoomTransform) => {
+		transformRef.current = next;
+		if (frameRef.current !== 0) {
+			cancelAnimationFrame(frameRef.current);
+			frameRef.current = 0;
+		}
+		// React skips the style write when the string matches its last render, but a pinch
+		// may have already put a different one on the node — without this the photo stays
+		// zoomed while state says fitted, and the next garment opens inside that zoom.
+		if (contentRef.current) {
+			contentRef.current.style.transform = toCssTransform(next);
+		}
+		setTransform(next);
+	}, []);
+
+	// Coalesced into one write per frame: a React render per pointermove drops frames on
+	// the mid-range phones the counter uses.
+	const applyTransform = useCallback((next: ZoomTransform) => {
+		transformRef.current = next;
+		if (frameRef.current !== 0) {
+			return;
+		}
+		frameRef.current = requestAnimationFrame(() => {
+			frameRef.current = 0;
+			if (contentRef.current) {
+				contentRef.current.style.transform = toCssTransform(
+					transformRef.current,
+				);
+			}
+		});
+	}, []);
+
+	// Every route into another photo — swipe, arrow key, desktop arrow, last-shot square — has
+	// to drop the previous zoom, or the next garment opens inside it. Adjusted during render
+	// rather than from an effect so the fitted photo is what first paints. A wheel zoom can
+	// still leave one uncommitted frame on the node, which its own pending commit flushes.
+	const [zoomedIndex, setZoomedIndex] = useState(activeIndex);
+	if (zoomedIndex !== activeIndex) {
+		setZoomedIndex(activeIndex);
+		transformRef.current = resetTransform();
+		setTransform(transformRef.current);
+		lastTapRef.current = null;
+	}
+
+	const showPrevious = () => {
+		if (!canNavigate) {
+			return;
+		}
+		onIndexChange(activeIndex === 0 ? imageCount - 1 : activeIndex - 1);
+	};
+
+	const showNext = () => {
+		if (!canNavigate) {
+			return;
+		}
+		onIndexChange(activeIndex === imageCount - 1 ? 0 : activeIndex + 1);
+	};
+
+	// A swipe resolves on pointerup, long after render, so the listeners read the current
+	// photo and navigation from here instead of taking them as effect dependencies. As deps
+	// they tore down and re-attached all six listeners on every photo change — mid-gesture,
+	// on the surface the operator still had fingers on.
+	const latestRef = useRef({ activeId, canNavigate, showNext, showPrevious });
+	useEffect(() => {
+		latestRef.current = { activeId, canNavigate, showNext, showPrevious };
+	});
+
+	const resetPointerState = useCallback(() => {
+		pointerStateRef.current = {
+			deltaX: 0,
+			deltaY: 0,
+			id: null,
+			startX: 0,
+			startY: 0,
+		};
+	}, []);
+
+	const handleImageLoad: React.ReactEventHandler<HTMLImageElement> = (
+		event,
+	) => {
+		const { naturalHeight, naturalWidth } = event.currentTarget;
+		if (activeId === undefined || naturalWidth === 0 || naturalHeight === 0) {
+			return;
+		}
+		naturalRef.current = {
+			id: activeId,
+			size: { height: naturalHeight, width: naturalWidth },
+		};
+	};
+
+	useEffect(() => {
+		const surface = surfaceNode;
+		if (!surface) {
+			return;
+		}
+
+		const pointers = pointersRef.current;
+		const gesture = gestureRef.current;
+		// A dialog closed mid-touch can leave a finger behind; a fresh surface starts empty
+		// so the next single tap is never mistaken for a pinch.
+		pointers.clear();
+		gesture.stage = null;
+		gesture.pinched = false;
+
+		const measureStage = (): Stage | null => {
+			const rect = stageRef.current?.getBoundingClientRect();
+			if (!rect || rect.width === 0 || rect.height === 0) {
+				return null;
+			}
+			return {
+				centreX: rect.left + rect.width / 2,
+				centreY: rect.top + rect.height / 2,
+				viewport: { height: rect.height, width: rect.width },
+			};
+		};
+
+		const photoBox = (stage: Stage) => {
+			const loaded = naturalRef.current;
+			if (!loaded || loaded.id !== latestRef.current.activeId) {
+				return null;
+			}
+			const fitted = fittedSize(stage.viewport, loaded.size);
+			return fitted.width > 0 && fitted.height > 0 ? fitted : null;
+		};
+
+		const pinchGeometry = (stage: Stage) => {
+			const [first, second] = [...pointers.values()];
+			if (!(first && second)) {
+				return null;
+			}
+			return {
+				dist: Math.hypot(first.x - second.x, first.y - second.y),
+				mid: {
+					x: (first.x + second.x) / 2 - stage.centreX,
+					y: (first.y + second.y) / 2 - stage.centreY,
+				},
+			};
+		};
+
+		// Every finger added or lifted re-baselines the pinch, otherwise the next frame
+		// computes a huge delta and the photo snaps away from the spot under discussion.
+		const rebasePinch = (stage: Stage | null) => {
+			const geometry = stage ? pinchGeometry(stage) : null;
+			gesture.pinchDist = geometry?.dist ?? 0;
+			gesture.pinchMid = geometry?.mid ?? { x: 0, y: 0 };
+		};
+
+		const handleDown = (event: PointerEvent) => {
+			if ((event.target as Element | null)?.closest("button")) {
+				return;
+			}
+			if (pointers.size === 0) {
+				gesture.stage = measureStage();
+				gesture.pinched = false;
+				gesture.startX = event.clientX;
+				gesture.startY = event.clientY;
+			}
+			const stage = gesture.stage;
+			if (!stage) {
+				return;
+			}
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+			if (pointers.size >= 2) {
+				gesture.pinched = true;
+				lastTapRef.current = null;
+				resetPointerState();
+				rebasePinch(stage);
+				return;
+			}
+			if (transformRef.current.scale > MIN_SCALE) {
+				return;
+			}
+			if (!latestRef.current.canNavigate || event.pointerType === "mouse") {
+				return;
+			}
+			pointerStateRef.current = {
+				deltaX: 0,
+				deltaY: 0,
+				id: event.pointerId,
+				startX: event.clientX,
+				startY: event.clientY,
+			};
+		};
+
+		const handlePinchMove = (event: PointerEvent, stage: Stage) => {
+			event.preventDefault();
+			const geometry = pinchGeometry(stage);
+			const fitted = photoBox(stage);
+			if (!(geometry && fitted) || gesture.pinchDist < 1 || geometry.dist < 1) {
+				rebasePinch(stage);
+				return;
+			}
+			const zoomed = pinchZoom(
+				transformRef.current,
+				gesture.pinchMid,
+				geometry.dist / gesture.pinchDist,
+				stage.viewport,
+				fitted,
+			);
+			applyTransform(
+				panBy(
+					zoomed,
+					geometry.mid.x - gesture.pinchMid.x,
+					geometry.mid.y - gesture.pinchMid.y,
+					stage.viewport,
+					fitted,
+				),
+			);
+			gesture.pinchDist = geometry.dist;
+			gesture.pinchMid = geometry.mid;
+		};
+
+		const handleMove = (event: PointerEvent) => {
+			const previous = pointers.get(event.pointerId);
+			const stage = gesture.stage;
+			if (!(previous && stage)) {
+				return;
+			}
+			pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+			if (pointers.size >= 2) {
+				handlePinchMove(event, stage);
+				return;
+			}
+
+			if (transformRef.current.scale > MIN_SCALE) {
+				const fitted = photoBox(stage);
+				if (!fitted) {
+					return;
+				}
+				event.preventDefault();
+				applyTransform(
+					panBy(
+						transformRef.current,
+						event.clientX - previous.x,
+						event.clientY - previous.y,
+						stage.viewport,
+						fitted,
+					),
+				);
+				return;
+			}
+
+			const swipe = pointerStateRef.current;
+			if (swipe.id !== event.pointerId) {
+				return;
+			}
+			swipe.deltaX = event.clientX - swipe.startX;
+			swipe.deltaY = event.clientY - swipe.startY;
+		};
+
+		const commitSwipe = () => {
+			const { deltaX, deltaY, id } = pointerStateRef.current;
+			if (id === null) {
+				return;
+			}
+
+			if (
+				Math.abs(deltaX) >= SWIPE_THRESHOLD &&
+				Math.abs(deltaX) > Math.abs(deltaY)
+			) {
+				if (deltaX < 0) {
+					latestRef.current.showNext();
+				} else {
+					latestRef.current.showPrevious();
+				}
+			}
+
+			resetPointerState();
+		};
+
+		const handleTap = (event: PointerEvent, stage: Stage | null) => {
+			const travelled = Math.hypot(
+				event.clientX - gesture.startX,
+				event.clientY - gesture.startY,
+			);
+			if (travelled > TAP_SLOP) {
+				lastTapRef.current = null;
+				commitSwipe();
+				return;
+			}
+
+			const at = Date.now();
+			const firstTap = lastTapRef.current;
+			lastTapRef.current = { at, x: event.clientX, y: event.clientY };
+			const isDoubleTap =
+				firstTap !== null &&
+				at - firstTap.at <= DOUBLE_TAP_WINDOW_MS &&
+				Math.hypot(event.clientX - firstTap.x, event.clientY - firstTap.y) <=
+					TAP_SLOP;
+			if (!isDoubleTap) {
+				commitSwipe();
+				return;
+			}
+
+			lastTapRef.current = null;
+			resetPointerState();
+			const fitted = stage ? photoBox(stage) : null;
+			if (!(stage && fitted)) {
+				return;
+			}
+			commitTransform(
+				doubleTapZoom(
+					transformRef.current,
+					{
+						x: event.clientX - stage.centreX,
+						y: event.clientY - stage.centreY,
+					},
+					stage.viewport,
+					fitted,
+				),
+			);
+		};
+
+		const dropPointer = (event: PointerEvent, tapEligible: boolean) => {
+			if (!pointers.delete(event.pointerId)) {
+				return;
+			}
+			const stage = gesture.stage;
+			const pinched = gesture.pinched;
+
+			if (pointers.size >= 2) {
+				rebasePinch(stage);
+				return;
+			}
+			// The finger still down carries on as a pan from its own last position.
+			if (pointers.size === 1) {
+				gesture.pinchDist = 0;
+				return;
+			}
+
+			gesture.stage = null;
+			gesture.pinched = false;
+			gesture.pinchDist = 0;
+			commitTransform(transformRef.current);
+
+			if (!tapEligible || pinched) {
+				lastTapRef.current = null;
+				resetPointerState();
+				return;
+			}
+			handleTap(event, stage);
+		};
+
+		const handleUp = (event: PointerEvent) => dropPointer(event, true);
+		// A stolen touch — Control Centre swipe, incoming call — drops the finger but keeps
+		// the operator's place on the tear.
+		const handleAbort = (event: PointerEvent) => dropPointer(event, false);
+
+		let wheelCommit: ReturnType<typeof setTimeout> | undefined;
+		const handleWheel = (event: WheelEvent) => {
+			if (!event.ctrlKey) {
+				return;
+			}
+			// Trackpad pinch arrives as ctrl+wheel; unprevented it zooms the whole admin.
+			event.preventDefault();
+			const stage = measureStage();
+			const fitted = stage ? photoBox(stage) : null;
+			if (!(stage && fitted)) {
+				return;
+			}
+			applyTransform(
+				pinchZoom(
+					transformRef.current,
+					{
+						x: event.clientX - stage.centreX,
+						y: event.clientY - stage.centreY,
+					},
+					Math.exp(-event.deltaY / WHEEL_ZOOM_DIVISOR),
+					stage.viewport,
+					fitted,
+				),
+			);
+			// A wheel burst has no finger to lift, so nothing else would ever commit it.
+			clearTimeout(wheelCommit);
+			wheelCommit = setTimeout(
+				() => commitTransform(transformRef.current),
+				WHEEL_COMMIT_DELAY_MS,
+			);
+		};
+
+		surface.addEventListener("pointerdown", handleDown, { passive: false });
+		surface.addEventListener("pointermove", handleMove, { passive: false });
+		surface.addEventListener("pointerup", handleUp, { passive: false });
+		surface.addEventListener("pointercancel", handleAbort, { passive: false });
+		surface.addEventListener("lostpointercapture", handleAbort, {
+			passive: false,
+		});
+		surface.addEventListener("wheel", handleWheel, { passive: false });
+
+		return () => {
+			clearTimeout(wheelCommit);
+			surface.removeEventListener("pointerdown", handleDown);
+			surface.removeEventListener("pointermove", handleMove);
+			surface.removeEventListener("pointerup", handleUp);
+			surface.removeEventListener("pointercancel", handleAbort);
+			surface.removeEventListener("lostpointercapture", handleAbort);
+			surface.removeEventListener("wheel", handleWheel);
+			// Re-attaching mid-gesture drops the fingers, so publish whatever the last frame
+			// wrote to the node — otherwise state and the photo disagree from here on.
+			commitTransform(transformRef.current);
+		};
+	}, [applyTransform, commitTransform, resetPointerState, surfaceNode]);
+
+	// The browser defaults that fight a pinch on the evidence: iOS Safari page-zooms on any
+	// two-finger touch whatever touch-action says, and a long press pops "Save image" over the
+	// photo. Scoped to this surface so the rest of the admin keeps accessibility zoom.
+	useEffect(() => {
+		if (!surfaceNode) {
+			return;
+		}
+		const suppress = (event: Event) => event.preventDefault();
+		for (const name of SUPPRESSED_UA_GESTURES) {
+			surfaceNode.addEventListener(name, suppress, { passive: false });
+		}
+		return () => {
+			for (const name of SUPPRESSED_UA_GESTURES) {
+				surfaceNode.removeEventListener(name, suppress);
+			}
+		};
+	}, [surfaceNode]);
+
+	// Turning the phone to show the customer resizes the stage under a zoomed photo, and the
+	// offsets it was panned to can now sit entirely outside it — a blank screen mid-dispute.
+	useEffect(() => {
+		if (!surfaceNode) {
+			return;
+		}
+		const observer = new ResizeObserver(() => {
+			const current = transformRef.current;
+			const rect = stageRef.current?.getBoundingClientRect();
+			const loaded = naturalRef.current;
+			if (current.scale === MIN_SCALE || !rect || !loaded) {
+				return;
+			}
+			const viewport = { height: rect.height, width: rect.width };
+			const offset = clampOffset(
+				current.scale,
+				{ x: current.offsetX, y: current.offsetY },
+				viewport,
+				fittedSize(viewport, loaded.size),
+			);
+			commitTransform({
+				offsetX: offset.x,
+				offsetY: offset.y,
+				scale: current.scale,
+			});
+		});
+		observer.observe(surfaceNode);
+		return () => observer.disconnect();
+	}, [commitTransform, surfaceNode]);
+
+	return (
+		<div
+			className={cn(
+				"relative flex min-h-0 flex-1 items-center justify-center [touch-action:none]",
+				className,
+			)}
+			ref={setSurfaceNode}
+		>
+			{activeItem ? (
+				<div className="relative h-full w-full overflow-hidden" ref={stageRef}>
+					<div
+						className="h-full w-full"
+						ref={contentRef}
+						style={{ transform: toCssTransform(transform) }}
+					>
+						<img
+							alt={activeItem.alt}
+							className="pointer-events-none h-full w-full object-contain select-none [-webkit-touch-callout:none]"
+							draggable={false}
+							key={activeItem.id}
+							onLoad={handleImageLoad}
+							src={activeItem.image_url}
+						/>
+					</div>
+				</div>
+			) : null}
+
+			{children}
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/photo-stage.tsx
+++ b/apps/web/src/features/orders/components/photo-stage.tsx
@@ -1,5 +1,7 @@
+import { ArrowLeftIcon, ArrowRightIcon } from "@phosphor-icons/react";
 import type * as React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
 	clampOffset,
 	doubleTapZoom,
@@ -43,9 +45,10 @@ export interface PhotoStageItem {
 interface PhotoStageProps {
 	activeIndex: number;
 	/**
-	 * Overlay chrome, absolutely positioned inside the gesture surface. Anything
-	 * interactive here must be a real `<button>` — that is what the surface tests for
-	 * before claiming a touch as a gesture.
+	 * Caller-specific overlay chrome, absolutely positioned inside the gesture surface
+	 * alongside the navigation arrows. Anything interactive here must be a real
+	 * `<button>` — that is what the surface tests for before claiming a touch as a
+	 * gesture.
 	 */
 	children?: React.ReactNode;
 	className?: string;
@@ -510,6 +513,42 @@ export const PhotoStage = ({
 		};
 	}, [applyTransform, commitTransform, resetPointerState, surfaceNode]);
 
+	// A mouse cannot swipe — a drag on the desk machine is a pan, never a page turn — so on
+	// a counter PC the arrow keys and the arrows above are the only way through a batch.
+	// Bound on the document rather than the surface because the surface is not focusable and
+	// nothing would reach it; both callers are full-screen dialogs that trap focus, so this
+	// never fires against the rest of the admin. Text fields are exempt or the note in the
+	// capture dialog could not be edited without the photo changing under it.
+	useEffect(() => {
+		const owner = surfaceNode?.ownerDocument;
+		if (!owner) {
+			return;
+		}
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (!latestRef.current.canNavigate || event.altKey || event.metaKey) {
+				return;
+			}
+			if (
+				(event.target as Element | null)?.closest(
+					"input, textarea, [contenteditable]",
+				)
+			) {
+				return;
+			}
+			if (event.key === "ArrowLeft") {
+				event.preventDefault();
+				latestRef.current.showPrevious();
+			} else if (event.key === "ArrowRight") {
+				event.preventDefault();
+				latestRef.current.showNext();
+			}
+		};
+
+		owner.addEventListener("keydown", handleKeyDown);
+		return () => owner.removeEventListener("keydown", handleKeyDown);
+	}, [surfaceNode]);
+
 	// The browser defaults that fight a pinch on the evidence: iOS Safari page-zooms on any
 	// two-finger touch whatever touch-action says, and a long press pops "Save image" over the
 	// photo. Scoped to this surface so the rest of the admin keeps accessibility zoom.
@@ -562,6 +601,9 @@ export const PhotoStage = ({
 		<div
 			className={cn(
 				"relative flex min-h-0 flex-1 items-center justify-center [touch-action:none]",
+				// Only from the breakpoint the arrows appear at — a phone gives the whole
+				// width to the garment and turns pages with a swipe.
+				canNavigate && "md:px-14",
 				className,
 			)}
 			ref={setSurfaceNode}
@@ -583,6 +625,29 @@ export const PhotoStage = ({
 						/>
 					</div>
 				</div>
+			) : null}
+
+			{canNavigate ? (
+				<>
+					<Button
+						aria-label="Show previous photo"
+						className="absolute top-1/2 left-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
+						icon={<ArrowLeftIcon className="size-5" aria-hidden="true" />}
+						onClick={showPrevious}
+						size="icon-lg"
+						type="button"
+						variant="outline"
+					/>
+					<Button
+						aria-label="Show next photo"
+						className="absolute top-1/2 right-3 z-10 hidden size-11 -translate-y-1/2 border-white/20 bg-black/45 text-white hover:bg-black/60 hover:text-white focus-visible:border-white/60 active:-translate-y-1/2! md:inline-flex"
+						icon={<ArrowRightIcon className="size-5" aria-hidden="true" />}
+						onClick={showNext}
+						size="icon-lg"
+						type="button"
+						variant="outline"
+					/>
+				</>
 			) : null}
 
 			{children}

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -1,5 +1,6 @@
 import {
 	CameraIcon,
+	CircleNotchIcon,
 	ImageSquareIcon,
 	PencilSimpleLineIcon,
 	TrashIcon,
@@ -85,7 +86,12 @@ const PhotoUploadDialogBase = ({
 	const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
 	const [note, setNote] = useState("");
 	const [isNoteOpen, setIsNoteOpen] = useState(false);
-	const [isNormalizing, setIsNormalizing] = useState(false);
+	// Which of a picked batch is being scaled down. A 12MP gallery photo takes long enough
+	// that the cashier retaps thinking nothing happened, so the count is worth carrying.
+	const [normalizing, setNormalizing] = useState<{
+		done: number;
+		total: number;
+	} | null>(null);
 	const sessionRef = useRef(0);
 
 	const stopCamera = camera.stop;
@@ -105,7 +111,7 @@ const PhotoUploadDialogBase = ({
 		// A scale-down that finishes after the operator gave up on the dialog must not push
 		// its photo into the next order's evidence: opening or closing voids work in flight.
 		sessionRef.current += 1;
-		setIsNormalizing(false);
+		setNormalizing(null);
 
 		if (!open) {
 			return;
@@ -133,11 +139,11 @@ const PhotoUploadDialogBase = ({
 
 			const accepted = multiple ? files : files.slice(0, 1);
 			const session = sessionRef.current;
-			setIsNormalizing(true);
 
 			const normalized: File[] = [];
 			try {
-				for (const file of accepted) {
+				for (const [index, file] of accepted.entries()) {
+					setNormalizing({ done: index, total: accepted.length });
 					try {
 						normalized.push(await normalizeImageFile(file));
 					} catch (error) {
@@ -151,7 +157,7 @@ const PhotoUploadDialogBase = ({
 				}
 			} finally {
 				if (sessionRef.current === session) {
-					setIsNormalizing(false);
+					setNormalizing(null);
 				}
 			}
 
@@ -268,7 +274,16 @@ const PhotoUploadDialogBase = ({
 
 	// Normalizing counts as busy: confirming while a pick is still being scaled down uploaded
 	// only the photos that had landed, toasted success, and dropped the rest of the evidence.
+	const isNormalizing = normalizing !== null;
 	const isBusy = uploadMutation.isPending || isNormalizing;
+	// Picking from the gallery before any photo exists leaves nothing on screen to hang a
+	// spinner off — the only feedback was the picker icon dimming, which read as a dead
+	// button and got retapped. The stage carries it instead, so every mode shows it.
+	const normalizeLabel =
+		normalizing && normalizing.total > 1
+			? `Processing ${normalizing.done + 1} of ${normalizing.total}...`
+			: "Processing...";
+	const busyLabel = isNormalizing ? normalizeLabel : "Uploading...";
 	const photoCount = pendingPhotos.length;
 	const photoNoun = multiple ? "photos" : "photo";
 	const labelSuffix = badgeLabel ? ` for ${badgeLabel}` : "";
@@ -380,7 +395,7 @@ const PhotoUploadDialogBase = ({
 								className="bg-white font-semibold text-black hover:bg-white/90"
 								disabled={isBusy}
 								loading={isBusy}
-								loadingText={isNormalizing ? "Processing..." : "Uploading..."}
+								loadingText={busyLabel}
 								onClick={handleConfirm}
 								size="sm"
 								type="button"
@@ -414,6 +429,17 @@ const PhotoUploadDialogBase = ({
 							<p>{placeholderText}</p>
 						</div>
 					)}
+
+					{isNormalizing ? (
+						<div
+							aria-live="polite"
+							className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/70 text-sm text-white"
+							role="status"
+						>
+							<CircleNotchIcon className="size-7 animate-spin" />
+							<p>{normalizeLabel}</p>
+						</div>
+					) : null}
 
 					{camera.error ? (
 						<div className="absolute inset-x-4 bottom-4 flex items-start gap-2 border border-destructive/40 bg-destructive px-3 py-2 text-sm text-destructive-foreground">
@@ -563,7 +589,7 @@ const PhotoUploadDialogBase = ({
 									type="button"
 									disabled={isBusy}
 									loading={isBusy}
-									loadingText={isNormalizing ? "Processing..." : "Uploading..."}
+									loadingText={busyLabel}
 									onClick={handleConfirm}
 								>
 									{confirmLabel}
@@ -581,7 +607,14 @@ const PhotoUploadDialogBase = ({
 							multiple={multiple}
 							className="sr-only"
 							onChange={(event) => {
-								void addFiles(Array.from(event.target.files ?? []));
+								const files = Array.from(event.target.files ?? []);
+								// A gallery pick used to land behind a still-running viewfinder, so the
+								// photo the cashier just chose was nowhere on screen. Cancelling the
+								// picker (no files) must leave the camera alone.
+								if (files.length > 0) {
+									stopCamera();
+								}
+								void addFiles(files);
 							}}
 						/>
 					)}

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { useCameraCapture } from "@/features/orders/hooks/useCameraCapture";
+import { normalizeImageFile } from "@/features/orders/utils/normalize-image";
 import {
 	ACCEPTED_IMAGE_TYPES,
 	isAcceptedImage,
@@ -124,6 +125,8 @@ const PhotoUploadDialogBase = ({
 	const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
 	const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
 	const [note, setNote] = useState("");
+	const [isNormalizing, setIsNormalizing] = useState(false);
+	const sessionRef = useRef(0);
 
 	const stopCamera = camera.stop;
 	const openCamera = camera.open;
@@ -138,6 +141,11 @@ const PhotoUploadDialogBase = ({
 	}, [stopCamera]);
 
 	useEffect(() => {
+		// A scale-down that finishes after the operator gave up on the dialog must not push
+		// its photo into the next order's evidence: opening or closing voids work in flight.
+		sessionRef.current += 1;
+		setIsNormalizing(false);
+
 		if (!open) {
 			return;
 		}
@@ -153,23 +161,44 @@ const PhotoUploadDialogBase = ({
 	// re-centering first — that snap was the layout shift.
 	useEffect(() => stopCamera, [stopCamera]);
 
+	// Single entry point for the strip: a 12MP phone photo is scaled down before it
+	// ever reaches 4G, and an iPhone HEIC either becomes a JPEG here or is rejected
+	// here rather than sitting in S3 as unviewable dispute evidence.
 	const addFiles = useCallback(
-		(files: File[]) => {
+		async (files: File[]) => {
 			if (files.length === 0) {
 				return;
 			}
 
 			const accepted = multiple ? files : files.slice(0, 1);
+			const session = sessionRef.current;
+			setIsNormalizing(true);
 
-			const unsupportedFile = accepted.find(
-				(file) => !isAcceptedImage(file.type),
-			);
-			if (unsupportedFile) {
-				toast.error(`Unsupported image type: ${unsupportedFile.name}`);
+			const normalized: File[] = [];
+			try {
+				for (const file of accepted) {
+					try {
+						normalized.push(await normalizeImageFile(file));
+					} catch (error) {
+						toast.error(
+							`${error instanceof Error && error.message ? error.message : "Unsupported image type"}: ${file.name}`,
+						);
+					}
+					if (sessionRef.current !== session) {
+						return;
+					}
+				}
+			} finally {
+				if (sessionRef.current === session) {
+					setIsNormalizing(false);
+				}
+			}
+
+			if (normalized.length === 0) {
 				return;
 			}
 
-			const created = accepted.map((file) => createPendingPhoto(file));
+			const created = normalized.map((file) => createPendingPhoto(file));
 			setPendingPhotos((previous) => {
 				if (!multiple) {
 					revokePhotos(previous);
@@ -207,7 +236,7 @@ const PhotoUploadDialogBase = ({
 		}
 
 		const timestamp = Date.now();
-		addFiles([
+		await addFiles([
 			new File([blob], `photo-${timestamp}.jpg`, {
 				type: "image/jpeg",
 			}),
@@ -275,7 +304,9 @@ const PhotoUploadDialogBase = ({
 		},
 	});
 
-	const isBusy = uploadMutation.isPending;
+	// Normalizing counts as busy: confirming while a pick is still being scaled down uploaded
+	// only the photos that had landed, toasted success, and dropped the rest of the evidence.
+	const isBusy = uploadMutation.isPending || isNormalizing;
 	const photoNoun = multiple ? "photos" : "photo";
 	const labelSuffix = badgeLabel ? ` for ${badgeLabel}` : "";
 
@@ -449,7 +480,7 @@ const PhotoUploadDialogBase = ({
 							multiple={multiple}
 							className="sr-only"
 							onChange={(event) => {
-								addFiles(Array.from(event.target.files ?? []));
+								void addFiles(Array.from(event.target.files ?? []));
 							}}
 						/>
 					)}
@@ -472,7 +503,7 @@ const PhotoUploadDialogBase = ({
 						type="button"
 						disabled={pendingPhotos.length === 0 || isBusy}
 						loading={isBusy}
-						loadingText="Uploading..."
+						loadingText={isNormalizing ? "Processing..." : "Uploading..."}
 						onClick={handleConfirm}
 					>
 						{confirmLabel}

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -329,7 +329,9 @@ const PhotoUploadDialogBase = ({
 	const isBusy = uploadMutation.isPending || isNormalizing;
 	// Picking from the gallery before any photo exists leaves nothing on screen to hang a
 	// spinner off — the only feedback was the picker icon dimming, which read as a dead
-	// button and got retapped. The stage carries it instead, so every mode shows it.
+	// button and got retapped. The stage carries it instead, so every mode shows it, and the
+	// confirm button is free to stay narrow enough to sit beside the shutter without
+	// "Uploading 4 of 5..." growing into it.
 	const normalizeLabel =
 		normalizing && normalizing.total > 1
 			? `Processing ${normalizing.done + 1} of ${normalizing.total}...`
@@ -419,8 +421,8 @@ const PhotoUploadDialogBase = ({
 						: "Pinch or double-tap to zoom. Swipe to move between photos."}
 				</DialogDescription>
 
-				{/* Top chrome: close · position · item badge, over the viewfinder. The fast path
-				    uploads from here so the shooting layout never gives up height for a button. */}
+				{/* Top chrome: close · position · item badge, over the viewfinder. Actions live in
+				    the bottom bar within thumb reach — nothing up here is a tap target but Close. */}
 				<div className="grid shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-3 px-4 pt-[calc(env(safe-area-inset-top)_+_0.75rem)] pb-3">
 					<button
 						aria-label="Close"
@@ -439,7 +441,7 @@ const PhotoUploadDialogBase = ({
 						<span />
 					)}
 
-					<div className="flex items-center justify-end gap-2 justify-self-end">
+					<div className="justify-self-end">
 						{badgeLabel ? (
 							<Badge
 								className="border-white/40 bg-transparent text-white"
@@ -447,19 +449,6 @@ const PhotoUploadDialogBase = ({
 							>
 								{badgeLabel}
 							</Badge>
-						) : null}
-						{isShooting && photoCount > 0 ? (
-							<Button
-								className="bg-white font-semibold text-black hover:bg-white/90"
-								disabled={isBusy}
-								loading={isBusy}
-								loadingText={busyLabel}
-								onClick={handleConfirm}
-								size="sm"
-								type="button"
-							>
-								{confirmLabel}
-							</Button>
 						) : null}
 					</div>
 				</div>
@@ -488,14 +477,14 @@ const PhotoUploadDialogBase = ({
 						</div>
 					)}
 
-					{isNormalizing ? (
+					{isBusy ? (
 						<div
 							aria-live="polite"
 							className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/70 text-sm text-white"
 							role="status"
 						>
 							<CircleNotchIcon className="size-7 animate-spin" />
-							<p>{normalizeLabel}</p>
+							<p>{busyLabel}</p>
 						</div>
 					) : null}
 
@@ -548,8 +537,22 @@ const PhotoUploadDialogBase = ({
 								<span className="size-12 rounded-full bg-white transition active:scale-90" />
 							</button>
 
+							{/* Finish the batch from where a document scanner puts it: bottom-right,
+							    beside the shot count, both a thumb's width from the shutter. The
+							    picker gives up the slot once a shot exists — mid-batch gallery picks
+							    are rare, and it is still one tap away behind the review square. */}
 							<div className="justify-self-end">
-								{cameraOnly ? null : (
+								{photoCount > 0 ? (
+									<Button
+										className="h-12 bg-white px-4 font-semibold text-black hover:bg-white/90"
+										disabled={isBusy}
+										loading={isBusy}
+										onClick={handleConfirm}
+										type="button"
+									>
+										{confirmLabel}
+									</Button>
+								) : cameraOnly ? null : (
 									<button
 										aria-label="Upload from device"
 										className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
@@ -647,7 +650,6 @@ const PhotoUploadDialogBase = ({
 									type="button"
 									disabled={isBusy}
 									loading={isBusy}
-									loadingText={busyLabel}
 									onClick={handleConfirm}
 								>
 									{confirmLabel}

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -25,7 +25,7 @@ import { normalizeImageFile } from "@/features/orders/utils/normalize-image";
 import {
 	ACCEPTED_IMAGE_TYPES,
 	isAcceptedImage,
-	type UploadPhotoInput,
+	type PhotoUploader,
 } from "@/features/orders/utils/photo-upload";
 import { readServerErrorMessage } from "@/lib/server-error";
 import { cn } from "@/lib/utils";
@@ -55,12 +55,12 @@ interface PhotoUploadDialogBaseProps {
 	badgeLabel?: string;
 	multiple: boolean;
 	withNote: boolean;
-	// Upload mode: presign → upload → save on confirm.
-	uploadPhoto?: (input: UploadPhotoInput) => Promise<void>;
+	// Upload mode: push bytes → commit on confirm.
+	uploader?: PhotoUploader;
 	onUploaded?: () => Promise<void>;
 	// Capture-only mode: hand the picked File(s) back instead of uploading. Used
 	// at the POS where the Order does not exist yet, so the upload is deferred to
-	// after checkout commits. When set, uploadPhoto/onUploaded are ignored.
+	// after checkout commits. When set, uploader/onUploaded are ignored.
 	onCapture?: (files: File[]) => void;
 	// Camera-only: drop the "Upload from device" path, auto-open the camera, and
 	// stop it after a shot for a single review still. For intake flows that want
@@ -75,7 +75,7 @@ const PhotoUploadDialogBase = ({
 	badgeLabel,
 	multiple,
 	withNote,
-	uploadPhoto,
+	uploader,
 	onUploaded,
 	onCapture,
 	cameraOnly = false,
@@ -92,6 +92,13 @@ const PhotoUploadDialogBase = ({
 		done: number;
 		total: number;
 	} | null>(null);
+	// How far the confirm has got through the batch, and which photos are already saved so a
+	// retry after a mid-batch failure does not upload them twice.
+	const [uploading, setUploading] = useState<{
+		done: number;
+		total: number;
+	} | null>(null);
+	const committedRef = useRef<string[]>([]);
 	const sessionRef = useRef(0);
 
 	const stopCamera = camera.stop;
@@ -241,6 +248,9 @@ const PhotoUploadDialogBase = ({
 			if (pendingPhotos.length === 0) {
 				throw new Error("Add at least one photo");
 			}
+			if (!uploader) {
+				return;
+			}
 
 			const validatedPhotos = pendingPhotos.map((photo) => {
 				const contentType = photo.file.type;
@@ -251,13 +261,45 @@ const PhotoUploadDialogBase = ({
 			});
 
 			const trimmedNote = withNote ? note.trim() || undefined : undefined;
-			// TODO: make this parallel instead of waterfall request
-			for (const photo of validatedPhotos) {
-				await uploadPhoto?.({
-					file: photo.file,
+			committedRef.current = [];
+
+			// The batch is a pipeline, not a fan-out. Commits stay strictly in shot order
+			// because the gallery sorts on the row id the commit assigns — fire them together
+			// and a before/after pair comes back shuffled, which is the whole point of the
+			// photo. What does overlap is the part worth overlapping: the next photo's bytes
+			// go up while the server is still re-encoding the current one, which was dead
+			// time on the uplink and most of why a five-photo batch felt stalled. A wider
+			// fan-out buys nothing on top of that — the shop uplink is already saturated by
+			// one upload, and every commit queues on the same container's transcode.
+			let pending: Promise<string> | null = null;
+			for (const [index, photo] of validatedPhotos.entries()) {
+				setUploading({ done: index, total: validatedPhotos.length });
+				const input = {
 					contentType: photo.contentType,
+					file: photo.file,
 					note: trimmedNote,
-				});
+				};
+				const key = await (pending ?? uploader.pushBytes(input));
+
+				const nextPhoto = validatedPhotos[index + 1];
+				pending = nextPhoto
+					? uploader.pushBytes({
+							contentType: nextPhoto.contentType,
+							file: nextPhoto.file,
+							note: trimmedNote,
+						})
+					: null;
+				// Claim the read-ahead's failure the moment it exists, not once the loop ends.
+				// The very next line parks for as long as the server takes to re-encode, and a
+				// push that dies inside that window — dropped 4G, expired token — would be
+				// reported as an unhandled rejection before anything awaits it. The await below
+				// still throws and still drives the error toast; this only stops the duplicate
+				// report. A read-ahead that succeeds after an abandoned batch leaves its bytes
+				// orphaned in the bucket, which the browser cannot clean up either way.
+				pending?.catch(() => undefined);
+
+				await uploader.commit(key, input);
+				committedRef.current.push(photo.id);
 			}
 		},
 		onSuccess: async () => {
@@ -269,6 +311,15 @@ const PhotoUploadDialogBase = ({
 		},
 		onError: (error: Error) => {
 			toast.error(readServerErrorMessage(error, "Failed to upload photos"));
+			// Photos already in the database have to leave the strip, or tapping Upload again
+			// saves a second copy of every one that had landed before the failure.
+			for (const photoId of committedRef.current) {
+				removePhoto(photoId);
+			}
+			committedRef.current = [];
+		},
+		onSettled: () => {
+			setUploading(null);
 		},
 	});
 
@@ -283,7 +334,11 @@ const PhotoUploadDialogBase = ({
 		normalizing && normalizing.total > 1
 			? `Processing ${normalizing.done + 1} of ${normalizing.total}...`
 			: "Processing...";
-	const busyLabel = isNormalizing ? normalizeLabel : "Uploading...";
+	const uploadLabel =
+		uploading && uploading.total > 1
+			? `Uploading ${uploading.done + 1} of ${uploading.total}...`
+			: "Uploading...";
+	const busyLabel = isNormalizing ? normalizeLabel : uploadLabel;
 	const photoCount = pendingPhotos.length;
 	const photoNoun = multiple ? "photos" : "photo";
 	const labelSuffix = badgeLabel ? ` for ${badgeLabel}` : "";
@@ -296,13 +351,16 @@ const PhotoUploadDialogBase = ({
 		: "Upload";
 	const confirmLabel =
 		multiple && photoCount > 0 ? `${confirmBase} · ${photoCount}` : confirmBase;
-	const handleConfirm = async () => {
+	const handleConfirm = () => {
 		if (onCapture) {
 			onCapture(pendingPhotos.map((photo) => photo.file));
 			onOpenChange(false);
 			return;
 		}
-		await uploadMutation.mutateAsync();
+		// mutate, not mutateAsync: onError already reports the failure, and the rejected
+		// promise mutateAsync hands back had nobody awaiting it on an onClick, so every
+		// failed batch also logged an uncaught rejection.
+		uploadMutation.mutate();
 	};
 
 	// Shooting fills the screen with the viewfinder; reviewing hands the same photo surface

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -1,11 +1,13 @@
 import {
 	CameraIcon,
 	ImageSquareIcon,
+	PencilSimpleLineIcon,
+	TrashIcon,
 	WarningCircleIcon,
 	XIcon,
 } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -16,6 +18,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { PhotoStage } from "@/features/orders/components/photo-stage";
 import { useCameraCapture } from "@/features/orders/hooks/useCameraCapture";
 import { normalizeImageFile } from "@/features/orders/utils/normalize-image";
 import {
@@ -43,50 +46,6 @@ const revokePhotos = (photos: PendingPhoto[]) => {
 		URL.revokeObjectURL(photo.previewUrl);
 	}
 };
-
-interface PhotoThumbProps {
-	disabled: boolean;
-	isActive: boolean;
-	onRemove: () => void;
-	onSelect: () => void;
-	photo: PendingPhoto;
-}
-
-// One captured/picked still in the bottom thumb strip (iOS-camera style): tap to
-// review it in the stage, the corner × removes it.
-const PhotoThumb = ({
-	disabled,
-	isActive,
-	onRemove,
-	onSelect,
-	photo,
-}: PhotoThumbProps) => (
-	<div className="relative shrink-0">
-		<button
-			aria-current={isActive}
-			aria-label={`Preview ${photo.file.name}`}
-			className={cn(
-				"block size-14 overflow-hidden border bg-white/5 transition",
-				isActive
-					? "border-white ring-1 ring-white"
-					: "border-white/30 opacity-70 hover:opacity-100",
-			)}
-			onClick={onSelect}
-			type="button"
-		>
-			<img alt="" className="size-full object-cover" src={photo.previewUrl} />
-		</button>
-		<button
-			aria-label={`Remove ${photo.file.name}`}
-			className="absolute top-1 right-1 grid size-5 place-items-center rounded-full bg-black/60 text-white shadow-sm transition hover:bg-black/80 disabled:opacity-50"
-			disabled={disabled}
-			onClick={onRemove}
-			type="button"
-		>
-			<XIcon className="size-3" aria-hidden="true" />
-		</button>
-	</div>
-);
 
 interface PhotoUploadDialogBaseProps {
 	open: boolean;
@@ -125,6 +84,7 @@ const PhotoUploadDialogBase = ({
 	const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
 	const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
 	const [note, setNote] = useState("");
+	const [isNoteOpen, setIsNoteOpen] = useState(false);
 	const [isNormalizing, setIsNormalizing] = useState(false);
 	const sessionRef = useRef(0);
 
@@ -138,6 +98,7 @@ const PhotoUploadDialogBase = ({
 		});
 		setSelectedPhotoId(null);
 		setNote("");
+		setIsNoteOpen(false);
 	}, [stopCamera]);
 
 	useEffect(() => {
@@ -243,7 +204,8 @@ const PhotoUploadDialogBase = ({
 		]);
 		// Single-photo flows: stop after the shot so the still preview replaces the
 		// live feed in the stage. Multiple-photo flows keep the camera open so
-		// consecutive shots can be taken — the shots pile up in the thumb strip.
+		// consecutive shots can be taken — the shots pile up behind the last-shot
+		// square, which the operator taps once to review them all.
 		if (!multiple) {
 			stopCamera();
 		}
@@ -261,8 +223,8 @@ const PhotoUploadDialogBase = ({
 		);
 	};
 
-	// Tapping a thumb reviews it in the stage, so the live feed must yield to the
-	// still — stop the camera and let the user reopen it to shoot more.
+	// Reviewing a still means the live feed must yield to it — stop the camera and let
+	// the operator reopen it to shoot more.
 	const reviewPhoto = (photoId: string) => {
 		setSelectedPhotoId(photoId);
 		stopCamera();
@@ -307,6 +269,7 @@ const PhotoUploadDialogBase = ({
 	// Normalizing counts as busy: confirming while a pick is still being scaled down uploaded
 	// only the photos that had landed, toasted success, and dropped the rest of the evidence.
 	const isBusy = uploadMutation.isPending || isNormalizing;
+	const photoCount = pendingPhotos.length;
 	const photoNoun = multiple ? "photos" : "photo";
 	const labelSuffix = badgeLabel ? ` for ${badgeLabel}` : "";
 
@@ -317,9 +280,7 @@ const PhotoUploadDialogBase = ({
 			: "Use photo"
 		: "Upload";
 	const confirmLabel =
-		multiple && pendingPhotos.length > 0
-			? `${confirmBase} · ${pendingPhotos.length}`
-			: confirmBase;
+		multiple && photoCount > 0 ? `${confirmBase} · ${photoCount}` : confirmBase;
 	const handleConfirm = async () => {
 		if (onCapture) {
 			onCapture(pendingPhotos.map((photo) => photo.file));
@@ -329,17 +290,39 @@ const PhotoUploadDialogBase = ({
 		await uploadMutation.mutateAsync();
 	};
 
-	// The stage shows the live feed while shooting; otherwise the reviewed still
-	// (falling back to the latest shot if the selection was removed).
-	const selectedPhoto =
-		pendingPhotos.find((photo) => photo.id === selectedPhotoId) ??
-		pendingPhotos.at(-1) ??
-		null;
+	// Shooting fills the screen with the viewfinder; reviewing hands the same photo surface
+	// the lightbox uses to the stills, so a shot swipes and pinches identically before and
+	// after it is uploaded.
+	const isShooting = camera.isOpen;
+	const lastPhoto = pendingPhotos.at(-1);
+	const selectedIndex = pendingPhotos.findIndex(
+		(photo) => photo.id === selectedPhotoId,
+	);
+	// A removed selection falls through to the newest shot rather than emptying the stage.
+	const activeIndex = selectedIndex === -1 ? photoCount - 1 : selectedIndex;
+	const selectedPhoto = pendingPhotos[activeIndex] ?? null;
+	const stageItems = useMemo(
+		() =>
+			pendingPhotos.map((photo) => ({
+				alt: `Preview ${photo.file.name}`,
+				id: photo.id,
+				image_url: photo.previewUrl,
+			})),
+		[pendingPhotos],
+	);
+	const handleIndexChange = (index: number) => {
+		const photo = pendingPhotos[index];
+		if (photo) {
+			setSelectedPhotoId(photo.id);
+		}
+	};
+
 	const cameraButtonLabel =
-		pendingPhotos.length === 0 ? "Open camera" : multiple ? "Camera" : "Retake";
+		photoCount === 0 ? "Open camera" : multiple ? "Camera" : "Retake";
 	const placeholderText = cameraOnly
 		? "Camera is required for this photo."
 		: "Open the camera or pick from your device.";
+	const hasNote = note.trim().length > 0;
 
 	return (
 		<Dialog
@@ -358,32 +341,59 @@ const PhotoUploadDialogBase = ({
 			>
 				<DialogTitle className="sr-only">{title}</DialogTitle>
 				<DialogDescription className="sr-only">
-					Capture a photo with the camera or upload one from your device.
+					{isShooting
+						? "Capture a photo with the camera or upload one from your device."
+						: "Pinch or double-tap to zoom. Swipe to move between photos."}
 				</DialogDescription>
 
-				{/* Top chrome: close · item badge, over the viewfinder. */}
-				<div className="flex shrink-0 items-center justify-between gap-3 px-4 pt-[calc(env(safe-area-inset-top)_+_0.75rem)] pb-3">
+				{/* Top chrome: close · position · item badge, over the viewfinder. The fast path
+				    uploads from here so the shooting layout never gives up height for a button. */}
+				<div className="grid shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-3 px-4 pt-[calc(env(safe-area-inset-top)_+_0.75rem)] pb-3">
 					<button
 						aria-label="Close"
-						className="grid size-9 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+						className="grid size-9 place-items-center justify-self-start rounded-full bg-white/10 text-white transition hover:bg-white/20"
 						onClick={() => onOpenChange(false)}
 						type="button"
 					>
 						<XIcon className="size-5" aria-hidden="true" />
 					</button>
-					{badgeLabel ? (
-						<Badge
-							className="border-white/40 bg-transparent text-white"
-							variant="outline"
-						>
-							{badgeLabel}
-						</Badge>
-					) : null}
+
+					{!isShooting && photoCount > 1 ? (
+						<p className="justify-self-center font-mono text-xs text-white/70 tabular-nums">
+							{activeIndex + 1} / {photoCount}
+						</p>
+					) : (
+						<span />
+					)}
+
+					<div className="flex items-center justify-end gap-2 justify-self-end">
+						{badgeLabel ? (
+							<Badge
+								className="border-white/40 bg-transparent text-white"
+								variant="outline"
+							>
+								{badgeLabel}
+							</Badge>
+						) : null}
+						{isShooting && photoCount > 0 ? (
+							<Button
+								className="bg-white font-semibold text-black hover:bg-white/90"
+								disabled={isBusy}
+								loading={isBusy}
+								loadingText={isNormalizing ? "Processing..." : "Uploading..."}
+								onClick={handleConfirm}
+								size="sm"
+								type="button"
+							>
+								{confirmLabel}
+							</Button>
+						) : null}
+					</div>
 				</div>
 
-				{/* Viewfinder: live feed, reviewed still, or empty hint. */}
-				<div className="relative min-h-0 flex-1 overflow-hidden px-4">
-					{camera.isOpen ? (
+				{/* Live feed, reviewed still, or empty hint. */}
+				<div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+					{isShooting ? (
 						<video
 							ref={camera.previewRef}
 							autoPlay
@@ -393,10 +403,10 @@ const PhotoUploadDialogBase = ({
 							className="size-full object-cover"
 						/>
 					) : selectedPhoto ? (
-						<img
-							src={selectedPhoto.previewUrl}
-							alt={`Preview ${selectedPhoto.file.name}`}
-							className="size-full object-contain"
+						<PhotoStage
+							activeIndex={activeIndex}
+							items={stageItems}
+							onIndexChange={handleIndexChange}
 						/>
 					) : (
 						<div className="flex size-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-white/70">
@@ -416,34 +426,61 @@ const PhotoUploadDialogBase = ({
 					) : null}
 				</div>
 
-				{/* Bottom chrome: thumbs · shutter · device, note, primary action. */}
+				{/* Bottom chrome: native-camera controls while shooting, photo actions while
+				    reviewing. Neither mode reserves height for the other's controls. */}
 				<div className="shrink-0 space-y-3 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom)_+_1rem)]">
-					<div className="grid h-16 grid-cols-[1fr_auto_1fr] items-center gap-2">
-						<div className="flex min-w-0 items-center gap-2 overflow-x-auto py-1">
-							{pendingPhotos.map((photo) => (
-								<PhotoThumb
-									disabled={isBusy}
-									isActive={!camera.isOpen && selectedPhoto?.id === photo.id}
-									key={photo.id}
-									onRemove={() => removePhoto(photo.id)}
-									onSelect={() => reviewPhoto(photo.id)}
-									photo={photo}
-								/>
-							))}
-						</div>
+					{isShooting ? (
+						<div className="grid h-16 grid-cols-[1fr_auto_1fr] items-center gap-2">
+							<div className="justify-self-start">
+								{lastPhoto ? (
+									<button
+										aria-label={`Review ${photoCount} ${photoCount === 1 ? "photo" : "photos"}`}
+										className="relative block size-14 overflow-hidden border border-white/40 bg-white/5 disabled:opacity-40"
+										disabled={isBusy}
+										onClick={() => reviewPhoto(lastPhoto.id)}
+										type="button"
+									>
+										<img
+											alt=""
+											className="size-full object-cover"
+											src={lastPhoto.previewUrl}
+										/>
+										{photoCount > 1 ? (
+											<span className="absolute top-0 right-0 grid size-5 place-items-center bg-white text-[0.625rem] font-medium text-black tabular-nums">
+												{photoCount}
+											</span>
+										) : null}
+									</button>
+								) : null}
+							</div>
 
-						<div className="justify-self-center">
-							{camera.isOpen ? (
-								<button
-									aria-label="Capture photo"
-									className="grid size-16 place-items-center rounded-full border-4 border-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 disabled:opacity-40"
-									disabled={!camera.isReady || isBusy}
-									onClick={captureCameraPhoto}
-									type="button"
-								>
-									<span className="size-12 rounded-full bg-white transition active:scale-90" />
-								</button>
-							) : (
+							<button
+								aria-label="Capture photo"
+								className="grid size-16 place-items-center justify-self-center rounded-full border-4 border-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 disabled:opacity-40"
+								disabled={!camera.isReady || isBusy}
+								onClick={captureCameraPhoto}
+								type="button"
+							>
+								<span className="size-12 rounded-full bg-white transition active:scale-90" />
+							</button>
+
+							<div className="justify-self-end">
+								{cameraOnly ? null : (
+									<button
+										aria-label="Upload from device"
+										className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+										disabled={isBusy}
+										onClick={openFileInput}
+										type="button"
+									>
+										<ImageSquareIcon className="size-5" aria-hidden="true" />
+									</button>
+								)}
+							</div>
+						</div>
+					) : (
+						<>
+							<div className="flex h-12 items-center gap-2">
 								<button
 									className="flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-5 py-2.5 font-medium text-sm text-white transition hover:bg-white/20 disabled:opacity-40"
 									disabled={isBusy}
@@ -453,23 +490,87 @@ const PhotoUploadDialogBase = ({
 									<CameraIcon className="size-4" aria-hidden="true" />
 									{cameraButtonLabel}
 								</button>
-							)}
-						</div>
 
-						<div className="justify-self-end">
-							{cameraOnly ? null : (
-								<button
-									aria-label="Upload from device"
-									className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+								{cameraOnly ? null : (
+									<button
+										aria-label="Upload from device"
+										className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+										disabled={isBusy}
+										onClick={openFileInput}
+										type="button"
+									>
+										<ImageSquareIcon className="size-5" aria-hidden="true" />
+									</button>
+								)}
+
+								{withNote && photoCount > 0 ? (
+									<button
+										aria-expanded={isNoteOpen}
+										aria-label={isNoteOpen ? "Hide note" : "Add note"}
+										className={cn(
+											"relative grid size-12 place-items-center rounded-full transition disabled:opacity-40",
+											isNoteOpen
+												? "bg-white text-black"
+												: "bg-white/10 text-white hover:bg-white/20",
+										)}
+										disabled={isBusy}
+										onClick={() => setIsNoteOpen((previous) => !previous)}
+										type="button"
+									>
+										<PencilSimpleLineIcon
+											className="size-5"
+											aria-hidden="true"
+										/>
+										{hasNote && !isNoteOpen ? (
+											<span className="absolute top-2 right-2 size-1.5 bg-white" />
+										) : null}
+									</button>
+								) : null}
+
+								{selectedPhoto ? (
+									<button
+										aria-label={`Remove ${selectedPhoto.file.name}`}
+										className="ml-auto grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+										disabled={isBusy}
+										onClick={() => removePhoto(selectedPhoto.id)}
+										type="button"
+									>
+										<TrashIcon className="size-5" aria-hidden="true" />
+									</button>
+								) : null}
+							</div>
+
+							{withNote && isNoteOpen ? (
+								<Textarea
+									value={note}
+									onChange={(event) => setNote(event.target.value)}
+									placeholder={
+										photoCount > 1
+											? `Note for all ${photoCount} photos`
+											: "Optional note"
+									}
+									rows={2}
+									maxLength={200}
 									disabled={isBusy}
-									onClick={openFileInput}
+									aria-label={`Photo note${labelSuffix}`}
+									className="border-white/20 bg-white/5 text-white placeholder:text-white/50 disabled:opacity-50"
+								/>
+							) : null}
+
+							{photoCount > 0 ? (
+								<Button
+									className="h-14 w-full bg-white font-semibold text-base text-black hover:bg-white/90"
 									type="button"
+									disabled={isBusy}
+									loading={isBusy}
+									loadingText={isNormalizing ? "Processing..." : "Uploading..."}
+									onClick={handleConfirm}
 								>
-									<ImageSquareIcon className="size-5" aria-hidden="true" />
-								</button>
-							)}
-						</div>
-					</div>
+									{confirmLabel}
+								</Button>
+							) : null}
+						</>
+					)}
 
 					{cameraOnly ? null : (
 						<input
@@ -484,30 +585,6 @@ const PhotoUploadDialogBase = ({
 							}}
 						/>
 					)}
-
-					{withNote ? (
-						<Textarea
-							value={note}
-							onChange={(event) => setNote(event.target.value)}
-							placeholder="Optional note"
-							rows={2}
-							maxLength={200}
-							disabled={isBusy || pendingPhotos.length === 0}
-							aria-label={`Photo note${labelSuffix}`}
-							className="border-white/20 bg-white/5 text-white placeholder:text-white/50 disabled:opacity-50"
-						/>
-					) : null}
-
-					<Button
-						className="h-14 w-full bg-white font-semibold text-base text-black hover:bg-white/90"
-						type="button"
-						disabled={pendingPhotos.length === 0 || isBusy}
-						loading={isBusy}
-						loadingText={isNormalizing ? "Processing..." : "Uploading..."}
-						onClick={handleConfirm}
-					>
-						{confirmLabel}
-					</Button>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -400,7 +400,7 @@ const PhotoUploadDialogBase = ({
 							muted
 							playsInline
 							onLoadedMetadata={camera.markReady}
-							className="size-full object-cover"
+							className="size-full object-contain"
 						/>
 					) : selectedPhoto ? (
 						<PhotoStage

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -130,11 +130,24 @@ const PhotoUploadDialogBase = ({
 		}
 	}, [open, autoOpenCamera, openCamera]);
 
-	// Release the camera if the dialog unmounts while still open. The visual reset
-	// (stop camera + clear photos) is deferred to onOpenChangeComplete so the popup
-	// keeps its full height through the close animation instead of collapsing and
-	// re-centering first — that snap was the layout shift.
-	useEffect(() => stopCamera, [stopCamera]);
+	// Release the camera and the previews if the dialog unmounts while still open. The
+	// visual reset is deferred to onOpenChangeComplete so the popup keeps its full height
+	// through the close animation instead of collapsing and re-centering first — that snap
+	// was the layout shift — but an unmount never reaches that callback. Navigating off the
+	// order, advancing the checkout step or switching queue item with shots still staged
+	// would otherwise strand a blob per photo for as long as the tab lives, and the till
+	// tab lives all day.
+	const pendingRef = useRef<PendingPhoto[]>([]);
+	useEffect(() => {
+		pendingRef.current = pendingPhotos;
+	});
+	useEffect(
+		() => () => {
+			stopCamera();
+			revokePhotos(pendingRef.current);
+		},
+		[stopCamera],
+	);
 
 	// Photos this dialog produced itself. The capture canvas already scaled them into
 	// budget and encoded them as JPEG, so there is nothing left to decode or check and

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -136,9 +136,31 @@ const PhotoUploadDialogBase = ({
 	// re-centering first — that snap was the layout shift.
 	useEffect(() => stopCamera, [stopCamera]);
 
-	// Single entry point for the strip: a 12MP phone photo is scaled down before it
-	// ever reaches 4G, and an iPhone HEIC either becomes a JPEG here or is rejected
-	// here rather than sitting in S3 as unviewable dispute evidence.
+	// Photos this dialog produced itself. The capture canvas already scaled them into
+	// budget and encoded them as JPEG, so there is nothing left to decode or check and
+	// they go on the strip in the same frame as the shutter press.
+	const stagePhotos = useCallback(
+		(files: File[]) => {
+			const created = files.map((file) => createPendingPhoto(file));
+			setPendingPhotos((previous) => {
+				if (!multiple) {
+					revokePhotos(previous);
+					return created;
+				}
+				return [...previous, ...created];
+			});
+			const newest = created.at(-1);
+			if (newest) {
+				setSelectedPhotoId(newest.id);
+			}
+		},
+		[multiple],
+	);
+
+	// Photos arriving from the device gallery, where nothing is known about them yet: a
+	// 12MP phone photo is scaled down before it ever reaches 4G, and an iPhone HEIC either
+	// becomes a JPEG here or is rejected here rather than sitting in S3 as unviewable
+	// dispute evidence. Slow enough on a real photo to need the progress overlay.
 	const addFiles = useCallback(
 		async (files: File[]) => {
 			if (files.length === 0) {
@@ -173,20 +195,9 @@ const PhotoUploadDialogBase = ({
 				return;
 			}
 
-			const created = normalized.map((file) => createPendingPhoto(file));
-			setPendingPhotos((previous) => {
-				if (!multiple) {
-					revokePhotos(previous);
-					return created;
-				}
-				return [...previous, ...created];
-			});
-			const newest = created.at(-1);
-			if (newest) {
-				setSelectedPhotoId(newest.id);
-			}
+			stagePhotos(normalized);
 		},
-		[multiple],
+		[multiple, stagePhotos],
 	);
 
 	const openFileInput = () => {
@@ -211,7 +222,7 @@ const PhotoUploadDialogBase = ({
 		}
 
 		const timestamp = Date.now();
-		await addFiles([
+		stagePhotos([
 			new File([blob], `photo-${timestamp}.jpg`, {
 				type: "image/jpeg",
 			}),

--- a/apps/web/src/features/orders/components/photo-upload-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-upload-dialog.tsx
@@ -1,5 +1,6 @@
 import {
 	CameraIcon,
+	CheckIcon,
 	CircleNotchIcon,
 	ImageSquareIcon,
 	PencilSimpleLineIcon,
@@ -62,10 +63,10 @@ interface PhotoUploadDialogBaseProps {
 	// at the POS where the Order does not exist yet, so the upload is deferred to
 	// after checkout commits. When set, uploader/onUploaded are ignored.
 	onCapture?: (files: File[]) => void;
-	// Camera-only: drop the "Upload from device" path, auto-open the camera, and
-	// stop it after a shot for a single review still. For intake flows that want
-	// a live photo, not a gallery pick. See SinglePhotoCaptureDialog.
-	cameraOnly?: boolean;
+	// Skip the chooser and go straight to the viewfinder. For intake flows where a
+	// live photo is the expected answer and the gallery is the exception — the
+	// picker is still in the shutter row. See SinglePhotoCaptureDialog.
+	autoOpenCamera?: boolean;
 }
 
 const PhotoUploadDialogBase = ({
@@ -78,7 +79,7 @@ const PhotoUploadDialogBase = ({
 	uploader,
 	onUploaded,
 	onCapture,
-	cameraOnly = false,
+	autoOpenCamera = false,
 }: PhotoUploadDialogBaseProps) => {
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const camera = useCameraCapture();
@@ -123,11 +124,11 @@ const PhotoUploadDialogBase = ({
 		if (!open) {
 			return;
 		}
-		// Camera-only intake: skip the chooser, go straight to the live camera.
-		if (cameraOnly) {
+		// Intake flows: skip the chooser, go straight to the live camera.
+		if (autoOpenCamera) {
 			void openCamera();
 		}
-	}, [open, cameraOnly, openCamera]);
+	}, [open, autoOpenCamera, openCamera]);
 
 	// Release the camera if the dialog unmounts while still open. The visual reset
 	// (stop camera + clear photos) is deferred to onOpenChangeComplete so the popup
@@ -353,6 +354,10 @@ const PhotoUploadDialogBase = ({
 		: "Upload";
 	const confirmLabel =
 		multiple && photoCount > 0 ? `${confirmBase} · ${photoCount}` : confirmBase;
+	// The shutter row has no width to spare for a word, so the count stays on the review
+	// square and the tick carries the action. Assistive tech still gets the full sentence.
+	const confirmAriaLabel =
+		photoCount > 1 ? `${confirmBase}, ${photoCount} photos` : confirmBase;
 	const handleConfirm = () => {
 		if (onCapture) {
 			onCapture(pendingPhotos.map((photo) => photo.file));
@@ -392,11 +397,8 @@ const PhotoUploadDialogBase = ({
 		}
 	};
 
-	const cameraButtonLabel =
-		photoCount === 0 ? "Open camera" : multiple ? "Camera" : "Retake";
-	const placeholderText = cameraOnly
-		? "Camera is required for this photo."
-		: "Open the camera or pick from your device.";
+	// Only ever rendered with a shot already in hand — the empty state has its own button.
+	const cameraButtonLabel = multiple ? "Camera" : "Retake";
 	const hasNote = note.trim().length > 0;
 
 	return (
@@ -471,9 +473,13 @@ const PhotoUploadDialogBase = ({
 							onIndexChange={handleIndexChange}
 						/>
 					) : (
-						<div className="flex size-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-white/70">
-							<CameraIcon className="size-10 opacity-60" />
-							<p>{placeholderText}</p>
+						// No sentence: the two buttons below already say what they do, and saying it
+						// twice put a second focal point in the middle of an otherwise empty screen.
+						<div className="grid size-full place-items-center">
+							<CameraIcon
+								className="size-10 text-white/40"
+								aria-hidden="true"
+							/>
 						</div>
 					)}
 
@@ -538,21 +544,27 @@ const PhotoUploadDialogBase = ({
 							</button>
 
 							{/* Finish the batch from where a document scanner puts it: bottom-right,
-							    beside the shot count, both a thumb's width from the shutter. The
-							    picker gives up the slot once a shot exists — mid-batch gallery picks
-							    are rare, and it is still one tap away behind the review square. */}
+							    beside the shot count, both a thumb's width from the shutter. Squared
+							    off rather than round, so a white circle beside the shutter is never
+							    mistaken for a second one. The picker gives up the slot once a shot
+							    exists — mid-batch gallery picks are rare, and it is still one tap
+							    behind the review square. */}
 							<div className="justify-self-end">
 								{photoCount > 0 ? (
-									<Button
-										className="h-12 bg-white px-4 font-semibold text-black hover:bg-white/90"
+									<button
+										aria-label={confirmAriaLabel}
+										className="grid size-14 place-items-center bg-white text-black transition hover:bg-white/90 disabled:opacity-40"
 										disabled={isBusy}
-										loading={isBusy}
 										onClick={handleConfirm}
 										type="button"
 									>
-										{confirmLabel}
-									</Button>
-								) : cameraOnly ? null : (
+										{isBusy ? (
+											<CircleNotchIcon className="size-6 animate-spin" />
+										) : (
+											<CheckIcon className="size-7" aria-hidden="true" />
+										)}
+									</button>
+								) : (
 									<button
 										aria-label="Upload from device"
 										className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
@@ -564,6 +576,31 @@ const PhotoUploadDialogBase = ({
 									</button>
 								)}
 							</div>
+						</div>
+					) : photoCount === 0 ? (
+						// Nothing captured yet, so there is only one thing to do: the camera takes the
+						// width and the fill that the confirm button takes once there is something to
+						// confirm, and the picker sits beside it as the exception it is.
+						<div className="flex h-14 items-center gap-2">
+							<button
+								className="flex h-14 flex-1 items-center justify-center gap-2 bg-white font-semibold text-base text-black transition hover:bg-white/90 disabled:opacity-40"
+								disabled={isBusy}
+								onClick={() => void openCamera()}
+								type="button"
+							>
+								<CameraIcon className="size-5" aria-hidden="true" />
+								Open camera
+							</button>
+
+							<button
+								aria-label="Upload from device"
+								className="grid size-14 place-items-center border border-white/30 bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+								disabled={isBusy}
+								onClick={openFileInput}
+								type="button"
+							>
+								<ImageSquareIcon className="size-6" aria-hidden="true" />
+							</button>
 						</div>
 					) : (
 						<>
@@ -578,19 +615,17 @@ const PhotoUploadDialogBase = ({
 									{cameraButtonLabel}
 								</button>
 
-								{cameraOnly ? null : (
-									<button
-										aria-label="Upload from device"
-										className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
-										disabled={isBusy}
-										onClick={openFileInput}
-										type="button"
-									>
-										<ImageSquareIcon className="size-5" aria-hidden="true" />
-									</button>
-								)}
+								<button
+									aria-label="Upload from device"
+									className="grid size-12 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+									disabled={isBusy}
+									onClick={openFileInput}
+									type="button"
+								>
+									<ImageSquareIcon className="size-5" aria-hidden="true" />
+								</button>
 
-								{withNote && photoCount > 0 ? (
+								{withNote ? (
 									<button
 										aria-expanded={isNoteOpen}
 										aria-label={isNoteOpen ? "Hide note" : "Add note"}
@@ -658,26 +693,24 @@ const PhotoUploadDialogBase = ({
 						</>
 					)}
 
-					{cameraOnly ? null : (
-						<input
-							ref={fileInputRef}
-							type="file"
-							aria-label={`Choose ${photoNoun}${labelSuffix}`}
-							accept={ACCEPTED_IMAGE_TYPES.join(",")}
-							multiple={multiple}
-							className="sr-only"
-							onChange={(event) => {
-								const files = Array.from(event.target.files ?? []);
-								// A gallery pick used to land behind a still-running viewfinder, so the
-								// photo the cashier just chose was nowhere on screen. Cancelling the
-								// picker (no files) must leave the camera alone.
-								if (files.length > 0) {
-									stopCamera();
-								}
-								void addFiles(files);
-							}}
-						/>
-					)}
+					<input
+						ref={fileInputRef}
+						type="file"
+						aria-label={`Choose ${photoNoun}${labelSuffix}`}
+						accept={ACCEPTED_IMAGE_TYPES.join(",")}
+						multiple={multiple}
+						className="sr-only"
+						onChange={(event) => {
+							const files = Array.from(event.target.files ?? []);
+							// A gallery pick used to land behind a still-running viewfinder, so the
+							// photo the cashier just chose was nowhere on screen. Cancelling the
+							// picker (no files) must leave the camera alone.
+							if (files.length > 0) {
+								stopCamera();
+							}
+							void addFiles(files);
+						}}
+					/>
 				</div>
 			</DialogContent>
 		</Dialog>
@@ -699,7 +732,7 @@ export const SinglePhotoUploadDialog = (props: PhotoUploadDialogProps) => (
 
 type SinglePhotoCaptureDialogProps = Pick<
 	PhotoUploadDialogBaseProps,
-	"open" | "onOpenChange" | "title" | "badgeLabel" | "cameraOnly"
+	"open" | "onOpenChange" | "title" | "badgeLabel" | "autoOpenCamera"
 > & {
 	onCapture: (file: File) => void;
 };
@@ -709,21 +742,21 @@ type SinglePhotoCaptureDialogProps = Pick<
 // flows where the target row does not exist yet (POS drop-off photo before
 // checkout) or where the upload is bundled with other data (pickup event).
 //
-// Defaults to camera-only: drop-off is an intake action, so we want a live photo
-// of the items in front of the cashier, not a gallery pick. Trade-off: a device
-// with no camera (or denied permission) cannot complete it — accepted, since the
-// POS runs on store iPads. Pass cameraOnly={false} for flows that should still
-// allow a gallery pick (e.g. pickup).
+// Opens on the viewfinder by default: drop-off is an intake action, so a live
+// photo of the items in front of the cashier is the expected answer. It is no
+// longer the only one — a store whose iPad camera is refused or broken can still
+// finish the drop-off from the gallery. Pass autoOpenCamera={false} for flows
+// that should land on the chooser instead (e.g. pickup).
 export const SinglePhotoCaptureDialog = ({
 	onCapture,
-	cameraOnly = true,
+	autoOpenCamera = true,
 	...props
 }: SinglePhotoCaptureDialogProps) => (
 	<PhotoUploadDialogBase
 		{...props}
 		multiple={false}
 		withNote={false}
-		cameraOnly={cameraOnly}
+		autoOpenCamera={autoOpenCamera}
 		onCapture={(files) => {
 			const [file] = files;
 			if (file) {

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -373,7 +373,7 @@ export function QueueServiceDetail({
 					open={isPhotoDialogOpen}
 					onOpenChange={setIsPhotoDialogOpen}
 					title="Add item photo"
-					badgeLabel={selectedService.item_code ?? `Service #${serviceId}`}
+					badgeLabel={selectedService.item_code ?? undefined}
 					uploader={orderServicePhotoUploader(orderId, serviceId)}
 					onUploaded={async () => {
 						await refreshData(detail.store?.id);

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -344,7 +344,7 @@ export function QueueServiceDetail({
 							title={`Photos for ${selectedService.item_code ?? `service-${selectedService.id}`}`}
 							emptyState={
 								needsPhotoToStart ? (
-									<div className="col-span-full flex items-start gap-2.5 border border-dashed border-warning/50 bg-warning/10 px-4 py-6 text-sm">
+									<div className="flex items-start gap-2.5 border border-dashed border-warning/50 bg-warning/10 px-4 py-6 text-sm">
 										<WarningCircleIcon
 											aria-hidden="true"
 											className="mt-0.5 size-4 shrink-0 text-warning"
@@ -360,7 +360,7 @@ export function QueueServiceDetail({
 										</div>
 									</div>
 								) : (
-									<p className="col-span-full border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+									<p className="border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
 										No photos.
 									</p>
 								)

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -21,7 +21,7 @@ import { OrderPhotoGallery } from "@/features/orders/components/order-photo-gall
 import { PhotoUploadDialog } from "@/features/orders/components/photo-upload-dialog";
 import { StatusTimeline } from "@/features/orders/components/status-timeline";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
-import { uploadOrderServicePhoto } from "@/features/orders/utils/photo-upload";
+import { orderServicePhotoUploader } from "@/features/orders/utils/photo-upload";
 import {
 	queryKeys,
 	type UpdateOrderServiceStatusPayload,
@@ -374,9 +374,7 @@ export function QueueServiceDetail({
 					onOpenChange={setIsPhotoDialogOpen}
 					title="Add item photo"
 					badgeLabel={selectedService.item_code ?? `Service #${serviceId}`}
-					uploadPhoto={(input) =>
-						uploadOrderServicePhoto(orderId, serviceId, input)
-					}
+					uploader={orderServicePhotoUploader(orderId, serviceId)}
 					onUploaded={async () => {
 						await refreshData(detail.store?.id);
 					}}

--- a/apps/web/src/features/orders/hooks/useCameraCapture.ts
+++ b/apps/web/src/features/orders/hooks/useCameraCapture.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { MAX_UPLOAD_DIMENSION } from "@/features/orders/utils/normalize-image";
 
 const waitForVideoReady = (video: HTMLVideoElement) =>
 	new Promise<void>((resolve, reject) => {
@@ -80,8 +81,15 @@ export const useCameraCapture = (): UseCameraCaptureResult => {
 		}
 
 		try {
+			// Unconstrained negotiation settles on 640x480, useless for proving a 5mm
+			// stain was already there. ideal (not exact) degrades on cheap Androids
+			// instead of refusing to open the camera.
 			const nextStream = await navigator.mediaDevices.getUserMedia({
-				video: { facingMode: { ideal: "environment" } },
+				video: {
+					facingMode: { ideal: "environment" },
+					width: { ideal: 2560 },
+					height: { ideal: 2560 },
+				},
 				audio: false,
 			});
 
@@ -164,9 +172,17 @@ export const useCameraCapture = (): UseCameraCaptureResult => {
 			sourceY = Math.round((frameHeight - sourceHeight) / 2);
 		}
 
+		// A 4K-capable phone hands back a frame well past what the server keeps, and letting
+		// the normalize step shrink it would cost a second JPEG generation before the WebP
+		// one — three lossy passes over the faint mark a dispute turns on. Scale here so the
+		// shot is already in budget and goes up re-encoded exactly once.
+		const outputScale = Math.min(
+			1,
+			MAX_UPLOAD_DIMENSION / Math.max(sourceWidth, sourceHeight),
+		);
 		const canvas = document.createElement("canvas");
-		canvas.width = sourceWidth;
-		canvas.height = sourceHeight;
+		canvas.width = Math.round(sourceWidth * outputScale);
+		canvas.height = Math.round(sourceHeight * outputScale);
 
 		const context = canvas.getContext("2d");
 		if (!context) {
@@ -182,8 +198,8 @@ export const useCameraCapture = (): UseCameraCaptureResult => {
 			sourceHeight,
 			0,
 			0,
-			sourceWidth,
-			sourceHeight,
+			canvas.width,
+			canvas.height,
 		);
 		const blob = await new Promise<Blob | null>((resolve) => {
 			canvas.toBlob(resolve, "image/jpeg", 0.92);

--- a/apps/web/src/features/orders/hooks/useCameraCapture.ts
+++ b/apps/web/src/features/orders/hooks/useCameraCapture.ts
@@ -143,46 +143,30 @@ export const useCameraCapture = (): UseCameraCaptureResult => {
 			return null;
 		}
 
-		if (video.videoWidth === 0 || video.videoHeight === 0) {
+		const frameWidth = video.videoWidth;
+		const frameHeight = video.videoHeight;
+		if (frameWidth === 0 || frameHeight === 0) {
 			setError("Camera preview is not ready yet.");
 			return null;
 		}
 
-		// Crop the captured frame to the region the object-cover preview actually
-		// showed, so the saved photo matches what the user framed (WYSIWYG) instead
-		// of the full sensor frame that object-cover hid behind the viewfinder edges.
-		const frameWidth = video.videoWidth;
-		const frameHeight = video.videoHeight;
-		const boxWidth = video.clientWidth || frameWidth;
-		const boxHeight = video.clientHeight || frameHeight;
-		const frameAspect = frameWidth / frameHeight;
-		const boxAspect = boxWidth / boxHeight;
-
-		let sourceX = 0;
-		let sourceY = 0;
-		let sourceWidth = frameWidth;
-		let sourceHeight = frameHeight;
-		if (frameAspect > boxAspect) {
-			// Frame wider than the viewfinder → its sides were cropped off.
-			sourceWidth = Math.round(frameHeight * boxAspect);
-			sourceX = Math.round((frameWidth - sourceWidth) / 2);
-		} else {
-			// Frame taller than the viewfinder → its top and bottom were cropped off.
-			sourceHeight = Math.round(frameWidth / boxAspect);
-			sourceY = Math.round((frameHeight - sourceHeight) / 2);
-		}
-
+		// Keep the whole sensor frame rather than the slice the viewfinder box happened to
+		// show. Cropping to the box was WYSIWYG, but a portrait viewfinder over a landscape
+		// track threw away a fifth of the width — exactly the pixels a whole-garment frame
+		// needs for a 5mm stain to read as a mark. The preview uses object-contain so this
+		// stays honest: the letterboxed feed is the frame that gets saved.
+		//
 		// A 4K-capable phone hands back a frame well past what the server keeps, and letting
 		// the normalize step shrink it would cost a second JPEG generation before the WebP
 		// one — three lossy passes over the faint mark a dispute turns on. Scale here so the
 		// shot is already in budget and goes up re-encoded exactly once.
 		const outputScale = Math.min(
 			1,
-			MAX_UPLOAD_DIMENSION / Math.max(sourceWidth, sourceHeight),
+			MAX_UPLOAD_DIMENSION / Math.max(frameWidth, frameHeight),
 		);
 		const canvas = document.createElement("canvas");
-		canvas.width = Math.round(sourceWidth * outputScale);
-		canvas.height = Math.round(sourceHeight * outputScale);
+		canvas.width = Math.round(frameWidth * outputScale);
+		canvas.height = Math.round(frameHeight * outputScale);
 
 		const context = canvas.getContext("2d");
 		if (!context) {
@@ -190,17 +174,7 @@ export const useCameraCapture = (): UseCameraCaptureResult => {
 			return null;
 		}
 
-		context.drawImage(
-			video,
-			sourceX,
-			sourceY,
-			sourceWidth,
-			sourceHeight,
-			0,
-			0,
-			canvas.width,
-			canvas.height,
-		);
+		context.drawImage(video, 0, 0, canvas.width, canvas.height);
 		const blob = await new Promise<Blob | null>((resolve) => {
 			canvas.toBlob(resolve, "image/jpeg", 0.92);
 		});

--- a/apps/web/src/features/orders/lib/photo-zoom.test.ts
+++ b/apps/web/src/features/orders/lib/photo-zoom.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "bun:test";
+import {
+	clampOffset,
+	DOUBLE_TAP_SCALE,
+	doubleTapZoom,
+	fittedSize,
+	MAX_SCALE,
+	MIN_SCALE,
+	type Point,
+	panBy,
+	pinchZoom,
+	resetTransform,
+	toCssTransform,
+	type ZoomTransform,
+} from "./photo-zoom";
+
+// Counter phone held upright, and a garment shot that letterboxes into it exactly —
+// the only geometry where the photo has slack on both axes, so a clamp never hides a
+// broken anchor.
+const upright = { height: 800, width: 400 };
+const uprightGarment = { height: 2000, width: 1000 };
+const uprightFitted = fittedSize(upright, uprightGarment);
+
+/** Which spot on the garment sits under a point on the glass, in unzoomed photo pixels. */
+const spotUnderFinger = (transform: ZoomTransform, glass: Point): Point => ({
+	x: (glass.x - transform.offsetX) / transform.scale,
+	y: (glass.y - transform.offsetY) / transform.scale,
+});
+
+const expectSameSpot = (before: Point, after: Point) => {
+	expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1e-9);
+	expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(1e-9);
+};
+
+describe("what the operator sees before touching anything", () => {
+	it("letterboxes a landscape drop-off shot into an upright phone", () => {
+		expect(fittedSize(upright, { height: 3000, width: 4000 })).toEqual({
+			height: 300,
+			width: 400,
+		});
+	});
+
+	it("pillarboxes an upright garment shot into a landscape tablet", () => {
+		expect(
+			fittedSize({ height: 500, width: 900 }, { height: 400, width: 300 }),
+		).toEqual({ height: 500, width: 375 });
+	});
+
+	it("measures nothing until the photo has come down over mobile data", () => {
+		expect(fittedSize(upright, { height: 0, width: 0 })).toEqual({
+			height: 0,
+			width: 0,
+		});
+	});
+});
+
+describe("pinching into the tear", () => {
+	it("leaves the spot the operator pinched under his fingers", () => {
+		const pinch = { x: 60, y: -10 };
+		const before = spotUnderFinger(resetTransform(), pinch);
+
+		const zoomed = pinchZoom(
+			resetTransform(),
+			pinch,
+			3,
+			upright,
+			uprightFitted,
+		);
+
+		expect(zoomed.scale).toBe(3);
+		expectSameSpot(before, spotUnderFinger(zoomed, pinch));
+	});
+
+	it("keeps that spot anchored while he pinches back out to show the whole garment", () => {
+		const deep = pinchZoom(
+			resetTransform(),
+			{ x: 60, y: -10 },
+			4,
+			upright,
+			uprightFitted,
+		);
+		const pinchOut = { x: -20, y: 40 };
+		const before = spotUnderFinger(deep, pinchOut);
+
+		const wider = pinchZoom(deep, pinchOut, 0.5, upright, uprightFitted);
+
+		expect(wider.scale).toBe(2);
+		expectSameSpot(before, spotUnderFinger(wider, pinchOut));
+	});
+
+	it("never shrinks the photo below the fitted view", () => {
+		const squeezed = pinchZoom(
+			resetTransform(),
+			{ x: 80, y: 120 },
+			0.2,
+			upright,
+			uprightFitted,
+		);
+
+		expect(squeezed).toEqual({ offsetX: 0, offsetY: 0, scale: MIN_SCALE });
+	});
+
+	it("holds the photo still under the fingers once it hits the deepest zoom", () => {
+		const deepest = panBy(
+			pinchZoom(
+				resetTransform(),
+				{ x: 0, y: 0 },
+				MAX_SCALE,
+				upright,
+				uprightFitted,
+			),
+			50,
+			-30,
+			upright,
+			uprightFitted,
+		);
+
+		const pushed = pinchZoom(
+			deepest,
+			{ x: 80, y: 120 },
+			3,
+			upright,
+			uprightFitted,
+		);
+
+		expect(pushed.scale).toBe(MAX_SCALE);
+		expect(pushed.offsetX).toBe(deepest.offsetX);
+		expect(pushed.offsetY).toBe(deepest.offsetY);
+	});
+
+	// What the lightbox actually runs per frame: the fingers spread and slide at once, so the
+	// zoom is composed with a pan by the midpoint's own travel.
+	it("carries the tear along with fingers that slide while they spread", () => {
+		const from = { x: 40, y: -30 };
+		const to = { x: 90, y: 10 };
+		const start = resetTransform();
+		const before = spotUnderFinger(start, from);
+
+		const slid = panBy(
+			pinchZoom(start, from, 2, upright, uprightFitted),
+			to.x - from.x,
+			to.y - from.y,
+			upright,
+			uprightFitted,
+		);
+
+		expect(slid.scale).toBe(2);
+		expectSameSpot(before, spotUnderFinger(slid, to));
+	});
+
+	it("ignores the frame where both fingers land on the same pixel", () => {
+		const zoomed = pinchZoom(
+			resetTransform(),
+			{ x: 10, y: 10 },
+			2,
+			upright,
+			uprightFitted,
+		);
+
+		for (const factor of [Number.NaN, Number.POSITIVE_INFINITY, 0, -2]) {
+			expect(
+				pinchZoom(zoomed, { x: 10, y: 10 }, factor, upright, uprightFitted),
+			).toEqual(zoomed);
+		}
+	});
+});
+
+describe("dragging a zoomed photo", () => {
+	it("stops at the edge of an upright garment shot on a landscape screen", () => {
+		const stage = { height: 500, width: 900 };
+		const fitted = fittedSize(stage, { height: 400, width: 300 });
+		const zoomed = pinchZoom(
+			resetTransform(),
+			{ x: 0, y: 0 },
+			2,
+			stage,
+			fitted,
+		);
+
+		expect(panBy(zoomed, -5000, -5000, stage, fitted)).toEqual({
+			offsetX: 0,
+			offsetY: -250,
+			scale: 2,
+		});
+		expect(panBy(zoomed, 5000, 5000, stage, fitted)).toEqual({
+			offsetX: 0,
+			offsetY: 250,
+			scale: 2,
+		});
+	});
+
+	it("stops at the edge of a landscape shot on an upright screen", () => {
+		const stage = { height: 900, width: 400 };
+		const fitted = fittedSize(stage, { height: 2000, width: 4000 });
+		const zoomed = pinchZoom(
+			resetTransform(),
+			{ x: 0, y: 0 },
+			3,
+			stage,
+			fitted,
+		);
+
+		expect(panBy(zoomed, -5000, -5000, stage, fitted)).toEqual({
+			offsetX: -400,
+			offsetY: 0,
+			scale: 3,
+		});
+		expect(panBy(zoomed, 5000, 5000, stage, fitted)).toEqual({
+			offsetX: 400,
+			offsetY: 0,
+			scale: 3,
+		});
+	});
+
+	it("refuses to drag a photo the customer is seeing whole", () => {
+		expect(panBy(resetTransform(), 200, -200, upright, uprightFitted)).toEqual({
+			offsetX: 0,
+			offsetY: 0,
+			scale: MIN_SCALE,
+		});
+	});
+
+	it("pins a photo narrower than the stage to the centre", () => {
+		const stage = { height: 500, width: 900 };
+		const fitted = fittedSize(stage, { height: 400, width: 300 });
+
+		expect(clampOffset(1.2, { x: 40, y: 0 }, stage, fitted).x).toBe(0);
+	});
+});
+
+describe("pinching back out after inspecting a corner", () => {
+	it("pulls the photo back on screen instead of stranding it off the edge", () => {
+		const cornered = panBy(
+			pinchZoom(
+				resetTransform(),
+				{ x: 0, y: 0 },
+				MAX_SCALE,
+				upright,
+				uprightFitted,
+			),
+			5000,
+			5000,
+			upright,
+			uprightFitted,
+		);
+		const deepestCorner = clampOffset(
+			MAX_SCALE,
+			{ x: Number.POSITIVE_INFINITY, y: Number.POSITIVE_INFINITY },
+			upright,
+			uprightFitted,
+		);
+		expect(cornered).toEqual({
+			offsetX: deepestCorner.x,
+			offsetY: deepestCorner.y,
+			scale: MAX_SCALE,
+		});
+
+		const halfwayScale = MAX_SCALE * 0.4;
+		const halfway = pinchZoom(
+			cornered,
+			{ x: 0, y: 0 },
+			0.4,
+			upright,
+			uprightFitted,
+		);
+		const halfwayCorner = clampOffset(
+			halfwayScale,
+			{ x: Number.POSITIVE_INFINITY, y: Number.POSITIVE_INFINITY },
+			upright,
+			uprightFitted,
+		);
+		expect(halfway).toEqual({
+			offsetX: halfwayCorner.x,
+			offsetY: halfwayCorner.y,
+			scale: halfwayScale,
+		});
+
+		const fittedAgain = pinchZoom(
+			halfway,
+			{ x: 0, y: 0 },
+			0.5,
+			upright,
+			uprightFitted,
+		);
+		expect(fittedAgain).toEqual(resetTransform());
+	});
+});
+
+describe("double tap", () => {
+	it("jumps to inspection depth on the spot the operator tapped", () => {
+		const tap = { x: 60, y: -10 };
+		const before = spotUnderFinger(resetTransform(), tap);
+
+		const zoomed = doubleTapZoom(resetTransform(), tap, upright, uprightFitted);
+
+		expect(zoomed.scale).toBe(DOUBLE_TAP_SCALE);
+		// The constant itself has to magnify, or the double tap does nothing and the operator
+		// is left arguing about a mark he cannot show.
+		expect(zoomed.scale).toBeGreaterThan(MIN_SCALE);
+		expectSameSpot(before, spotUnderFinger(zoomed, tap));
+	});
+
+	it("returns to the whole garment on the next double tap", () => {
+		const zoomed = doubleTapZoom(
+			resetTransform(),
+			{ x: 60, y: -10 },
+			upright,
+			uprightFitted,
+		);
+
+		expect(
+			doubleTapZoom(zoomed, { x: -80, y: 200 }, upright, uprightFitted),
+		).toEqual(resetTransform());
+	});
+});
+
+describe("css output", () => {
+	it("translates before scaling, so a drag covers the same distance at every depth", () => {
+		expect(toCssTransform({ offsetX: -90, offsetY: 15, scale: 2.5 })).toBe(
+			"translate(-90px, 15px) scale(2.5)",
+		);
+	});
+});

--- a/apps/web/src/features/orders/lib/photo-zoom.ts
+++ b/apps/web/src/features/orders/lib/photo-zoom.ts
@@ -1,0 +1,129 @@
+export interface Point {
+	x: number;
+	y: number;
+}
+
+export interface Size {
+	height: number;
+	width: number;
+}
+
+/**
+ * Rendered as `transform: translate(offsetX px, offsetY px) scale(scale)` on a box whose
+ * transform-origin is its own centre. In that order the offsets stay in unscaled screen
+ * pixels measured from the stage centre, so dragging a finger 40px shifts the photo 40px
+ * at 1x and at 5x alike.
+ */
+export interface ZoomTransform {
+	offsetX: number;
+	offsetY: number;
+	scale: number;
+}
+
+export const MIN_SCALE = 1;
+
+/**
+ * A 2560px capture on a counter phone already runs out of source pixels around 2.3x, so this
+ * is deliberate headroom past native detail: it lets the operator put a single torn thread
+ * under his finger while the customer watches, not resolve anything new.
+ */
+export const MAX_SCALE = 5;
+
+export const DOUBLE_TAP_SCALE = 2.5;
+
+const clamp = (value: number, min: number, max: number) =>
+	Math.min(Math.max(value, min), max);
+
+const clampAxis = (value: number, limit: number) =>
+	limit === 0 ? 0 : clamp(value, -limit, limit);
+
+export const resetTransform = (): ZoomTransform => ({
+	offsetX: 0,
+	offsetY: 0,
+	scale: MIN_SCALE,
+});
+
+export const toCssTransform = ({ offsetX, offsetY, scale }: ZoomTransform) =>
+	`translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+
+/** The box `object-contain` paints the photo into, before any zoom. */
+export const fittedSize = (viewport: Size, natural: Size): Size => {
+	const ratio = Math.min(
+		viewport.width / natural.width,
+		viewport.height / natural.height,
+	);
+	if (!Number.isFinite(ratio) || ratio <= 0) {
+		return { height: 0, width: 0 };
+	}
+	return { height: natural.height * ratio, width: natural.width * ratio };
+};
+
+export const clampOffset = (
+	scale: number,
+	offset: Point,
+	viewport: Size,
+	fitted: Size,
+): Point => {
+	const limitX = Math.max(0, (fitted.width * scale - viewport.width) / 2);
+	const limitY = Math.max(0, (fitted.height * scale - viewport.height) / 2);
+	return {
+		x: clampAxis(offset.x, limitX),
+		y: clampAxis(offset.y, limitY),
+	};
+};
+
+/** `mid` is the pinch midpoint relative to the stage centre. */
+export const pinchZoom = (
+	prev: ZoomTransform,
+	mid: Point,
+	factor: number,
+	viewport: Size,
+	fitted: Size,
+): ZoomTransform => {
+	if (!Number.isFinite(factor) || factor <= 0) {
+		return prev;
+	}
+
+	const scale = clamp(prev.scale * factor, MIN_SCALE, MAX_SCALE);
+	// Post-clamp ratio: at the zoom stops the photo must sit still under the fingers.
+	const ratio = scale / prev.scale;
+	const offset = clampOffset(
+		scale,
+		{
+			x: mid.x - ratio * (mid.x - prev.offsetX),
+			y: mid.y - ratio * (mid.y - prev.offsetY),
+		},
+		viewport,
+		fitted,
+	);
+
+	return { offsetX: offset.x, offsetY: offset.y, scale };
+};
+
+export const panBy = (
+	prev: ZoomTransform,
+	dx: number,
+	dy: number,
+	viewport: Size,
+	fitted: Size,
+): ZoomTransform => {
+	const offset = clampOffset(
+		prev.scale,
+		{ x: prev.offsetX + dx, y: prev.offsetY + dy },
+		viewport,
+		fitted,
+	);
+	return { offsetX: offset.x, offsetY: offset.y, scale: prev.scale };
+};
+
+export const doubleTapZoom = (
+	prev: ZoomTransform,
+	tap: Point,
+	viewport: Size,
+	fitted: Size,
+): ZoomTransform => {
+	if (prev.scale > MIN_SCALE) {
+		return resetTransform();
+	}
+	return pinchZoom(prev, tap, DOUBLE_TAP_SCALE / prev.scale, viewport, fitted);
+};

--- a/apps/web/src/features/orders/utils/normalize-image.test.ts
+++ b/apps/web/src/features/orders/utils/normalize-image.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_UPLOAD_DIMENSION, normalizeImageFile } from "./normalize-image";
+
+interface CounterPhone {
+	/** null stands for a phone with no codec for what the operator picked. */
+	decodes: { height: number; width: number } | null;
+	encodedAs: string | null;
+	reEncodeTo: Blob | null;
+}
+
+const globals = globalThis as unknown as {
+	createImageBitmap: unknown;
+	document: unknown;
+};
+
+// The test harness has no DOM, so the decode and the canvas the counter phone would use are
+// stood in for here — and handed back after, so no other suite inherits a fake document.
+const onCounterPhone = async (
+	phone: CounterPhone,
+	run: () => Promise<void>,
+) => {
+	const previous = {
+		createImageBitmap: globals.createImageBitmap,
+		document: globals.document,
+	};
+
+	globals.createImageBitmap = async () => {
+		if (!phone.decodes) {
+			throw new Error("undecodable");
+		}
+		return { close: () => undefined, ...phone.decodes };
+	};
+	globals.document = {
+		createElement: () => ({
+			getContext: () => ({ drawImage: () => undefined }),
+			height: 0,
+			toBlob: (callback: (blob: Blob | null) => void, type: string) => {
+				phone.encodedAs = type;
+				callback(phone.reEncodeTo);
+			},
+			width: 0,
+		}),
+	};
+
+	try {
+		await run();
+	} finally {
+		globals.createImageBitmap = previous.createImageBitmap;
+		globals.document = previous.document;
+	}
+};
+
+const counterPhone = (
+	decodes: { height: number; width: number } | null,
+): CounterPhone => ({
+	decodes,
+	encodedAs: null,
+	reEncodeTo: new Blob(["re-encoded"], { type: "image/jpeg" }),
+});
+
+const picked = (name: string, type: string, size: number) =>
+	({ name, size, type }) as File;
+
+const failureOf = async (run: () => Promise<unknown>) => {
+	try {
+		await run();
+	} catch (error) {
+		return error as Error;
+	}
+	return null;
+};
+
+describe("normalizeImageFile", () => {
+	it("sends a full-size camera shot up untouched rather than burning a second lossy generation on the evidence", async () => {
+		const phone = counterPhone({ height: 1920, width: MAX_UPLOAD_DIMENSION });
+		const shot = picked("photo-1754200000000.jpg", "image/jpeg", 2_400_000);
+
+		await onCounterPhone(phone, async () => {
+			expect(await normalizeImageFile(shot)).toBe(shot);
+			expect(phone.encodedAs).toBeNull();
+		});
+	});
+
+	it("scales a 12MP drop-off photo down to the bound the server keeps anyway", async () => {
+		const phone = counterPhone({ height: 3024, width: 4032 });
+
+		await onCounterPhone(phone, async () => {
+			const normalized = await normalizeImageFile(
+				picked("IMG_4821.JPEG", "image/jpeg", 4_000_000),
+			);
+
+			expect(normalized.type).toBe("image/jpeg");
+			expect(normalized.name).toBe("IMG_4821.jpg");
+			expect(phone.encodedAs).toBe("image/jpeg");
+		});
+	});
+
+	it("re-encodes a fat PNG screenshot instead of spending shop 4G on bytes the server discards", async () => {
+		const phone = counterPhone({ height: 1440, width: 2560 });
+
+		await onCounterPhone(phone, async () => {
+			const normalized = await normalizeImageFile(
+				picked("Screenshot 2026.08.03.png", "image/png", 9_000_000),
+			);
+
+			expect(normalized.type).toBe("image/jpeg");
+			expect(normalized.name).toBe("Screenshot 2026.08.03.jpg");
+		});
+	});
+
+	it("converts an iPhone HEIC on the phone that can decode it, so S3 never holds a photo nobody can open", async () => {
+		const phone = counterPhone({ height: 3024, width: 4032 });
+
+		await onCounterPhone(phone, async () => {
+			const normalized = await normalizeImageFile(
+				picked("IMG_0007.HEIC", "image/heic", 1_200_000),
+			);
+
+			expect(normalized.type).toBe("image/jpeg");
+			expect(normalized.name).toBe("IMG_0007.jpg");
+		});
+	});
+
+	it("rejects a HEIC on a phone with no codec for it, where the upload would be unviewable evidence", async () => {
+		await onCounterPhone(counterPhone(null), async () => {
+			const failure = await failureOf(() =>
+				normalizeImageFile(picked("IMG_0007.HEIC", "image/heic", 1_200_000)),
+			);
+
+			expect(failure?.message).toBe("Unsupported image type");
+		});
+	});
+
+	it("reports the canvas giving up separately from an unsupported format", async () => {
+		const phone = counterPhone({ height: 3024, width: 4032 });
+		phone.reEncodeTo = null;
+
+		await onCounterPhone(phone, async () => {
+			const failure = await failureOf(() =>
+				normalizeImageFile(picked("tear.jpg", "image/jpeg", 4_000_000)),
+			);
+
+			expect(failure?.message).toBe("Unable to process this image");
+		});
+	});
+});

--- a/apps/web/src/features/orders/utils/normalize-image.ts
+++ b/apps/web/src/features/orders/utils/normalize-image.ts
@@ -1,0 +1,64 @@
+// Keep in step with MAX_IMAGE_DIMENSION in packages/server/src/utils/s3.ts.
+// Anything larger spends shop-floor 4G on pixels the server discards when it
+// re-encodes the photo.
+export const MAX_UPLOAD_DIMENSION = 2560;
+
+// A PNG screenshot of a garment can be 10MB inside the dimension budget, and the server
+// re-encodes it to a few hundred KB regardless — those bytes are pure shop-floor 4G. Set
+// above what a full-size camera capture weighs at q92, so a live shot still passes through
+// instead of paying a second lossy generation to get under a byte limit.
+const MAX_PASSTHROUGH_BYTES = 4_000_000;
+
+const PASSTHROUGH_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+const FILE_EXTENSION = /\.[^.]*$/;
+
+export const normalizeImageFile = async (file: File): Promise<File> => {
+	// iPhones hand over HEIC and only their own OS codec decodes it — that decode
+	// happens here. Everywhere else this throws, which is the correct rejection:
+	// the server cannot decode HEIC and other browsers show it as a broken image,
+	// so the evidence would be gone by the time a customer disputes a tear.
+	let bitmap: ImageBitmap;
+	try {
+		bitmap = await createImageBitmap(file);
+	} catch {
+		throw new Error("Unsupported image type");
+	}
+
+	try {
+		const longEdge = Math.max(bitmap.width, bitmap.height);
+		if (
+			longEdge <= MAX_UPLOAD_DIMENSION &&
+			file.size <= MAX_PASSTHROUGH_BYTES &&
+			PASSTHROUGH_TYPES.includes(file.type)
+		) {
+			// Already in budget — re-encoding would burn a second lossy generation on
+			// the photo that has to hold up in a dispute.
+			return file;
+		}
+
+		const scale = Math.min(1, MAX_UPLOAD_DIMENSION / longEdge);
+		const canvas = document.createElement("canvas");
+		canvas.width = Math.round(bitmap.width * scale);
+		canvas.height = Math.round(bitmap.height * scale);
+
+		const context = canvas.getContext("2d");
+		if (!context) {
+			throw new Error("Unable to process this image");
+		}
+
+		context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+		const blob = await new Promise<Blob | null>((resolve) => {
+			canvas.toBlob(resolve, "image/jpeg", 0.92);
+		});
+		if (!blob) {
+			throw new Error("Unable to process this image");
+		}
+
+		return new File([blob], `${file.name.replace(FILE_EXTENSION, "")}.jpg`, {
+			type: "image/jpeg",
+		});
+	} finally {
+		bitmap.close();
+	}
+};

--- a/apps/web/src/features/orders/utils/photo-upload.ts
+++ b/apps/web/src/features/orders/utils/photo-upload.ts
@@ -22,28 +22,58 @@ export interface UploadPhotoInput {
 	note?: string;
 }
 
-export const uploadOrderServicePhoto = async (
+/**
+ * Uploading a photo is two jobs with very different costs, so a batch needs them apart.
+ * `pushBytes` is the slow one — a presign plus the file itself over shop 4G. `commit` is a
+ * small request the server answers only after it has re-encoded the image, and it decides
+ * the row id the gallery sorts on. Keeping them separate lets a caller push the next
+ * photo's bytes while the server is still working on the current one, without letting two
+ * commits race and shuffle a before/after pair.
+ */
+export interface PhotoUploader {
+	commit: (key: string, input: UploadPhotoInput) => Promise<void>;
+	pushBytes: (input: UploadPhotoInput) => Promise<string>;
+}
+
+export const orderServicePhotoUploader = (
 	orderId: number,
 	serviceId: number,
-	{ file, contentType, note }: UploadPhotoInput,
-) => {
-	const presigned = await presignOrderServicePhoto(orderId, serviceId, {
-		content_type: contentType,
-	});
-	await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
-	await saveOrderServicePhoto(orderId, serviceId, {
-		image_path: presigned.key,
-		note,
-	});
-};
+): PhotoUploader => ({
+	pushBytes: async ({ file, contentType }) => {
+		const presigned = await presignOrderServicePhoto(orderId, serviceId, {
+			content_type: contentType,
+		});
+		await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
+		return presigned.key;
+	},
+	commit: async (key, { note }) => {
+		await saveOrderServicePhoto(orderId, serviceId, {
+			image_path: key,
+			note,
+		});
+	},
+});
 
+export const orderDropoffPhotoUploader = (orderId: number): PhotoUploader => ({
+	pushBytes: async ({ file, contentType }) => {
+		const presigned = await presignOrderDropoffPhoto(orderId, {
+			content_type: contentType,
+		});
+		await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
+		return presigned.key;
+	},
+	commit: async (key) => {
+		await saveOrderDropoffPhoto(orderId, { image_path: key });
+	},
+});
+
+// The drop-off photo is a single column on the order, so it is always one photo and the
+// POS uploads it straight after checkout rather than through the dialog.
 export const uploadOrderDropoffPhoto = async (
 	orderId: number,
-	{ file, contentType }: UploadPhotoInput,
+	input: UploadPhotoInput,
 ) => {
-	const presigned = await presignOrderDropoffPhoto(orderId, {
-		content_type: contentType,
-	});
-	await uploadFileToPresignedUrl(presigned.upload_url, file, contentType);
-	await saveOrderDropoffPhoto(orderId, { image_path: presigned.key });
+	const uploader = orderDropoffPhotoUploader(orderId);
+	const key = await uploader.pushBytes(input);
+	await uploader.commit(key, input);
 };

--- a/apps/web/src/features/orders/utils/photo-upload.ts
+++ b/apps/web/src/features/orders/utils/photo-upload.ts
@@ -11,7 +11,6 @@ export const ACCEPTED_IMAGE_TYPES: readonly PhotoContentType[] = [
 	"image/jpeg",
 	"image/png",
 	"image/webp",
-	"image/heic",
 ];
 
 export const isAcceptedImage = (value: string): value is PhotoContentType =>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -408,11 +408,7 @@ export type UpdateOrderCourierPayload = {
 	collected_by: number | null;
 };
 
-export type PhotoContentType =
-	| "image/jpeg"
-	| "image/png"
-	| "image/webp"
-	| "image/heic";
+export type PhotoContentType = "image/jpeg" | "image/png" | "image/webp";
 
 export type PresignOrderServicePhotoPayload = {
 	content_type: PhotoContentType;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
 		react(),
 		tailwindcss(),
 	],
+	server: {
+		allowedHosts: ["4961-103-165-128-11.ngrok-free.app"],
+	},
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),

--- a/packages/server/src/modules/orders/order-admin.schema.test.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { POSTOrderServicePhotoPresignSchema } from "@/modules/orders/order-admin.schema";
+
+describe("POSTOrderServicePhotoPresignSchema", () => {
+  it("rejects HEIC now that the counter phone converts before upload", () => {
+    // An accepted HEIC used to reach the bucket unconverted and open as a
+    // broken image when the operator pulled it up against a damage claim.
+    expect(
+      POSTOrderServicePhotoPresignSchema.safeParse({
+        content_type: "image/heic",
+      }).success
+    ).toBe(false);
+  });
+
+  it("accepts what the counter phone actually uploads", () => {
+    for (const content_type of ["image/jpeg", "image/png", "image/webp"]) {
+      expect(
+        POSTOrderServicePhotoPresignSchema.safeParse({ content_type }).success
+      ).toBe(true);
+    }
+  });
+
+  it("tolerates padding a phone browser adds to the content type header", () => {
+    expect(
+      POSTOrderServicePhotoPresignSchema.parse({
+        content_type: " image/jpeg ",
+      })
+    ).toEqual({ content_type: "image/jpeg" });
+  });
+});

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -30,8 +30,7 @@ const photoContentTypeSchema = z
   .string()
   .trim()
   .refine(
-    (value) =>
-      ["image/jpeg", "image/png", "image/webp", "image/heic"].includes(value),
+    (value) => ["image/jpeg", "image/png", "image/webp"].includes(value),
     "Unsupported content type"
   );
 

--- a/packages/server/src/utils/s3.test.ts
+++ b/packages/server/src/utils/s3.test.ts
@@ -1,0 +1,139 @@
+// Guards the two promises the damage-audit evidence rests on: a stored photo
+// key resolves to a link an operator can open mid-dispute, and nothing but
+// browser-renderable WebP survives the upload path.
+
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { s3 } from "bun";
+import { BadRequestException } from "@/errors";
+import { buildMediaUrl, optimizeUploadedImage } from "@/utils/s3";
+
+describe("buildMediaUrl", () => {
+  const originalBase = process.env.CDN_BASE_URL;
+
+  afterEach(() => {
+    if (originalBase === undefined) {
+      delete process.env.CDN_BASE_URL;
+    } else {
+      process.env.CDN_BASE_URL = originalBase;
+    }
+  });
+
+  it("turns a stored key into a link the counter phone can open during a dispute", () => {
+    process.env.CDN_BASE_URL = "https://cdn.fresclean.id";
+    expect(buildMediaUrl("orders/812/dropoff.webp")).toBe(
+      "https://cdn.fresclean.id/orders/812/dropoff.webp"
+    );
+  });
+
+  it("does not double the slash when the stored key starts with one", () => {
+    process.env.CDN_BASE_URL = "https://cdn.fresclean.id/";
+    expect(buildMediaUrl("/orders/812/dropoff.webp")).toBe(
+      "https://cdn.fresclean.id/orders/812/dropoff.webp"
+    );
+  });
+
+  it("returns null for a garment with no drop-off photo on file", () => {
+    expect(buildMediaUrl(null)).toBeNull();
+    expect(buildMediaUrl(undefined)).toBeNull();
+  });
+
+  it("fails loudly on a misconfigured deploy instead of serving broken photo links", () => {
+    delete process.env.CDN_BASE_URL;
+    expect(() => buildMediaUrl("orders/812/dropoff.webp")).toThrow(
+      "Missing CDN_BASE_URL configuration"
+    );
+  });
+});
+
+interface StubbedUpload {
+  resize: unknown[];
+  webp: unknown[];
+  written: { bytes: Uint8Array; options: unknown }[];
+}
+
+/** Stands in for the object the counter phone just PUT to its presigned URL. */
+const stubUpload = (decode: () => Uint8Array) => {
+  const calls: StubbedUpload = { resize: [], webp: [], written: [] };
+  const spy = spyOn(s3, "file").mockReturnValue({
+    image: () => ({
+      resize: (...resizeArgs: unknown[]) => {
+        calls.resize = resizeArgs;
+        return {
+          webp: (...webpArgs: unknown[]) => {
+            calls.webp = webpArgs;
+            return { bytes: async () => decode() };
+          },
+        };
+      },
+    }),
+    write: (bytes: Uint8Array, options: unknown) => {
+      calls.written.push({ bytes, options });
+      return Promise.resolve(bytes.byteLength);
+    },
+  } as never);
+
+  return { calls, restore: () => spy.mockRestore() };
+};
+
+const imageFailure = (code: string) => Object.assign(new Error(code), { code });
+
+describe("optimizeUploadedImage", () => {
+  let restore = () => {
+    // replaced per test
+  };
+
+  afterEach(() => restore());
+
+  it("replaces the drop-off photo with WebP the customer's dispute can be argued from on any phone", async () => {
+    const optimized = new Uint8Array([1, 2, 3]);
+    const { calls, restore: undo } = stubUpload(() => optimized);
+    restore = undo;
+
+    await optimizeUploadedImage("orders/812/dropoff.jpg");
+
+    expect(calls.resize).toEqual([
+      2560,
+      2560,
+      { fit: "inside", withoutEnlargement: true },
+    ]);
+    expect(calls.webp).toEqual([{ quality: 85 }]);
+    expect(calls.written).toEqual([
+      { bytes: optimized, options: { type: "image/webp" } },
+    ]);
+  });
+
+  it("rejects a HEIC that slipped past the counter phone instead of keeping evidence nobody can open", async () => {
+    const { calls, restore: undo } = stubUpload(() => {
+      throw imageFailure("ERR_IMAGE_FORMAT_UNSUPPORTED");
+    });
+    restore = undo;
+
+    await expect(
+      optimizeUploadedImage("orders/812/dropoff.heic")
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(calls.written).toHaveLength(0);
+  });
+
+  it("rejects a photo truncated by a dropped 4G upload", async () => {
+    const { restore: undo } = stubUpload(() => {
+      throw imageFailure("ERR_IMAGE_DECODE_FAILED");
+    });
+    restore = undo;
+
+    await expect(
+      optimizeUploadedImage("orders/812/services/9/tear.jpg")
+    ).rejects.toThrow("Uploaded file is not a valid image");
+  });
+
+  it("surfaces an S3 outage as an outage, not as the operator's photo being bad", async () => {
+    const outage = new Error("socket hang up");
+    const { restore: undo } = stubUpload(() => {
+      throw outage;
+    });
+    restore = undo;
+
+    await expect(optimizeUploadedImage("orders/812/dropoff.jpg")).rejects.toBe(
+      outage
+    );
+  });
+});

--- a/packages/server/src/utils/s3.ts
+++ b/packages/server/src/utils/s3.ts
@@ -2,8 +2,15 @@ import { s3 } from "bun";
 import { BadRequestException } from "@/errors";
 
 const DEFAULT_PRESIGNED_EXPIRES_SECONDS = 300;
-const MAX_IMAGE_DIMENSION = 1600;
-const WEBP_QUALITY = 80;
+// 2560 on the long edge keeps a 5mm stain reading as a mark rather than a smudge across a
+// whole-garment frame when a customer disputes the damage; q80 smoothed away exactly the
+// faint low-contrast discoloration those disputes turn on. The counter app already scales
+// its uploads to the same bound (MAX_UPLOAD_DIMENSION in apps/web normalize-image.ts), so
+// the resize below only bites on bytes that skipped it — a counter phone still running a
+// stale bundle, or anything else PUTting to a presigned URL. Raise one bound without the
+// other and they stop matching.
+const MAX_IMAGE_DIMENSION = 2560;
+const WEBP_QUALITY = 85;
 
 export function buildMediaUrl(path: string): string;
 export function buildMediaUrl(path: null | undefined): null;
@@ -60,13 +67,14 @@ export async function optimizeUploadedImage(key: string): Promise<void> {
       .webp({ quality: WEBP_QUALITY })
       .bytes();
   } catch (error) {
-    const code = (error as { code?: string }).code;
-    // Format Bun can't decode on this platform (e.g. HEIC) — keep the original.
-    if (code === "ERR_IMAGE_FORMAT_UNSUPPORTED") {
-      return;
-    }
-    // Any other image error means the upload isn't a usable image.
-    if (code?.startsWith("ERR_IMAGE_")) {
+    // Every stored object has to be browser-renderable WebP. Keeping an
+    // undecodable original instead meant a drop-off photo opened as a broken
+    // image for every operator not on Safari — the evidence was silently gone
+    // by the time a customer claimed the tear was ours. Note HEIC only reaches
+    // this branch where no OS codec exists, which is the Linux container we
+    // deploy to: the same upload converts fine on a macOS dev machine via
+    // ImageIO, so a local success is not evidence HEIC is safe to accept again.
+    if ((error as { code?: string }).code?.startsWith("ERR_IMAGE_")) {
       throw new BadRequestException("Uploaded file is not a valid image");
     }
     // S3/network/other infra fault — propagate, don't mislabel as a bad image.


### PR DESCRIPTION
Drop-off photos are dispute evidence — an operator pulls one up to show a customer a tear was already there. Three links in that chain capped what could actually be shown, and fixing only one would have been inert.

## What changed

| Link | Before | After |
|---|---|---|
| Capture | no resolution constraint → track negotiated at 640×480 | `width`/`height: { ideal: 2560 }` |
| Display | fit-to-screen, no zoom — stored detail unreachable | pinch, pan, double-tap |
| Store | 1600px / WebP q80 | 2560px / WebP q85 |
| Upload | 6MB raw PUT, then re-downloaded by the API | normalized to a 2560px JPEG in-browser first |

`ideal` rather than `exact` so a cheap Android degrades to its best mode instead of failing to open the camera at all.

Zoom geometry lives in `photo-zoom.ts` as pure functions (anchor-preserving pinch, offset clamping, fitted size) so the maths is testable; the component holds only pointer plumbing. Swipe-to-navigate is preserved at 1x and suppressed while zoomed.

Client normalization short-circuits when a photo is already within the dimension, byte, and type budget, so a live camera shot is encoded exactly once before the server's WebP pass — evidence never pays a second lossy generation.

## HEIC is no longer accepted

iOS decodes HEIC via the OS codec during normalization, so it now reaches the server as JPEG. The accepted-type list drops `image/heic` on both sides, and `optimizeUploadedImage` no longer keeps an undecodable original.

That old keep-the-original path was silently destructive: the container cannot decode HEIC and no browser but Safari renders it, so the photo was stored but opened as a broken image for most operators — the evidence was gone by the time anyone needed it.

**Deploy web at or before server.** A counter phone on a cached older bundle still presigns `image/heic` and will now get a 400.

**Pre-existing HEIC objects are not backfilled.** Anything already in the bucket from the old path stays unviewable; worth counting separately.

## Verification

`packages/server` 259 pass · `apps/web` 70 pass · both type-checks clean · `ultracite check` clean.

Pinch was verified in a real browser under touch emulation (iPhone-14 viewport, dpr 3, simultaneous multi-touch confirmed at the event level), not just unit-tested. Ten behaviours checked: first-open pinch, anchor invariance, pan clamping at the photo edge, one-finger-lift with no jump, swipe at 1x, pan-not-navigate while zoomed, double-tap round-trip, buttons still firing, zoom reset on navigation, and no page-level zoom or scroll.

That pass caught a blocker the unit tests could not: gesture listeners never attached on a freshly opened lightbox, because Base UI mounts the popup in a later commit and `surfaceRef.current` was still null when the effect ran. The zoom maths was correct and the feature was simply inert. Fixed by holding the surface node in state so it becomes an effect dependency, then confirmed with a negative control — reverting the fix reproduces the dead pinch, restoring it makes it live.

## Known limits, not addressed here

**Whole-garment frames still fall short of the resolution the constant implies.** `capture()` crops WYSIWYG to the viewfinder box *before* scaling, so a portrait viewfinder over a landscape sensor stores ~990×1440 rather than 2560. A 5mm stain now reads clearly in a ~20cm close-up on any device above 720p (3.7–8.8 px/mm) but not in a ~70cm whole-garment frame on any phone (1.06–2.51 px/mm against a ~3 px/mm threshold). Still a 3–4.5× linear gain over the old 330×480. Switching the viewfinder to `object-contain` and dropping the crop would buy ~2.6× more and preserve WYSIWYG honestly, at the cost of a letterboxed preview — a product call, left out deliberately.

**Serving 2560px WebP into 480px gallery thumbnails** is now 2.6× the bytes on the gallery path. Pre-existing behaviour, but it compounds per order; wants a thumbnail derivative and a backfill as its own change.

**A failed decode orphans the uploaded S3 object** — the phone has already PUT the bytes when `optimizeUploadedImage` throws, and no row is created. Reachable before this change, more reachable now that HEIC lands there. No cleanup path exists.