### PR TITLE
fix(server): gate retired services at checkout, lock every handler claim

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,17 @@ _Avoid_: Quota, max uses.
 **PaymentMethod**:
 A configurable tender (cash, transfer, QRIS, etc.). Same list across all Stores. An Order carries a PaymentMethod **only when `payment_status = paid`** — a tender is *how money arrived*, so an unpaid Order has none. The POS hides the method picker while a Cart is unpaid and drops any chosen method when it toggles back to unpaid; a paid Order **requires** one. This is a corollary of binary payment — see [ADR-0001](docs/adr/0001-payment-is-binary.md).
 
+### Activation
+
+**Active** (`is_active`):
+Whether a row may be used in day-to-day operation. Every table carrying the column starts in the state the business would pick by hand, and the two groups deliberately disagree:
+
+- **Starts inactive** — Category, Service, Product, PaymentMethod, Store. A catalog row is drafted before it is sellable: someone fills in a price, a COGS, a code, and only then puts it on sale. A half-finished Service appearing on six tills the moment it is saved is the worse accident, so the column defaults to `false`.
+- **Starts active** — User, Campaign. Both exist to work immediately: a new cashier logs in on their first shift, and a Campaign already carries its own date window and rules. Here `is_active` is the kill switch, not the go switch, so it defaults to `true`.
+
+Those DB defaults are close to inert in practice — `isActiveSchema` is a **required** boolean on every create payload (Campaign's create schema defaults it to `true`), so the default only surfaces in hand-written SQL. The rule that matters is where inactive is enforced: **server-side, never only in the browser**. Checkout rejects an inactive Service or Product even though the POS also hides them; login and `adminMiddleware` reject an inactive User; Campaign eligibility rejects an inactive Campaign.
+_Avoid_: enabled, published, visible.
+
 ### Operators
 
 **Store**:

--- a/packages/server/src/modules/orders/order-queue.service.test.ts
+++ b/packages/server/src/modules/orders/order-queue.service.test.ts
@@ -120,6 +120,7 @@ const {
   getMyOrderServices,
   getOrderServiceQueue,
   startOrderServiceWork,
+  updateOrderServiceHandler,
   updateOrderServiceStatus,
 } = await import("@/modules/orders/order-queue.service");
 
@@ -362,6 +363,61 @@ describe("getOrderServiceQueue", () => {
       items: [],
       meta: { limit: 25, offset: 0, total: 0 },
     });
+  });
+});
+
+describe("updateOrderServiceHandler", () => {
+  it("records the handler it took the garment from under the same lock it writes", async () => {
+    // Two supervisors reassigning one garment at the same moment: whoever
+    // commits second must log Sari as the previous handler, not the handler the
+    // first one saw. Reading it outside the lock forks the trail, and the trail
+    // is what the shop follows when an item cannot be found.
+    dbState.lockedRows = [
+      makeLockedRow({ handler_id: 9, status: "processing" }),
+    ];
+
+    const result = await updateOrderServiceHandler({
+      body: { handler_id: 11, note: "Sari went home" },
+      orderId: 88,
+      serviceId: 501,
+      user: ADMIN,
+    });
+
+    expect(result).toEqual({ handler_id: 11, order_service_id: 501 });
+    expect(dbState.transactions).toBe(1);
+    expect(dbState.updates).toEqual([
+      { table: ordersServicesTable, values: { handler_id: 11 } },
+    ]);
+    expect(dbState.inserts).toEqual([
+      {
+        table: orderServiceHandlerLogsTable,
+        values: {
+          changed_by: 1,
+          from_handler_id: 9,
+          note: "Sari went home",
+          order_service_id: 501,
+          to_handler_id: 11,
+        },
+      },
+    ]);
+  });
+
+  it("refuses a reassignment for a garment that is not on this order", async () => {
+    // A mistyped order number must not move a garment belonging to someone else.
+    dbState.lockedRows = [];
+
+    const error = await captureRejection(
+      updateOrderServiceHandler({
+        body: { handler_id: 11, note: "wrong order" },
+        orderId: 88,
+        serviceId: 501,
+        user: ADMIN,
+      })
+    );
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect(dbState.updates).toEqual([]);
+    expect(dbState.inserts).toEqual([]);
   });
 });
 

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -19,7 +19,7 @@ import {
   usersTable,
 } from "@/db/schema";
 import { BadRequestException, ForbiddenException } from "@/errors";
