### PR TITLE
fix: re-arm the order money constraints, name the whole-rupiah rule

### DIFF
--- a/apps/web/src/features/orders/components/order-line-items-card.tsx
+++ b/apps/web/src/features/orders/components/order-line-items-card.tsx
@@ -6,7 +6,7 @@ import { OrderSectionHeader } from "@/features/orders/components/order-section-h
 import { OrderServiceRow } from "@/features/orders/components/order-service-row";
 import type { OrderDetail, OrderRefundReason } from "@/lib/api";
 import { formatCancelReason, formatRefundReason } from "@/lib/status";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney } from "@/shared/money";
 
 type OrderDetailProduct = OrderDetail["products"][number];
 
@@ -37,11 +37,11 @@ const ProductLine = ({
 					) : null}
 				</div>
 				<p className="text-muted-foreground text-xs tabular-nums">
-					{formatIDRCurrency(String(product.price ?? 0))} × {product.qty}
+					{formatMoney(product.price)} × {product.qty}
 				</p>
 			</div>
 			<p className="shrink-0 font-mono text-sm tabular-nums">
-				{formatIDRCurrency(String(product.subtotal ?? 0))}
+				{formatMoney(product.subtotal)}
 			</p>
 		</div>
 

--- a/apps/web/src/features/orders/components/order-money-summary.tsx
+++ b/apps/web/src/features/orders/components/order-money-summary.tsx
@@ -1,23 +1,23 @@
 import { Separator } from "@/components/ui/separator";
 import type { OrderDetail } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney, parseMoney } from "@/shared/money";
 
 interface OrderMoneySummaryProps {
 	detail: OrderDetail;
 }
 
 export const OrderMoneySummary = ({ detail }: OrderMoneySummaryProps) => {
-	const discount = Number(detail.discount ?? 0);
-	const net = Number(detail.total ?? 0) - discount;
-	const refunded = Number(detail.refunded_amount ?? 0);
+	const discount = parseMoney(detail.discount);
+	const net = parseMoney(detail.total) - discount;
+	const refunded = parseMoney(detail.refunded_amount);
 
 	const servicesSubtotal = detail.services.reduce(
-		(sum, service) => sum + Number(service.subtotal ?? 0),
+		(sum, service) => sum + parseMoney(service.subtotal),
 		0,
 	);
 	const productsSubtotal = detail.products.reduce(
-		(sum, product) => sum + Number(product.subtotal ?? 0),
+		(sum, product) => sum + parseMoney(product.subtotal),
 		0,
 	);
 	// Only worth splitting when the subtotal mixes both — otherwise the component
@@ -32,23 +32,17 @@ export const OrderMoneySummary = ({ detail }: OrderMoneySummaryProps) => {
 					<>
 						<div className="flex justify-between gap-4">
 							<dt className="text-muted-foreground">Services</dt>
-							<dd className="font-mono">
-								{formatIDRCurrency(String(servicesSubtotal))}
-							</dd>
+							<dd className="font-mono">{formatMoney(servicesSubtotal)}</dd>
 						</div>
 						<div className="flex justify-between gap-4">
 							<dt className="text-muted-foreground">Products</dt>
-							<dd className="font-mono">
-								{formatIDRCurrency(String(productsSubtotal))}
-							</dd>
+							<dd className="font-mono">{formatMoney(productsSubtotal)}</dd>
 						</div>
 					</>
 				) : null}
 				<div className="flex justify-between gap-4">
 					<dt className="text-muted-foreground">Subtotal</dt>
-					<dd className="font-mono">
-						{formatIDRCurrency(String(detail.total ?? 0))}
-					</dd>
+					<dd className="font-mono">{formatMoney(detail.total)}</dd>
 				</div>
 				{detail.campaigns.map((row) => (
 					<div className="flex justify-between gap-4" key={row.id}>
@@ -62,16 +56,14 @@ export const OrderMoneySummary = ({ detail }: OrderMoneySummaryProps) => {
 							) : null}
 						</dt>
 						<dd className="font-mono text-destructive">
-							-{formatIDRCurrency(String(row.applied_amount ?? 0))}
+							-{formatMoney(row.applied_amount)}
 						</dd>
 					</div>
 				))}
 				<div className="flex justify-between gap-4">
 					<dt className="text-muted-foreground">Discount total</dt>
 					<dd className={cn("font-mono", discount > 0 && "text-destructive")}>
-						{discount > 0
-							? `-${formatIDRCurrency(String(discount))}`
-							: formatIDRCurrency("0")}
+						{discount > 0 ? `-${formatMoney(discount)}` : formatMoney(0)}
 					</dd>
 				</div>
 			</dl>
