### PR TITLE
fix(server): stop error bodies carrying customer data, log what broke

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -8,6 +8,9 @@ const app = new Hono<{ Variables: JwtVariables<JWTPayload> }>()
   .basePath("/api")
   .use(logger())
   .use(
+    // Only local Vite needs this. Deployed, vercel.json rewrites /api/* to this
+    // service, so the dashboard and the API share one origin and nothing the
+    // browser sends is ever cross-origin.
     cors({
       origin: ["http://localhost:5173", "http://localhost:4173"],
     })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,13 +1,11 @@
 import "@/utils/date";
-import { HTTPException } from "hono/http-exception";
-import { StatusCodes } from "http-status-codes";
 import app from "@/app";
 import { adminMiddleware } from "@/middlewares/admin";
 import adminRoutes from "@/routes/admin";
 import authRoutes from "@/routes/auth";
 import internalRoutes from "@/routes/internal";
 import publicRoutes from "@/routes/public";
-import { failure } from "@/utils/http";
+import { errorHandler } from "@/utils/error-handler";
 
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET environment variable is required");
@@ -21,40 +19,7 @@ const router = app
   .route("/public", publicRoutes)
   .route("/internal", internalRoutes);
 
-// error handling
-router.onError((err, c) => {
-  if (err instanceof HTTPException) {
-    return c.json(failure(err.message, err.cause), err.status);
-  }
-
-  if (typeof err.cause === "object" && err.cause && "detail" in err.cause) {
-    let statusCode: StatusCodes = StatusCodes.INTERNAL_SERVER_ERROR;
-    if ("code" in err.cause) {
-      switch (err.cause.code) {
-        case "23505": {
-          statusCode = StatusCodes.CONFLICT;
-          break;
-        }
-        case "23502":
-        case "23503":
-        case "23514":
-        case "22P02": {
-          statusCode = StatusCodes.BAD_REQUEST;
-          break;
-        }
-
-        default: {
-          statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
-        }
-      }
-    }
-
-    return c.json(failure(err.cause.detail as string), statusCode);
-  }
-
-  // console.error(err);
-  return c.json(failure(err.message), StatusCodes.INTERNAL_SERVER_ERROR);
-});
+router.onError(errorHandler);
 
 export type AppType = typeof router;
 export default {

--- a/packages/server/src/utils/error-handler.ts
+++ b/packages/server/src/utils/error-handler.ts
@@ -1,0 +1,48 @@
+import type { ErrorHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { JwtVariables } from "hono/jwt";
+import { StatusCodes } from "http-status-codes";
+import type { JWTPayload } from "@/types/jwt";
+import {
+  asPostgresError,
+  mapPostgresError,
+  redactDetail,
+} from "@/utils/errors";
+import { failure } from "@/utils/http";
+
+export const errorHandler: ErrorHandler<{
+  Variables: JwtVariables<JWTPayload>;
+}> = (err, c) => {
+  if (err instanceof HTTPException) {
+    return c.json(failure(err.message), err.status);
+  }
+
+  const request = {
+    method: c.req.method,
+    path: c.req.path,
+    userId: c.get("jwtPayload")?.id,
+  };
+
+  const dbError = asPostgresError(err);
+  if (dbError) {
+    console.error("database error", {
+      ...request,
+      code: dbError.code,
+      column: dbError.column,
+      constraint: dbError.constraint,
+      detail: dbError.detail ? redactDetail(dbError.detail) : undefined,
+    });
+
+    const { message, status } = mapPostgresError(dbError);
+    return c.json(failure(message), status);
+  }
+
+  // Drizzle builds its message from the failed query and every bound parameter,
+  // so a dropped connection during a customer save would otherwise hand the
+  // whole submitted row — or a new user's password hash — back to the browser.
+  console.error("unhandled error", request, err);
+  return c.json(
+    failure("Something went wrong"),
+    StatusCodes.INTERNAL_SERVER_ERROR
+  );
+};

--- a/packages/server/src/utils/errors.test.ts
+++ b/packages/server/src/utils/errors.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { JwtVariables } from "hono/jwt";
+import { StatusCodes } from "http-status-codes";
+import type { JWTPayload } from "@/types/jwt";
+import { errorHandler } from "@/utils/error-handler";
+import { mapPostgresError, redactDetail } from "@/utils/errors";
+
+const PHONE = "+628123456789";
+
+describe("mapPostgresError", () => {
+  it("tells the counter the customer is already on file without printing the other customer's number", () => {
+    // Two branches take the same walk-in on the same day. Postgres reports the
+    // clash by quoting the number it found, and that number belongs to whoever
+    // registered first — it must not reach the screen of whoever tried second.
+    const { message, status } = mapPostgresError({
+      code: "23505",
+      constraint: "customers_phone_number_unique",
+      detail: `Key (phone_number)=(${PHONE}) already exists.`,
+    });
+
+    expect(message).toBe("A customer with that phone number already exists");
+    expect(message).not.toContain(PHONE);
+    expect(status).toBe(StatusCodes.CONFLICT);
+  });
+
+  it("says the same thing whether the shop is on the dev or the production database", () => {
+    // Dev names the constraint customers_phone_number_key, production names it
+    // customers_phone_number_unique — both databases are live.
+    const { message } = mapPostgresError({
+      code: "23505",
+      constraint: "customers_phone_number_key",
+    });
+
+    expect(message).toBe("A customer with that phone number already exists");
+  });
+
+  it("names the mistake when a refund is written for more than the customer paid", () => {
+    const { message, status } = mapPostgresError({
+      code: "23514",
+      constraint: "refunded_amount_valid_check",
+      detail: `Failing row contains (91, ORD-0007, 1, 2, 50000, 80000, Budi Santoso, ${PHONE}).`,
+    });
+
+    expect(message).toBe("Refund cannot be more than the amount paid");
+    expect(message).not.toContain("Budi Santoso");
+    expect(status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("keeps the half-typed order off the screen when a required field was left blank", () => {
+    const { message, status } = mapPostgresError({
+      code: "23502",
+      detail: `Failing row contains (91, ORD-0007, null, Budi Santoso, ${PHONE}).`,
+    });
+
+    expect(message).toBe("A required field is missing");
+    expect(message).not.toContain("Budi Santoso");
+    expect(status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("stays quiet about a database failure nobody has mapped", () => {
+    const { message, status } = mapPostgresError({
+      code: "40001",
+      detail: `Key (phone_number)=(${PHONE}) already exists.`,
+    });
+
+    expect(message).toBe("Something went wrong");
+    expect(message).not.toContain(PHONE);
+    expect(status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
+});
+
+describe("redactDetail", () => {
+  it("keeps which column clashed and drops whose number it was", () => {
+    expect(redactDetail(`Key (phone_number)=(${PHONE}) already exists.`)).toBe(
+      "Key (phone_number)=(…) already exists."
+    );
+  });
+
+  it("drops the whole customer row Postgres echoes back on a rejected save", () => {
+    const redacted = redactDetail(
+      `Failing row contains (91, Budi Santoso, ${PHONE}, budi@example.com).`
+    );
+
+    expect(redacted).toBe("Failing row contains (…).");
+    expect(redacted).not.toContain(PHONE);
+    expect(redacted).not.toContain("Budi Santoso");
+  });
+});
+
+const respondTo = async (thrown: unknown) => {
+  const app = new Hono<{ Variables: JwtVariables<JWTPayload> }>().get(
+    "/boom",
+    () => {
+      throw thrown;
+    }
+  );
+  app.onError(errorHandler);
+
+  const logged: unknown[][] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => logged.push(args);
+  try {
+    const response = await app.request("/boom");
+    return { body: await response.text(), logged, status: response.status };
+  } finally {
+    console.error = original;
+  }
+};
+
+describe("errorHandler", () => {
+  it("does not hand a customer's number back when their record already exists", async () => {
+    // The leak this guards: Postgres puts the conflicting value in `detail`, and
+    // the dashboard renders whatever message it gets straight into a toast.
+    const { body, logged, status } = await respondTo(
+      Object.assign(
+        new Error("duplicate key value violates unique constraint"),
+        {
+          code: "23505",
+          constraint: "customers_phone_number_unique",
+          detail: `Key (phone_number)=(${PHONE}) already exists.`,
+        }
+      )
+    );
+
+    expect(status).toBe(StatusCodes.CONFLICT);
+    expect(body).not.toContain(PHONE);
+    expect(body).toContain("A customer with that phone number already exists");
+    // Redacted, but still says which column clashed — otherwise closing the leak
+    // would leave nobody able to diagnose it.
+    expect(JSON.stringify(logged)).toContain("phone_number");
+    expect(JSON.stringify(logged)).not.toContain(PHONE);
+  });
+
+  it("reads a failed lookup as a database error even though the driver throws it bare", async () => {
+    // Reads on db.query.* throw the driver error directly instead of wrapping
+    // it, so a handler that only inspects `cause` maps none of them.
+    const { body, status } = await respondTo(
+      Object.assign(new Error("invalid input syntax for type integer"), {
+        code: "22P02",
+      })
+    );
+
+    expect(status).toBe(StatusCodes.BAD_REQUEST);
+    expect(body).toContain("That value is not in a valid format");
+    expect(body).not.toContain("invalid input syntax");
+  });
+
+  it("does not echo the whole submitted row back when the database connection drops mid-save", async () => {
+    // Drizzle builds its message from the query and every bound parameter, so
+    // this is the shape a thawed container produces on the first write — and on
+    // POST /admin/users those parameters include the new password hash.
+    const { body, status } = await respondTo(
+      new Error(
+        'Failed query: insert into "customers" ("name", "phone_number") values ($1, $2)\n' +
+          `params: Ibu Ani Wijaya,${PHONE}`
+      )
+    );
+
+    expect(status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(body).not.toContain(PHONE);
+    expect(body).not.toContain("Ibu Ani Wijaya");
+    expect(body).not.toContain("insert into");
+    expect(body).toContain("Something went wrong");
+  });
+
+  it("keeps a rejected order's reason but not the record attached to it", async () => {
+    const { body, status } = await respondTo(
+      new HTTPException(StatusCodes.CONFLICT, {
+        cause: {
+          code: "23505",
+          detail: `Key (phone_number)=(${PHONE}) already exists.`,
+        },
+        message: "Order already cancelled",
+      })
+    );
+
+    expect(status).toBe(StatusCodes.CONFLICT);
+    expect(body).toContain("Order already cancelled");
+    expect(body).not.toContain(PHONE);
+  });
+});

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -1,3 +1,6 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { StatusCodes } from "http-status-codes";
+
 // True when a thrown DB error is a Postgres unique-violation (SQLSTATE 23505).
 // The code can sit on the error itself or on `error.cause` depending on the
 // driver/wrapper, so both shapes are checked. Used by services that recover
@@ -13,3 +16,92 @@ export function isUniqueViolation(error: unknown): boolean {
   }
   return "code" in error && (error as { code?: string }).code === "23505";
 }
+
+export interface PostgresError {
+  code?: string;
+  column?: string;
+  constraint?: string;
+  detail?: string;
+}
+
+export interface PostgresFailure {
+  message: string;
+  status: ContentfulStatusCode;
+}
+
+const hasCode = (value: unknown): value is PostgresError =>
+  typeof value === "object" && value !== null && "code" in value;
+
+// Reads on `db.query.*` throw the driver error directly while writes arrive
+// wrapped, so the code sits on the error itself as often as on its cause.
+export function asPostgresError(error: unknown): PostgresError | undefined {
+  if (hasCode(error)) {
+    return error;
+  }
+  const cause = (error as { cause?: unknown } | null)?.cause;
+  return hasCode(cause) ? cause : undefined;
+}
+
+// Dev calls the constraint customers_phone_number_key, production calls it
+// customers_phone_number_unique. The same duplicate must read the same at the
+// till on either database.
+const UNIQUE_SUFFIX = /_(?:key|unique)$/;
+
+const CONSTRAINT_MESSAGES: Partial<Record<string, string>> = {
+  customers_email: "A customer with that email already exists",
+  customers_phone_number: "A customer with that phone number already exists",
+  paid_amount_valid_check: "Payment cannot be more than the order total",
+  products_sku: "That SKU is already in use",
+  refunded_amount_valid_check: "Refund cannot be more than the amount paid",
+  services_code: "That service code is already in use",
+  stores_code: "That store code is already in use",
+  users_username: "That username is taken",
+};
+
+const CODE_FAILURES: Partial<Record<string, PostgresFailure>> = {
+  "22P02": {
+    message: "That value is not in a valid format",
+    status: StatusCodes.BAD_REQUEST,
+  },
+  "23502": {
+    message: "A required field is missing",
+    status: StatusCodes.BAD_REQUEST,
+  },
+  "23503": {
+    message: "That record is still linked to another record",
+    status: StatusCodes.BAD_REQUEST,
+  },
+  "23505": {
+    message: "That record already exists",
+    status: StatusCodes.CONFLICT,
+  },
+  "23514": {
+    message: "That value is not allowed",
+    status: StatusCodes.BAD_REQUEST,
+  },
+};
+
+const UNKNOWN_FAILURE: PostgresFailure = {
+  message: "Something went wrong",
+  status: StatusCodes.INTERNAL_SERVER_ERROR,
+};
+
+export function mapPostgresError({
+  code,
+  constraint,
+}: PostgresError): PostgresFailure {
+  const failure = (code ? CODE_FAILURES[code] : undefined) ?? UNKNOWN_FAILURE;
+  const named = constraint
+    ? CONSTRAINT_MESSAGES[constraint.replace(UNIQUE_SUFFIX, "")]
+    : undefined;
+
+  return named ? { message: named, status: failure.status } : failure;
+}
+
+// Postgres quotes the data that broke the save — the duplicate phone number, or
+// the whole half-typed customer row. Which column clashed is worth keeping in
+// the log; whose phone number it was is not.
+export const redactDetail = (detail: string): string =>
+  detail
+    .replaceAll(/=\([^)]*\)/g, "=(…)")
+    .replaceAll(/contains \([^)]*\)/g, "contains (…)");


### PR DESCRIPTION
Audit findings **S1, S2, S14** — plus **three leaks the audit missed**, found while reviewing the first attempt at this batch.

### S2 — raw Postgres `detail` was returned to the client

For a duplicate customer that's the conflicting phone number. For a check or not-null violation it's `Failing row contains (91, …, Budi Santoso, +628123456789)` — the whole row. The dashboard renders whatever message it gets straight into `toast.error`, so a customer's number could land on screen.

Every message is now one this codebase owns, keyed off the constraint name.

**Naming gotcha worth recording:** dev and production spell the same constraint differently, and production mixes both styles:

```
DEV   customers_phone_number_key      products_sku_key
PROD  customers_phone_number_unique   campaigns_code_key
```

So the mapping strips either suffix. (One reviewer claimed the `_key` branch was dead based on `drizzle/dev/schema.ts`; that file is a stale pulled snapshot. Verified against both live databases with read-only `pg_constraint` queries.)

### Three leaks that weren't in the audit

**1. The fall-through returned `err.message`.** Drizzle builds that message from the failed query *and every bound parameter*:

```json
{"message":"Failed query: insert into \"customers\" (…) values ($1,$2,…)\nparams: Jl. Kemang Raya 12,ibu.ani@gmail.com,Ibu Ani Wijaya,+628123456789"}
```

Triggered by any dead pooled Neon socket — a thawed container, a compute autosuspend, a `sin1`↔Neon blip. **This was worse than the `detail` leak sitting two lines above it**, and on `POST /admin/users` the bound parameters include the new user's argon2 password hash.

**2. `asPostgresError` only inspected `err.cause`.** Drizzle's relational-query path throws the driver error directly rather than wrapping it, so `code` sits on the error itself. Every `db.query.*` read — which is the whole auth path, `middlewares/admin.ts`, and every repository read — skipped the mapping entirely and fell through to leak #1.

**3. The `HTTPException` branch passed `err.cause` to the client.** Dormant today, but a `DatabaseError` assigns `detail`/`constraint`/`table` as own enumerable properties, so one `throw new ConflictException(msg, { cause: err })` republishes the exact leak this batch closes, wearing the `errors` field instead.

### S1 — unhandled 500s were silent

The container's only diagnostic surface is stdout, and the line that would have written to it was commented out. Both branches now log method, path and acting user id — never the request body.

`detail` moves into the log rather than being dropped, **with the values redacted**:

```
Key (phone_number)=(+628123456789) already exists.   →   Key (phone_number)=(…) already exists.
Failing row contains (91, Budi Santoso, +628…)       →   Failing row contains (…).
```

Which column clashed is the diagnostic; whose number it was isn't. Vercel container logs are retained and readable by anyone with project access, so returning PII to a log instead of a browser would have been relocating it, not containing it.

### S14

One comment recording why localhost-only CORS is correct in production. No config change.

### Structure

The handler moves out of `index.ts` into `utils/error-handler.ts`, which is what makes the leak testable — the previous tests all called the pure mapper, so re-adding `return c.json(failure(detail))` at the real defect site left every one of them passing.

### Verification

`ultracite check` clean · `type-check` 3/3 · **284 server + 78 web tests, 0 fail** · `build` green.

Each of the four leaks is covered by a test **verified to fail when the leak is put back**:

```
baseline                                    0 failing
L1 err.message in body                      1 failing
L2 cause-only lookup                        2 failing
L3 cause in HTTPException body              1 failing
redaction removed                           1 failing
restored                                    0 failing
```

Status codes are unchanged: 23505 → 409; 23502/23503/23514/22P02 → 400; everything else → 500. Response shape unchanged, so the web's `details?.data?.message` toasts still work.

Also trimmed from the first attempt: constraint messages for situations that can't occur (`stock_non_negative_check` is already guarded in the repository's `WHERE`, and the server-computed `*_non_negative_check` family would be a server bug dressed as a cashier error), and `discount_valid_check`, whose name exists on three tables with different meanings — any specific wording there would be wrong two-thirds of the time.