-import { getOrderServiceOrThrow } from "@/modules/orders/order.repository";
+import type { OrderTx } from "@/modules/orders/order.repository";
 import type {
   GetMyOrderServicesQuery,
   GetOrderServiceQueueQuery,
@@ -35,6 +35,7 @@ import {
 } from "@/modules/orders/order-status-machine";
 import { assertCanReassignHandler } from "@/modules/permissions/permissions";
 import type { JWTPayload } from "@/types";
+import type { OrderService } from "@/types/entity";
 import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
 import { jakartaDayEnd, jakartaDayStart } from "@/utils/date";
 import { buildPaginationMeta } from "@/utils/pagination";
@@ -266,6 +267,62 @@ export async function getOrderServiceQueue(
   };
 }
 
+interface ClaimHandlerInput {
+  lockedOrderService: OrderService;
+  note: string;
+  user: JWTPayload;
+}
+
+// Two scanners can hit the same tag at once, and only one of them may end up
+// holding the garment.
+async function lockOrderServiceOrThrow(
+  tx: OrderTx,
+  orderId: number,
+  serviceId: number
+) {
+  const [locked] = await tx
+    .select()
+    .from(ordersServicesTable)
+    .where(
+      and(
+        eq(ordersServicesTable.id, serviceId),
+        eq(ordersServicesTable.order_id, orderId)
+      )
+    )
+    .for("update");
+
+  if (!locked) {
+    throw new BadRequestException("Order service not found for this order");
+  }
+
+  return locked;
+}
+
+// The hand-off log is what the shop reads when a garment goes missing. Picking up
+// an item you already hold changes nothing — a second row would invent a hand-off
+// that never happened.
+async function claimHandler(
+  tx: OrderTx,
+  { lockedOrderService, note, user }: ClaimHandlerInput
+) {
+  if (lockedOrderService.handler_id === user.id) {
+    return;
+  }
+
+  await tx
+    .update(ordersServicesTable)
+    .set({ handler_id: user.id })
+    .where(eq(ordersServicesTable.id, lockedOrderService.id));
+
+  await tx.insert(orderServiceHandlerLogsTable).values({
+    order_service_id: lockedOrderService.id,
+    from_handler_id: lockedOrderService.handler_id,
+    to_handler_id: user.id,
+    changed_by: user.id,
+    note,
+  });
+}
+
 export async function startOrderServiceWork({
   orderId,
   serviceId,
@@ -276,20 +333,7 @@ export async function startOrderServiceWork({
   user: JWTPayload;
 }) {
   const result = await db.transaction(async (tx) => {
-    const [locked] = await tx
-      .select()
-      .from(ordersServicesTable)
-      .where(
-        and(
-          eq(ordersServicesTable.id, serviceId),
-          eq(ordersServicesTable.order_id, orderId)
-        )
-      )
-      .for("update");
-
-    if (!locked) {
-      throw new BadRequestException("Order service not found for this order");
-    }
+    const locked = await lockOrderServiceOrThrow(tx, orderId, serviceId);
 
     if (
       locked.handler_id !== null &&
@@ -301,20 +345,11 @@ export async function startOrderServiceWork({
       );
     }
 
-    if (locked.handler_id !== user.id) {
-      await tx
-        .update(ordersServicesTable)
-        .set({ handler_id: user.id })
-        .where(eq(ordersServicesTable.id, serviceId));
-
-      await tx.insert(orderServiceHandlerLogsTable).values({
-        order_service_id: serviceId,
-        from_handler_id: locked.handler_id,
-        to_handler_id: user.id,
-        changed_by: user.id,
-        note: "Started from queue",
-      });
-    }
+    await claimHandler(tx, {
+      note: "Started from queue",
+      lockedOrderService: locked,
+      user,
+    });
 
     const { from } = await transitionOrderService(tx, {
       orderId,
@@ -348,9 +383,12 @@ export async function updateOrderServiceHandler({
 }) {
   assertCanReassignHandler(user);
 
-  const orderService = await getOrderServiceOrThrow(orderId, serviceId);
-
   await db.transaction(async (tx) => {
+    // Who held the garment has to be read under the lock: two managers
+    // reassigning at once would otherwise both log the same previous handler,
+    // and the trail could no longer say who to ask when an item goes missing.
+    const orderService = await lockOrderServiceOrThrow(tx, orderId, serviceId);
+
     await tx
       .update(ordersServicesTable)
       .set({ handler_id: body.handler_id })
@@ -391,39 +429,19 @@ export async function updateOrderServiceStatus({
   }
 
   const fromStatus = await db.transaction(async (tx) => {
-    const [locked] = await tx
-      .select()
-      .from(ordersServicesTable)
-      .where(
-        and(
-          eq(ordersServicesTable.id, serviceId),
-          eq(ordersServicesTable.order_id, orderId)
-        )
-      )
-      .for("update");
+    const locked = await lockOrderServiceOrThrow(tx, orderId, serviceId);
 
-    if (!locked) {
-      throw new BadRequestException("Order service not found for this order");
-    }
-
+    // Restarting work on a queued or QC-rejected item means the person doing it
+    // now owns it — the worker who dropped it may have gone home.
     const isClaimTransition =
       (locked.status === "queued" || locked.status === "qc_reject") &&
       body.status === "processing";
-    const needsHandlerAssign =
-      isClaimTransition && locked.handler_id !== user.id;
 
-    if (needsHandlerAssign) {
-      await tx
-        .update(ordersServicesTable)
-        .set({ handler_id: user.id })
-        .where(eq(ordersServicesTable.id, serviceId));
-
-      await tx.insert(orderServiceHandlerLogsTable).values({
-        order_service_id: serviceId,
-        from_handler_id: locked.handler_id,
-        to_handler_id: user.id,
-        changed_by: user.id,
+    if (isClaimTransition) {
+      await claimHandler(tx, {
         note: "Auto-assigned on status update",
+        lockedOrderService: locked,
+        user,
       });
     }
 

--- a/packages/server/src/modules/orders/order.service.test.ts
+++ b/packages/server/src/modules/orders/order.service.test.ts
@@ -27,6 +27,7 @@ type AnyObj = Record<string, unknown>;
 interface CatalogService {
   cogs: string;
   id: number;
+  is_active: boolean;
   is_priority: boolean;
   price: string;
 }
@@ -330,8 +331,20 @@ describe("createOrder", () => {
     // must literally read 02082026 — the Jakarta business date — and no
     // rupiah may land in paid_amount before money actually changes hands.
     catalog.services = [
-      { id: 10, price: "30000", cogs: "12000", is_priority: false },
-      { id: 11, price: "15000", cogs: "4000", is_priority: false },
+      {
+        id: 10,
+        price: "30000",
+        cogs: "12000",
+        is_priority: false,
+        is_active: true,
+      },
+      {
+        id: 11,
+        price: "15000",
+        cogs: "4000",
+        is_priority: false,
+        is_active: true,
+      },
     ];
 
     const result = await checkout({ services: [{ id: 10 }, { id: 11 }] });
@@ -391,7 +404,13 @@ describe("createOrder", () => {
     // holds Rp45.000 — booking the gross would overstate revenue by the
     // discount, and the promo's redemption must be burned in the same breath.
     catalog.services = [
-      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+      {
+        id: 10,
+        price: "50000",
+        cogs: "20000",
+        is_priority: false,
+        is_active: true,
+      },
     ];
     discount.result = {
       campaignRows: [{ campaign_id: 3, kind: "listed" }],
@@ -437,7 +456,13 @@ describe("createOrder", () => {
     // total is nonsense at the till — and the customer's slip must survive the
     // failed checkout so they can retry, not lose the code to a dead order.
     catalog.services = [
-      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+      {
+        id: 10,
+        price: "50000",
+        cogs: "20000",
+        is_priority: false,
+        is_active: true,
+      },
     ];
     discount.result = {
       campaignRows: [
@@ -465,7 +490,13 @@ describe("createOrder", () => {
     // the exact-match comp would strand the manager's apology voucher. And the
     // voucher still burns, or the customer washes free twice.
     catalog.services = [
-      { id: 10, price: "50000", cogs: "20000", is_priority: false },
+      {
+        id: 10,
+        price: "50000",
+        cogs: "20000",
+        is_priority: false,
+        is_active: true,
+      },
     ];
     discount.result = {
       campaignRows: [
@@ -514,6 +545,30 @@ describe("createOrder", () => {
     expect(repo.insertedOrder).toBeUndefined();
   });
 
+  it("refuses a retired treatment a still-open till keeps offering", async () => {
+    // The shop pulled suede restoration off the menu this morning, but the
+    // cashier's tablet has been open since before that and still lists it. The
+    // POS only hides retired treatments client-side, so nothing but this gate
+    // stops its price and COGS being snapshotted onto a live order.
+    catalog.services = [
+      {
+        id: 12,
+        price: "40000",
+        cogs: "18000",
+        is_priority: false,
+        is_active: false,
+      },
+    ];
+
+    const error = await captureRejection(checkout({ services: [{ id: 12 }] }));
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as Error).message).toBe("Service is not active: 12");
+    expect(repo.reserveCalls).toHaveLength(0);
+    expect(repo.insertedOrder).toBeUndefined();
+    expect(repo.serviceRows).toEqual([]);
+  });
+
   it("lets an out-of-stock failure escape the transaction so no half-created order survives", async () => {
     // Two cashiers race for the last bottle. The loser's order row was already
     // written inside the transaction — the thrown error is what rolls it back;
@@ -554,8 +609,20 @@ describe("createOrder", () => {
     // receipt code; a line without an explicit priority takes the service's
     // default, an explicit choice beats it.
     catalog.services = [
-      { id: 10, price: "30000", cogs: "12000", is_priority: true },
-      { id: 11, price: "15000", cogs: "4000", is_priority: true },
+      {
+        id: 10,
+        price: "30000",
+        cogs: "12000",
+        is_priority: true,
+        is_active: true,
+      },
+      {
+        id: 11,
+        price: "15000",
+        cogs: "4000",
+        is_priority: true,
+        is_active: true,
+      },
     ];
     catalog.products = [
       {
@@ -611,7 +678,13 @@ describe("createOrder", () => {
     // Most orders are handed over the counter; only courier-collected bags
     // must name an active courier, so the check must not fire for walk-ins.
     catalog.services = [
-      { id: 10, price: "30000", cogs: "12000", is_priority: false },
+      {
+        id: 10,
+        price: "30000",
+        cogs: "12000",
+        is_priority: false,
+        is_active: true,
+      },
     ];
 
     await checkout({ services: [{ id: 10 }] });

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -70,38 +70,73 @@ type OrderProductInput = NonNullable<
   z.infer<typeof POSTOrderSchema>["products"]
 >[number];
 
+interface CatalogLine<TItem, TRow> {
+  item: TItem;
+  row: TRow;
+}
+
+// A till stays open for hours and the POS only hides retired items on screen, so
+// the basket is matched against the live catalog here — before the transaction,
+// so a doomed order never burns a daily order number.
+function resolveCatalogLines<
+  TItem extends { id: number },
+  TRow extends { id: number; is_active: boolean },
+>(label: string, items: TItem[], rows: TRow[]): CatalogLine<TItem, TRow>[] {
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const missing = new Set<number>();
+  const inactive = new Set<number>();
+  const lines: CatalogLine<TItem, TRow>[] = [];
+
+  for (const item of items) {
+    const row = rowsById.get(item.id);
+
+    if (!row) {
+      missing.add(item.id);
+    } else if (row.is_active) {
+      lines.push({ item, row });
+    } else {
+      inactive.add(item.id);
+    }
+  }
+
+  if (missing.size > 0) {
+    throw new NotFoundException(
+      `${label} not found: ${[...missing].join(", ")}`
+    );
+  }
+
+  if (inactive.size > 0) {
+    throw new BadRequestException(
+      `${label} is not active: ${[...inactive].join(", ")}`
+    );
+  }
+
+  return lines;
+}
+
 function buildOrderServiceRows({
   code,
-  expandedServices,
   orderId,
-  serviceMap,
+  serviceLines,
 }: {
   code: string;
-  expandedServices: ExpandedServiceItem[];
   orderId: number;
-  serviceMap: Map<number, DbService>;
+  serviceLines: CatalogLine<ExpandedServiceItem, DbService>[];
 }) {
-  return expandedServices.map((item, index) => {
-    const service = serviceMap.get(item.id);
-    if (!service) {
-      throw new NotFoundException(`Service not found: ${item.id}`);
-    }
-
-    return {
-      brand: item.brand,
-      item_code: `${code}-S${String(index + 1).padStart(3, "0")}`,
-      is_priority: item.is_priority ?? service.is_priority,
-      model: item.model,
-      order_id: orderId,
-      service_id: service.id,
-      price: service.price,
-      cogs_snapshot: service.cogs,
-      notes: item.notes,
-      color: item.color,
-      size: item.size,
-      status: "queued" as const,
-    };
-  });
+  return serviceLines.map(({ item, row: service }, index) => ({
+    brand: item.brand,
+    item_code: `${code}-S${String(index + 1).padStart(3, "0")}`,
+    is_priority: item.is_priority ?? service.is_priority,
+    model: item.model,
+    order_id: orderId,
+    service_id: service.id,
+    price: service.price,
+    cogs_snapshot: service.cogs,
+    notes: item.notes,
+    color: item.color,
+    size: item.size,
+    status: "queued" as const,
+  }));
 }
 
 export async function listOrders(query?: GetOrdersQuery, user?: JWTPayload) {
@@ -126,15 +161,13 @@ export async function listOrders(query?: GetOrdersQuery, user?: JWTPayload) {
 
 async function decrementProductsStock(
   tx: OrderTx,
-  products: OrderProductInput[],
-  productMap: Map<number, DbProduct>
+  productLines: CatalogLine<OrderProductInput, DbProduct>[]
 ) {
-  for (const item of products) {
-    const [decremented] = await decrementProductStock(tx, item.id, item.qty);
+  for (const { item, row: product } of productLines) {
+    const [decremented] = await decrementProductStock(tx, product.id, item.qty);
     if (!decremented) {
-      const product = productMap.get(item.id);
       throw new BadRequestException(
-        `Insufficient stock for product ${product?.name ?? item.id}`
+        `Insufficient stock for product ${product.name}`
       );
     }
   }
@@ -165,41 +198,17 @@ export async function createOrder(
     serviceIds.length > 0 ? findServices(serviceIds) : Promise.resolve([]),
   ]);
 
-  const productMap = new Map(
-    dbProducts.map((product) => [product.id, product])
+  const productLines = resolveCatalogLines("Product", products, dbProducts);
+  const serviceLines = resolveCatalogLines(
+    "Service",
+    expandServices(services),
+    dbServices
   );
-  const serviceMap = new Map(
-    dbServices.map((service) => [service.id, service])
-  );
-
-  const missingProducts = productIds.filter((id) => !productMap.has(id));
-  if (missingProducts.length > 0) {
-    throw new NotFoundException(
-      `Product not found: ${missingProducts.join(", ")}`
-    );
-  }
-
-  const inactiveProducts = productIds.filter(
-    (id) => !productMap.get(id)?.is_active
-  );
-  if (inactiveProducts.length > 0) {
-    throw new BadRequestException(
-      `Product is not active: ${inactiveProducts.join(", ")}`
-    );
-  }
-
-  const missingServices = serviceIds.filter((id) => !serviceMap.has(id));
-  if (missingServices.length > 0) {
-    throw new NotFoundException(
-      `Service not found: ${missingServices.join(", ")}`
-    );
-  }
 
   return db.transaction(async (tx) => {
     const dateStr = jakartaNow().format("DDMMYYYY");
     const sequence = await reserveNextOrderNumber(tx, store.code, dateStr);
     const code = formatOrderCode(store.code, dateStr, sequence);
-    const expandedServices = expandServices(services);
 
     const customerId = await resolveOrCreateCustomer({
       executor: tx,
@@ -218,8 +227,8 @@ export async function createOrder(
       discount_source: "none",
       paid_amount: "0",
       notes: orderPayload.notes,
-      status: expandedServices.length > 0 ? "created" : "completed",
-      completed_at: expandedServices.length > 0 ? null : new Date(),
+      status: serviceLines.length > 0 ? "created" : "completed",
+      completed_at: serviceLines.length > 0 ? null : new Date(),
       paid_at: null,
       store_id: store.id,
       collected_by: orderPayload.collected_by ?? null,
@@ -227,48 +236,35 @@ export async function createOrder(
       updated_by: userId,
     });
 
-    await decrementProductsStock(tx, products, productMap);
+    await decrementProductsStock(tx, productLines);
 
     const [serviceSubtotal, productSubtotal] = await Promise.all([
       insertOrderServices(
         tx,
         buildOrderServiceRows({
           code,
-          expandedServices,
           orderId,
-          serviceMap,
+          serviceLines,
         })
       ),
       insertOrderProducts(
         tx,
-        products.map((item) => {
-          const product = productMap.get(item.id);
-          if (!product) {
-            throw new NotFoundException(`Product not found: ${item.id}`);
-          }
-
-          return {
-            order_id: orderId,
-            product_id: product.id,
-            price: product.price,
-            // COGS is stored in whole rupiah, like every amount at the counter.
-            cogs_snapshot: Math.round(
-              Number(product.cogs) * item.qty
-            ).toString(),
-            qty: item.qty,
-          };
-        })
+        productLines.map(({ item, row: product }) => ({
+          order_id: orderId,
+          product_id: product.id,
+          price: product.price,
+          // COGS is stored in whole rupiah, like every amount at the counter.
+          cogs_snapshot: Math.round(Number(product.cogs) * item.qty).toString(),
+          qty: item.qty,
+        }))
       ),
     ]);
 
     const grossTotal = serviceSubtotal + productSubtotal;
-    const lines = expandedServices.map((item) => {
-      const service = serviceMap.get(item.id);
-      return {
-        price: Number(service?.price ?? 0),
-        service_id: item.id,
-      };
-    });
+    const lines = serviceLines.map(({ item, row: service }) => ({
+      price: Number(service.price),
+      service_id: item.id,
+    }));
 
     const { discountAmount, discountSource, campaignRows } =
       await resolveDiscount({

--- a/packages/server/src/routes/admin/reports.ts
+++ b/packages/server/src/routes/admin/reports.ts
@@ -2,13 +2,11 @@ import { Hono } from "hono";
 import { assertIsAdmin } from "@/modules/permissions/permissions";
 import {
   GETAgingQueueQuerySchema,
-  GETDailyReportQuerySchema,
   GETReportOverviewQuerySchema,
   GETReportRangeQuerySchema,
 } from "@/modules/reports/report.schema";
 import {
   getAgingQueueReport,
-  getDailyReport,
   getReportOverview,
 } from "@/modules/reports/report.service";
 import {
@@ -30,21 +28,6 @@ const app = new Hono()
     assertIsAdmin(c.get("jwtPayload") as JWTPayload);
     await next();
   })
-  .get(
-    "/daily",
-    zodValidator("query", GETDailyReportQuerySchema),
-    async (c) => {
-      const user = c.get("jwtPayload") as JWTPayload;
-
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-
-      const data = await getDailyReport(query);
-      return c.json(success(data));
-    }
-  )
   .get(
     "/overview",
     zodValidator("query", GETReportOverviewQuerySchema),


### PR DESCRIPTION
Audit findings **S7, S9, S10, S11, S12** — plus a **pre-existing lost update** the S9 review turned up.

### S7 — a retired service was still sellable

`createOrder` rejected inactive *products* but not inactive *services*, three lines apart. So "you cannot sell a retired service" lived only in the browser: a till open since before a service was retired could still sell it, and the server snapshotted its price and COGS onto the order. The POS filtering retired rows out client-side is exactly why this survived — it makes the gap invisible in normal use.

Now symmetric with the products path. Test added, verified to fail without the fix.

### S12 — the "unreachable" throws were load-bearing for the type system

The two dead `NotFoundException`s were what narrowed `T | undefined` to `T`. Deleting them required either a cast (forbidden) or a restructure. I took the restructure: the catalog check now *returns* the rows it resolved, so downstream code receives real entities instead of re-fetching from a map of optionals.

That's why `order.service.ts` is larger than "add a gate" implies — and it paid for itself by deleting two fictional fallbacks the throws were hiding:

```diff
- price: Number(service?.price ?? 0)   // a map miss discounted against a zero line
+ price: Number(service.price)
- `Insufficient stock for product ${product?.name ?? item.id}`
+ `Insufficient stock for product ${product.name}`
```

### S9 — and a third copy that was actually broken

Extracted the row lock and the claim write. **Deliberately did not merge** the `Forbidden` guard or the claim decision, because the two callers genuinely differ: starting work *refuses* to take an item off a colleague, while a status change is *meant* to take over from a worker who went home. Folding either in would have silently broken the QC-redo takeover or let the status dropdown steal any item.

Doing that surfaced a third copy of the same write pair that nobody had flagged — `updateOrderServiceHandler` read the current handler **outside** its transaction with no lock, then blind-wrote inside it:

```
t0  item 88: handler_id = 7 (Budi)
t1  Mgr A reassigns to 9  → reads 7   (unlocked, outside tx)
t2  Mgr B reassigns to 11 → reads 7   (unlocked, outside tx)
t3  A commits: handler_id = 9  ; log(from 7 → 9)
t4  B commits: handler_id = 11 ; log(from 7 → 11)
```

End state: two log rows both claim they took it from Budi. Sari (9) never appears as a `from`, so replaying the hand-off chain forks and there's no path to the person actually holding the garment — which is the one question that table exists to answer.

The read now happens under the same lock as the write. Behaviour-preserving for the missing-row case: `getOrderServiceOrThrow` and `lockOrderServiceOrThrow` throw the identical exception. Two tests added (the path had none), mutation-verified:

```
with the unlocked read restored:  1 fail
restored:                        14 pass, 0 fail
```

### S10 — dead report route removed

⚠️ **This deletes an endpoint** — `GET /admin/reports/daily`. Flagging it because you're overhauling reports separately: nothing called it (no `fetchDailyReport` in `lib/api.ts`, not in `vercel.json` crons), and `getDailyReport` *the function* is kept because `getReportOverview` uses it. Easy to revive from git if the overhaul wants it.

### S11 — the audit was wrong here

It claimed "creating a service through the API without explicitly passing `is_active` yields a service nobody can sell, with no error." Not true: `isActiveSchema` is a **required** boolean on every create payload, so omitting it is a **400**, not a silent unsellable row. Every seed insert also sets it explicitly.

So the finding reduces to an undocumented inconsistency (`users`/`campaigns` default `true`, the five catalog tables default `false`). **No default changed, no DDL run** — churning a default nothing reads has no value. The convention those defaults encode is written into `CONTEXT.md` instead, along with the rule that actually matters: inactive is enforced server-side, never only in the browser.

Suggested audit correction for S11: *"the create API rejects a missing `is_active` with 400; the column defaults are undocumented and disagree across tables."*

### Verification

`ultracite check` clean · `type-check` 3/3 · **287 server + 78 web tests, 0 fail** · `build` green.

No file under `apps/web/` changed — server-only batch. Nothing under `features/reports/`. No new casts, non-null assertions, or `any`; no existing test assertion edited (checked explicitly, since that happened in an earlier batch — this time the only fixture change is a *required* new `is_active` field, which forces every fixture to state it rather than letting a default satisfy the new gate).