@@ -79,14 +71,12 @@ export const OrderMoneySummary = ({ detail }: OrderMoneySummaryProps) => {
 			<dl className="grid gap-1.5 text-sm tabular-nums">
 				<div className="flex justify-between gap-4 font-medium">
 					<dt>Net</dt>
-					<dd className="font-mono">{formatIDRCurrency(String(net))}</dd>
+					<dd className="font-mono">{formatMoney(net)}</dd>
 				</div>
 				{refunded > 0 ? (
 					<div className="flex justify-between gap-4 text-destructive">
 						<dt>Refunded</dt>
-						<dd className="font-mono">
-							-{formatIDRCurrency(String(refunded))}
-						</dd>
+						<dd className="font-mono">-{formatMoney(refunded)}</dd>
 					</div>
 				) : null}
 			</dl>

--- a/apps/web/src/features/orders/components/order-service-row.tsx
+++ b/apps/web/src/features/orders/components/order-service-row.tsx
@@ -7,7 +7,7 @@ import {
 	formatOrderServiceStatus,
 	getOrderServiceStatusBadgeVariant,
 } from "@/lib/status";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney } from "@/shared/money";
 import { useSheet } from "@/stores/sheet-store";
 
 type OrderServiceRowService = OrderDetail["services"][number];
@@ -76,7 +76,7 @@ export const OrderServiceRow = memo(
 						</Badge>
 					</span>
 					<span className="font-mono text-sm tabular-nums">
-						{formatIDRCurrency(String(service.subtotal ?? 0))}
+						{formatMoney(service.subtotal)}
 					</span>
 				</span>
 			</button>

--- a/apps/web/src/features/orders/components/pickup-radar.tsx
+++ b/apps/web/src/features/orders/components/pickup-radar.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { Badge } from "@/components/ui/badge";
 import type { Order } from "@/lib/api";
 import { formatOrderStatus, getOrderStatusBadgeVariant } from "@/lib/status";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney } from "@/shared/money";
 
 type PickupRadarProps = {
 	orders: Order[];
@@ -85,7 +85,7 @@ function RadarRow({ order }: { order: Order }) {
 			</div>
 			<div className="flex items-center gap-3">
 				<p className="font-mono text-xs text-muted-foreground">
-					{formatIDRCurrency(String(order.total ?? 0))}
+					{formatMoney(order.total)}
 				</p>
 				<ArrowRightIcon className="size-3.5 text-muted-foreground transition-colors group-hover:text-foreground" />
 			</div>

--- a/apps/web/src/features/orders/lib/refund-preview.ts
+++ b/apps/web/src/features/orders/lib/refund-preview.ts
@@ -1,13 +1,14 @@
 import { lineKey, lineRefundCap } from "@fresclean/api/schema";
 import type { OrderDetail } from "@/lib/api";
+import { parseMoney } from "@/shared/money";
 
 // Client-side mirror of the server's per-line refund caps, built from the same
 // pure math (lineRefundCap) over the same inputs the server reads from the DB
 // (line gross, order gross, order discount, already-refunded sums) — so the
 // dialog preview always matches what the server books.
 export const buildRefundCaps = (detail: OrderDetail): Map<string, number> => {
-	const grossTotal = Number(detail.total ?? 0);
-	const orderDiscount = Number(detail.discount ?? 0);
+	const grossTotal = parseMoney(detail.total);
+	const orderDiscount = parseMoney(detail.discount);
 
 	const refundedByLineKey = new Map<string, number>();
 	for (const refund of detail.refunds ?? []) {
@@ -18,7 +19,7 @@ export const buildRefundCaps = (detail: OrderDetail): Map<string, number> => {
 					: lineKey("service", item.order_service_id);
 			refundedByLineKey.set(
 				key,
-				(refundedByLineKey.get(key) ?? 0) + Number(item.amount),
+				(refundedByLineKey.get(key) ?? 0) + parseMoney(item.amount),
 			);
 		}
 	}
@@ -26,7 +27,7 @@ export const buildRefundCaps = (detail: OrderDetail): Map<string, number> => {
 	const capFor = (key: string, subtotal: string | null) =>
 		lineRefundCap({
 			alreadyRefunded: refundedByLineKey.get(key) ?? 0,
-			grossLine: Number(subtotal ?? 0),
+			grossLine: parseMoney(subtotal),
 			grossTotal,
 			orderDiscount,
 		});

--- a/apps/web/src/features/printing/build-receipt.ts
+++ b/apps/web/src/features/printing/build-receipt.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import type { OrderReceipt } from "@/lib/api";
 import { getOrderServiceItemDetails } from "@/lib/order-service-item-details";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney as money, parseMoney } from "@/shared/money";
 import { EscPosBuilder, toPrintableAscii } from "./escpos";
 import { RECEIPT_LOGO } from "./receipt-logo";
 
@@ -13,9 +13,6 @@ const FOOTER_THANKS = "Terima kasih - Fresclean";
 const FOOTER_DISCLAIMER =
 	"Barang tidak diambil lebih dari 30 hari di luar tanggung jawab kami. " +
 	"Kerusakan bawaan sesuai persetujuan saat serah terima.";
-
-const money = (value: string | number | null | undefined): string =>
-	formatIDRCurrency(String(Number(value ?? 0)));
 
 // Measure and pad on the ASCII-coerced text — escpos.text() coerces before
 // encoding, so raw .length would drift from the printed column count whenever
@@ -73,13 +70,13 @@ export const buildReceiptEscPos = (
 	receipt: OrderReceipt,
 	trackingUrl: string,
 ): Uint8Array => {
-	const discount = Number(receipt.discount ?? 0);
+	const discount = parseMoney(receipt.discount);
 	const campaignDiscount = receipt.campaigns.reduce(
-		(sum, entry) => sum + Number(entry.applied_amount ?? 0),
+		(sum, entry) => sum + parseMoney(entry.applied_amount),
 		0,
 	);
 	const manualDiscount = Math.max(discount - campaignDiscount, 0);
-	const net = Number(receipt.total ?? 0) - discount;
+	const net = parseMoney(receipt.total) - discount;
 	const isPaid = receipt.payment_status === "paid";
 	const isCancelled = receipt.status === "cancelled";
 

--- a/apps/web/src/features/products/components/product-form.tsx
+++ b/apps/web/src/features/products/components/product-form.tsx
@@ -26,6 +26,10 @@ const productFormResolverSchema = z.object({
 		(value) => Number(value),
 		POSTProductSchema.shape.category_id,
 	),
+	// The server parses money into a number for itself, but the API still takes
+	// the digit string the currency field types out — keep the form in that shape.
+	cogs: POSTProductSchema.shape.cogs.transform(String),
+	price: POSTProductSchema.shape.price.transform(String),
 });
 
 export type ProductFormState = z.infer<typeof productFormResolverSchema>;

--- a/apps/web/src/features/services/components/service-form.tsx
+++ b/apps/web/src/features/services/components/service-form.tsx
@@ -25,6 +25,10 @@ const serviceFormResolverSchema = z.object({
 		(value) => Number(value),
 		POSTServiceSchema.shape.category_id,
 	),
+	// The server parses money into a number for itself, but the API still takes
+	// the digit string the currency field types out — keep the form in that shape.
+	cogs: POSTServiceSchema.shape.cogs.transform(String),
+	price: POSTServiceSchema.shape.price.transform(String),
 });
 
 export type ServiceFormState = z.infer<typeof serviceFormResolverSchema>;

--- a/apps/web/src/features/transactions/cart/cart.ts
+++ b/apps/web/src/features/transactions/cart/cart.ts
@@ -12,6 +12,7 @@ import type {
 	Service,
 } from "@/lib/api";
 import { isValidPhoneNumber, normalizePhoneNumber } from "@/lib/phone-number";
+import { parseMoney } from "@/shared/money";
 
 export type ProductCartLine = {
 	kind: "product";
@@ -125,10 +126,13 @@ export const getCartSubtotal = (
 	serviceRows: { service: { price: string | number } }[],
 ): number =>
 	productRows.reduce(
-		(total, line) => total + Number(line.product.price) * line.qty,
+		(total, line) => total + parseMoney(line.product.price) * line.qty,
 		0,
 	) +
-	serviceRows.reduce((total, line) => total + Number(line.service.price), 0);
+	serviceRows.reduce(
+		(total, line) => total + parseMoney(line.service.price),
+		0,
+	);
 
 export const getCartCount = (
 	productCart: ProductCartLine[],

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -19,7 +19,7 @@ import { useCart } from "@/features/transactions/cart/useCart";
 import { getEntityCategoryName } from "@/features/transactions/lib/transactions";
 import { categoriesQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney, parseMoney } from "@/shared/money";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
 // Step ② — the goods: review/annotate cart lines, order notes, and the
@@ -115,9 +115,7 @@ export const CheckoutItemsStep = () => {
 								</Button>
 							</div>
 							<p className="text-sm font-semibold">
-								{formatIDRCurrency(
-									String(Number(line.product.price) * line.qty),
-								)}
+								{formatMoney(parseMoney(line.product.price) * line.qty)}
 							</p>
 						</div>
 					</div>
@@ -256,7 +254,7 @@ export const CheckoutItemsStep = () => {
 						</div>
 						<div className="flex items-center justify-end gap-3">
 							<p className="text-sm font-semibold">
-								{formatIDRCurrency(String(line.service.price))}
+								{formatMoney(line.service.price)}
 							</p>
 						</div>
 					</div>

--- a/apps/web/src/features/transactions/hooks/useCheckoutPricing.ts
+++ b/apps/web/src/features/transactions/hooks/useCheckoutPricing.ts
@@ -8,6 +8,7 @@ import {
 } from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
 import { campaignsQueryOptions } from "@/lib/query-options";
+import { parseMoney } from "@/shared/money";
 
 // Shared checkout derivation — campaign eligibility + final pricing. Lives in a
 // hook (not the component) because both the payment step's breakdown and the
@@ -86,7 +87,7 @@ export function useCheckoutPricing() {
 	const serviceLines = useMemo(
 		() =>
 			serviceRows.map((row) => ({
-				price: Number(row.service.price),
+				price: parseMoney(row.service.price),
 				service_id: row.service.id,
 			})),
 		[serviceRows],

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -264,17 +264,20 @@ export type CreateStorePayload = z.infer<typeof POSTStoreSchema>;
 export type UpdateStorePayload = z.infer<typeof POSTStoreSchema>;
 export type CreateCategoryPayload = z.infer<typeof POSTCategorySchema>;
 export type UpdateCategoryPayload = z.infer<typeof POSTCategorySchema>;
-export type CreateServicePayload = z.infer<typeof POSTServiceSchema>;
-export type UpdateServicePayload = z.infer<typeof POSTServiceSchema>;
-export type CreateProductPayload = z.infer<typeof POSTProductSchema>;
-export type UpdateProductPayload = z.infer<typeof POSTProductSchema>;
+// Money crosses the wire as the digit string the currency field produced; the
+// server is what turns it into a number. So these payloads are the schemas'
+// input side, not their parsed output.
+export type CreateServicePayload = z.input<typeof POSTServiceSchema>;
+export type UpdateServicePayload = z.input<typeof POSTServiceSchema>;
+export type CreateProductPayload = z.input<typeof POSTProductSchema>;
+export type UpdateProductPayload = z.input<typeof POSTProductSchema>;
 export type CreatePaymentMethodPayload = z.infer<
 	typeof POSTPaymentMethodSchema
 >;
 export type UpdatePaymentMethodPayload = z.infer<
 	typeof POSTPaymentMethodSchema
 >;
-export type CreateOrderPayload = z.infer<typeof POSTOrderSchema> & {
+export type CreateOrderPayload = z.input<typeof POSTOrderSchema> & {
 	voucher_codes: string[];
 };
 

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -31,7 +31,7 @@ import {
 	getOrderStatusBadgeVariant,
 	getRefundStatusBadgeVariant,
 } from "@/lib/status";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney } from "@/shared/money";
 import { getCurrentUser } from "@/stores/auth-store";
 import { useSheet } from "@/stores/sheet-store";
 
@@ -270,7 +270,7 @@ function OrdersPage() {
 				},
 				cell: ({ row }) => (
 					<div className="text-right font-mono font-medium tabular-nums">
-						{row.original.total ? formatIDRCurrency(row.original.total) : "—"}
+						{formatMoney(row.original.total)}
 					</div>
 				),
 			},

--- a/apps/web/src/shared/money.ts
+++ b/apps/web/src/shared/money.ts
@@ -1,0 +1,17 @@
+const IDR = new Intl.NumberFormat("id-ID", {
+	style: "currency",
+	currency: "IDR",
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 0,
+});
+
+// Money reaches the browser as a string because Postgres hands numeric back as
+// one, and the counter only ever charges whole rupiah — never sen.
+export const parseMoney = (value: string | number | null | undefined): number =>
+	Number(value ?? 0);
+
+// Never format an API money string directly: "45000.00" read as digits alone
+// prints as Rp4.500.000, a hundred times the real price.
+export const formatMoney = (
+	value: string | number | null | undefined,
+): string => IDR.format(parseMoney(value));

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -15,6 +15,9 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
+// The shop never charges a fraction of a rupiah — there is no sen at the
+// counter — so every money column below is scale: 0, whole rupiah only.
+
 export const userRoleEnum = pgEnum("user_role", [
   "admin",
   "cashier",
@@ -106,8 +109,8 @@ export const productsTable = pgTable(
     category_id: integer("category_id")
       .references(() => categoriesTable.id)
       .notNull(),
-    cogs: decimal("cogs", { precision: 12 }).default("0").notNull(),
-    price: decimal("price", { precision: 12 }).default("0").notNull(),
+    cogs: decimal("cogs", { precision: 12, scale: 0 }).default("0").notNull(),
+    price: decimal("price", { precision: 12, scale: 0 }).default("0").notNull(),
     description: text("description"),
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
     is_active: boolean("is_active").default(false).notNull(),
@@ -129,8 +132,8 @@ export const servicesTable = pgTable(
       .references(() => categoriesTable.id)
       .notNull(),
     code: varchar("code", { length: 4 }).unique().notNull(),
-    cogs: decimal("cogs", { precision: 12 }).default("0").notNull(),
-    price: decimal("price", { precision: 12 }).default("0").notNull(),
+    cogs: decimal("cogs", { precision: 12, scale: 0 }).default("0").notNull(),
+    price: decimal("price", { precision: 12, scale: 0 }).default("0").notNull(),
     description: text("description"),
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
     is_active: boolean("is_active").default(false).notNull(),
@@ -222,7 +225,7 @@ export const campaignsTable = pgTable(
       .references(() => usersTable.id)
       .notNull(),
     discount_type: campaignDiscountTypeEnum("discount_type").notNull(),
-    discount_value: decimal("discount_value", { precision: 12 })
+    discount_value: decimal("discount_value", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     buy_quantity: integer("buy_quantity"),
@@ -230,8 +233,8 @@ export const campaignsTable = pgTable(
     ends_at: timestamp("ends_at"),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
     is_active: boolean("is_active").default(true).notNull(),
-    max_discount: decimal("max_discount", { precision: 12 }),
-    min_order_total: decimal("min_order_total", { precision: 12 })
+    max_discount: decimal("max_discount", { precision: 12, scale: 0 }),
+    min_order_total: decimal("min_order_total", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     name: varchar("name", { length: 255 }).notNull(),
@@ -446,7 +449,9 @@ export const ordersTable = pgTable(
     discount_source: discountSourceEnum("discount_source")
       .default("none")
       .notNull(),
-    discount: decimal("discount", { precision: 12 }).default("0").notNull(),
+    discount: decimal("discount", { precision: 12, scale: 0 })
+      .default("0")
+      .notNull(),
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
 
     notes: text("notes"),
@@ -457,7 +462,7 @@ export const ordersTable = pgTable(
     payment_status: orderPaymentStatusEnum("payment_status")
       .default("unpaid")
       .notNull(),
-    paid_amount: decimal("paid_amount", { precision: 12 })
+    paid_amount: decimal("paid_amount", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     paid_at: timestamp("paid_at"),
@@ -468,7 +473,7 @@ export const ordersTable = pgTable(
       .notNull()
       .default(sql`lpad(floor(random() * 1000000)::text, 6, '0')`),
 
-    refunded_amount: decimal("refunded_amount", { precision: 12 })
+    refunded_amount: decimal("refunded_amount", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     status: orderStatusEnum("status").default("created").notNull(),
@@ -478,7 +483,7 @@ export const ordersTable = pgTable(
       .notNull(),
 
     // snapshot
-    total: decimal("total", { precision: 12 }).default("0"),
+    total: decimal("total", { precision: 12, scale: 0 }).default("0").notNull(),
     updated_at: timestamp("updated_at")
       .notNull()
       .defaultNow()
@@ -533,7 +538,7 @@ export const orderCountersTable = pgTable(
 export const orderCampaignsTable = pgTable(
   "order_campaigns",
   {
-    applied_amount: decimal("applied_amount", { precision: 12 })
+    applied_amount: decimal("applied_amount", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     buy_quantity: integer("buy_quantity"),
@@ -545,12 +550,12 @@ export const orderCampaignsTable = pgTable(
     }),
     created_at: timestamp("created_at").defaultNow().notNull(),
     discount_type: campaignDiscountTypeEnum("discount_type").notNull(),
-    discount_value: decimal("discount_value", { precision: 12 })
+    discount_value: decimal("discount_value", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     free_quantity: integer("free_quantity"),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    max_discount: decimal("max_discount", { precision: 12 }),
+    max_discount: decimal("max_discount", { precision: 12, scale: 0 }),
     order_id: integer("order_id")
       .references(() => ordersTable.id, { onDelete: "cascade" })
       .notNull(),
@@ -573,7 +578,9 @@ export const orderCampaignsTable = pgTable(
 export const ordersServicesTable = pgTable(
   "orders_services",
   {
-    discount: decimal("discount", { precision: 12 }).default("0").notNull(),
+    discount: decimal("discount", { precision: 12, scale: 0 })
+      .default("0")
+      .notNull(),
 
     cancel_reason: cancelReasonEnum("cancel_reason"),
     cancel_note: text("cancel_note"),
@@ -599,8 +606,8 @@ export const ordersServicesTable = pgTable(
     ),
 
     // snapshot
-    price: decimal("price", { precision: 12 }).default("0"),
-    cogs_snapshot: decimal("cogs_snapshot", { precision: 12 })
+    price: decimal("price", { precision: 12, scale: 0 }).default("0"),
+    cogs_snapshot: decimal("cogs_snapshot", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
 
@@ -616,6 +623,7 @@ export const ordersServicesTable = pgTable(
 
     subtotal: decimal("subtotal", {
       precision: 12,
+      scale: 0,
     }).generatedAlwaysAs(
       (): SQL =>
         sql`${ordersServicesTable.price} - ${ordersServicesTable.discount}`
@@ -779,7 +787,7 @@ export const orderRefundsTable = pgTable(
     refunded_by: integer("refunded_by")
       .references(() => usersTable.id)
       .notNull(),
-    total_amount: decimal("total_amount", { precision: 12 })
+    total_amount: decimal("total_amount", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
   },
@@ -796,7 +804,9 @@ export const orderRefundsTable = pgTable(
 export const orderRefundItemsTable = pgTable(
   "order_refund_items",
   {
-    amount: decimal("amount", { precision: 12 }).default("0").notNull(),
+    amount: decimal("amount", { precision: 12, scale: 0 })
+      .default("0")
+      .notNull(),
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
     note: text("note"),
     order_product_id: integer("order_product_id").references(
@@ -836,14 +846,16 @@ export const ordersProductsTable = pgTable(
   "orders_products",
   {
     id: integer().primaryKey().generatedAlwaysAsIdentity(),
-    discount: decimal("discount", { precision: 12 }).default("0").notNull(),
+    discount: decimal("discount", { precision: 12, scale: 0 })
+      .default("0")
+      .notNull(),
     order_id: integer("order_id").references(() => ordersTable.id, {
       onDelete: "cascade",
     }),
 
     // snapshot
-    price: decimal("price", { precision: 12 }).default("0"),
-    cogs_snapshot: decimal("cogs_snapshot", { precision: 12 })
+    price: decimal("price", { precision: 12, scale: 0 }).default("0"),
+    cogs_snapshot: decimal("cogs_snapshot", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),
     product_id: integer("product_id").references(() => productsTable.id, {
@@ -862,6 +874,7 @@ export const ordersProductsTable = pgTable(
 
     subtotal: decimal("subtotal", {
       precision: 12,
+      scale: 0,
     }).generatedAlwaysAs(
       (): SQL =>
         sql`(${ordersProductsTable.price} * ${ordersProductsTable.qty}) - ${ordersProductsTable.discount}`

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -68,7 +68,7 @@ export interface OrderListItem {
   store_code: string;
   store_id: number;
   store_name: string;
-  total: string | null;
+  total: string;
   updated_at: Date;
   updated_by: number;
 }

--- a/packages/server/src/modules/orders/order.service.test.ts
+++ b/packages/server/src/modules/orders/order.service.test.ts
@@ -291,7 +291,7 @@ const checkout = (over: AnyObj = {}) =>
     store_id: 1,
     campaign_ids: [],
     voucher_codes: [],
-    discount: "0",
+    discount: 0,
     payment_status: "unpaid",
     ...over,
   } as never);
@@ -339,8 +339,8 @@ describe("createOrder", () => {
     expect(result).toEqual({
       code: `#JKT/${JAKARTA_DATE}/1`,
       id: 501,
-      total: 45_000,
-      total_after_discount: 45_000,
+      total: "45000",
+      total_after_discount: "45000",
     });
     expect(repo.reserveCalls).toHaveLength(1);
     expect(repo.reserveCalls[0].tx).toBe(TX);
@@ -406,8 +406,8 @@ describe("createOrder", () => {
       payment_method_id: 1,
     });
 
-    expect(result.total).toBe(50_000);
-    expect(result.total_after_discount).toBe(45_000);
+    expect(result.total).toBe("50000");
+    expect(result.total_after_discount).toBe("45000");
 
     // The discount desk judges the GROSS order, not the running balance.
     expect(discount.calls[0]).toMatchObject({
@@ -480,8 +480,8 @@ describe("createOrder", () => {
       voucher_codes: ["SORRY123"],
     });
 
-    expect(result.total).toBe(50_000);
-    expect(result.total_after_discount).toBe(0);
+    expect(result.total).toBe("50000");
+    expect(result.total_after_discount).toBe("0");
     expect(redemptions.calls).toHaveLength(1);
     expect(redemptions.calls[0].rows).toBe(discount.result.campaignRows);
     expect(finalize.writes[0].set).toMatchObject({
@@ -548,10 +548,11 @@ describe("createOrder", () => {
 
   it("snapshots catalog prices and COGS onto the lines and tags each garment", async () => {
     // Margins are reported from these snapshots months later, when catalog
-    // prices have moved on. 3 detergents at COGS 1250.50 must book 3751.50;
-    // each garment gets a sequential tag off the receipt code; a line without
-    // an explicit priority takes the service's default, an explicit choice
-    // beats it.
+    // prices have moved on. 3 detergents at COGS 1250.50 must book 3752 — the
+    // books are kept in whole rupiah, so the half is settled here rather than
+    // left for the database to drop. Each garment gets a sequential tag off the
+    // receipt code; a line without an explicit priority takes the service's
+    // default, an explicit choice beats it.
     catalog.services = [
       { id: 10, price: "30000", cogs: "12000", is_priority: true },
       { id: 11, price: "15000", cogs: "4000", is_priority: true },
@@ -572,7 +573,7 @@ describe("createOrder", () => {
     });
 
     const code = `#JKT/${JAKARTA_DATE}/1`;
-    expect(result.total).toBe(120_000);
+    expect(result.total).toBe("120000");
 
     // Three bottles sold must leave the shelf count as three — a decrement of
     // one would let the system keep selling detergent that is no longer there.
@@ -583,7 +584,7 @@ describe("createOrder", () => {
         order_id: 501,
         product_id: 20,
         price: "25000",
-        cogs_snapshot: "3751.50",
+        cogs_snapshot: "3752",
         qty: 3,
       },
     ]);

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -251,7 +251,10 @@ export async function createOrder(
             order_id: orderId,
             product_id: product.id,
             price: product.price,
-            cogs_snapshot: (Number(product.cogs) * item.qty).toFixed(2),
+            // COGS is stored in whole rupiah, like every amount at the counter.
+            cogs_snapshot: Math.round(
+              Number(product.cogs) * item.qty
+            ).toString(),
             qty: item.qty,
           };
         })
@@ -272,7 +275,7 @@ export async function createOrder(
         campaignIds: [...new Set(campaign_ids)],
         voucherCodes: [...new Set(voucher_codes)],
         grossTotal,
-        manualDiscount: Number(orderPayload.discount),
+        manualDiscount: orderPayload.discount,
         storeId: store.id,
         storeCode: store.code,
         lines,
@@ -299,11 +302,13 @@ export async function createOrder(
       })
       .where(eq(ordersTable.id, orderId));
 
+    // Money leaves as a string here to match every order read, so the POS
+    // reads one shape whether it just made the order or fetched it back.
     return {
       code,
       id: orderId,
-      total: grossTotal,
-      total_after_discount: netTotal,
+      total: grossTotal.toString(),
+      total_after_discount: netTotal.toString(),
     };
   });
 }

--- a/packages/server/src/modules/products/product.schema.ts
+++ b/packages/server/src/modules/products/product.schema.ts
@@ -37,4 +37,9 @@ export const POSTProductSchema = z.object({
   cogs: currencySchema("COGS"),
   price: currencySchema("Price"),
 });
-export const PUTProductSchema = createUpdateSchema(productsTable);
+// Editing a price is the same money boundary as creating one, so it gets the
+// same guard — otherwise "1.500" reaches the column as one and a half rupiah.
+export const PUTProductSchema = createUpdateSchema(productsTable).extend({
+  cogs: currencySchema("COGS").optional(),
+  price: currencySchema("Price").optional(),
+});

--- a/packages/server/src/modules/products/product.service.ts
+++ b/packages/server/src/modules/products/product.service.ts
@@ -1,11 +1,14 @@
-import type { InferInsertModel } from "drizzle-orm";
-import type { productsTable } from "@/db/schema";
+import type z from "zod";
 import {
   findProductById,
   insertProduct,
   listProducts,
   updateProductById,
 } from "@/modules/products/product.repository";
+import type {
+  POSTProductSchema,
+  PUTProductSchema,
+} from "@/modules/products/product.schema";
 
 export function getProducts() {
   return listProducts();
@@ -16,16 +19,25 @@ export function getProductById(id: number) {
 }
 
 export async function createProduct(
-  payload: InferInsertModel<typeof productsTable>
+  payload: z.infer<typeof POSTProductSchema>
 ) {
-  const [product] = await insertProduct(payload);
+  const [product] = await insertProduct({
+    ...payload,
+    cogs: payload.cogs.toString(),
+    price: payload.price.toString(),
+  });
   return product;
 }
 
 export async function updateProduct(
   id: number,
-  payload: Partial<InferInsertModel<typeof productsTable>>
+  payload: z.infer<typeof PUTProductSchema>
 ) {
-  const [product] = await updateProductById(id, payload);
+  const { cogs, price, ...rest } = payload;
+  const [product] = await updateProductById(id, {
+    ...rest,
+    ...(cogs === undefined ? {} : { cogs: cogs.toString() }),
+    ...(price === undefined ? {} : { price: price.toString() }),
+  });
   return product ?? null;
 }

--- a/packages/server/src/modules/services/service.schema.ts
+++ b/packages/server/src/modules/services/service.schema.ts
@@ -40,4 +40,9 @@ export const POSTServiceSchema = z.object({
   is_active: isActiveSchema,
   is_priority: z.boolean().default(false),
 });
-export const PUTServiceSchema = createUpdateSchema(servicesTable);
+// Editing a price is the same money boundary as creating one, so it gets the
+// same guard — otherwise "1.500" reaches the column as one and a half rupiah.
+export const PUTServiceSchema = createUpdateSchema(servicesTable).extend({
+  cogs: currencySchema("COGS").optional(),
+  price: currencySchema("Price").optional(),
+});

--- a/packages/server/src/modules/services/service.service.ts
+++ b/packages/server/src/modules/services/service.service.ts
@@ -1,11 +1,14 @@
-import type { InferInsertModel } from "drizzle-orm";
-import type { servicesTable } from "@/db/schema";
+import type z from "zod";
 import {
   findServiceById,
   insertService,
   listServices,
   updateServiceById,
 } from "@/modules/services/service.repository";
+import type {
+  POSTServiceSchema,
+  PUTServiceSchema,
+} from "@/modules/services/service.schema";
 
 export function getServices() {
   return listServices();
@@ -16,16 +19,25 @@ export function getServiceById(id: number) {
 }
 
 export async function createService(
-  payload: InferInsertModel<typeof servicesTable>
+  payload: z.infer<typeof POSTServiceSchema>
 ) {
-  const [service] = await insertService(payload);
+  const [service] = await insertService({
+    ...payload,
+    cogs: payload.cogs.toString(),
+    price: payload.price.toString(),
+  });
   return service;
 }
 
 export async function updateService(
   id: number,
-  payload: Partial<InferInsertModel<typeof servicesTable>>
+  payload: z.infer<typeof PUTServiceSchema>
 ) {
-  const [service] = await updateServiceById(id, payload);
+  const { cogs, price, ...rest } = payload;
+  const [service] = await updateServiceById(id, {
+    ...rest,
+    ...(cogs === undefined ? {} : { cogs: cogs.toString() }),
+    ...(price === undefined ? {} : { price: price.toString() }),
+  });
   return service ?? null;
 }

--- a/packages/server/src/schema/common.test.ts
+++ b/packages/server/src/schema/common.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { currencySchema } from "@/schema/common";
+
+describe("currencySchema", () => {
+  it("reads a dot in a typed price as a thousands separator, not cents", () => {
+    // A shelf tag at the counter reads Rp1.500 for fifteen hundred rupiah, so
+    // punctuation in a typed price is grouping — 1500.75 is a hundred and fifty
+    // thousand and seventy-five rupiah, never fifteen hundred plus change.
+    expect(currencySchema("Price").parse("1500.75")).toBe(150_075);
+  });
+
+  it("refuses a discount the cashier typed as a negative", () => {
+    // A minus at the till is a slip of the hand. Stripping punctuation would
+    // erase the sign and hand the customer a real Rp500 off instead.
+    const result = currencySchema("Discount").safeParse("-500");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Discount cannot be negative"
+      );
+    }
+  });
+});

--- a/packages/server/src/schema/common.ts
+++ b/packages/server/src/schema/common.ts
@@ -4,8 +4,10 @@ import {
 } from "libphonenumber-js";
 import { z } from "zod";
 
-const getNumericValue = (formattedValue: string): string =>
-  formattedValue.replaceAll(/[^\d]/g, "");
+// Indonesian prices are written 1.500 for fifteen hundred: the dot is a
+// thousands separator, never a decimal point, and the counter has no sen.
+const parseIndonesianCurrency = (formattedValue: string): number =>
+  Number(formattedValue.replaceAll(/[^\d]/g, ""));
 
 export const varcharSchema = (field: string) =>
   z
@@ -45,10 +47,8 @@ export const currencySchema = (field: string) =>
   z
     .string(`${field} is required!`)
     .min(1, `${field} is required!`)
-    .transform(getNumericValue)
-    .transform(Number)
-    .pipe(z.number().nonnegative(`${field} cannot be negative`))
-    .pipe(z.coerce.string());
+    .refine((value) => !value.includes("-"), `${field} cannot be negative`)
+    .transform(parseIndonesianCurrency);
 
 const DATE_YYYY_MM_DD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -187,7 +187,7 @@ export const POSTOrderSchema = z
         )
       )
       .optional(),
-    discount: currencySchema("Discount").default("0"),
+    discount: currencySchema("Discount").default(0),
     payment_method_id: z.number().optional(),
     payment_status: z.enum(
       orderPaymentStatusEnum.enumValues,


### PR DESCRIPTION
Audit findings **M1–M5** ([report](../blob/main/docs/audit/2026-08-05-code-quality-audit.html), section 01).

The money in this system was already correct — but for reasons the system didn't know about. This makes those reasons explicit so a future change can't quietly break them.

### M1 — `orders.total` was the only nullable money column

Three CHECK constraints reference it. A Postgres CHECK fails only on `FALSE`; `NULL` yields `UNKNOWN`, which passes. So a single NULL would have disarmed `total >= 0`, `total >= discount` **and** `paid_amount <= total` simultaneously — an order could carry a discount larger than its total and every constraint would still be satisfied.

Verified against both databases before touching anything:

| | rows | `total IS NULL` | was nullable |
|---|---|---|---|
| dev | — | 0 | yes → **fixed** |
| prod | 1 | 0 | yes → **pending, see below** |

### M2 — "money is whole rupiah" was true but written nowhere

All 24 money columns were `decimal(…, { precision: 12 })`, which Postgres reads as `numeric(12,0)`. That was omission, not intent — two lines away, `latitude`/`longitude` *do* declare a scale. It held only because three unrelated things each forced integers independently.

`scale: 0` is now explicit on all 24. **Emitted DDL is byte-identical, so no migration.** The rule is named once, in business terms: the shop has no sen.

### M3 — `.toFixed(2)` into a scale-0 column

`cogs_snapshot` asserted a precision the schema forbids. Harmless today, but it's how the next person concludes fractional COGS is supported.

### M4 — `currencySchema`'s validation could not fail

The sanitiser deleted the minus sign *before* `.nonnegative()` ran, so `"-500"` validated as a perfectly good `500`. The error message was unreachable code that read like a live guarantee.

The check now runs on what the cashier actually typed, the parser is named for what it does, and the `string → number → string` round-trip is gone.

**Beyond the audit's description:** a reviewer found the guard was wired only into `POST`. The edit path had none at all:

| `PUT /admin/products/:id` `{price}` | before | after |
|---|---|---|
| `"-500"` | accepted, stored `-500` | **rejected** |
| `"1.500"` | accepted, stored **`2`** | **`1500`** |

That second row is silent price destruction. Editing a price now passes the same guard as creating one.

### M5 — money had two TypeScript types

`POST /orders` answered `total: 45000`; `GET /orders/:id` answered `total: "45000"`. Root cause of ~66 hand-rolled `Number()` coercions in the web app.

`createOrder` now returns strings like every read path, and the coercions go through one helper. Kept strings on the wire deliberately rather than the audit's preferred numbers — that would mean rewriting every read path including the reports module, which is being overhauled separately.

`formatMoney` parses before formatting. Formatting `"45000.00"` as digits alone prints **Rp4.500.000** — a hundred times the price. Several call sites were one decimal away from that; they now can't be.

---

### Needs a manual step

```sql
ALTER TABLE orders ALTER COLUMN total SET NOT NULL;  -- production
```

Dev is done. Production is safe (1 row, 0 violations) and reversible via `DROP NOT NULL`, but it mutates the production schema so it's left for a human. Until it runs, the merged code types `total` as non-null while prod still permits null — harmless, since nothing writes null, but M1 isn't truly closed until then.

### Verification

`ultracite check` clean · `type-check` 3/3 · 273 server + 78 web tests, 0 fail · `bun run build` green.

Nothing under `apps/web/src/features/reports/` is touched.

One test regression was caught and reversed during review: an implementer had changed a fixture from `cogs: "1250.50"` to `"1250"`, which removed the only fractional-COGS input in the suite — precisely the line M3 changed. The fixture is restored and now asserts the rounded result.