### PR TITLE
refactor(server): one store scope, one order access gate

### DIFF
--- a/docs/audit/2026-08-05-code-quality-audit.html
+++ b/docs/audit/2026-08-05-code-quality-audit.html
@@ -276,6 +276,27 @@
     .sev.lo {
       color: var(--lo);
     }
+    .shipped {
+      padding: 0.15em 0.5em;
+      font-family: var(--mono);
+      font-size: 9.5px;
+      font-weight: 600;
+      color: var(--ok);
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      white-space: nowrap;
+      text-decoration: none;
+      border: 1px solid currentColor;
+    }
+    .shipped:hover,
+    .shipped:focus-visible {
+      color: var(--bg);
+      background: var(--ok);
+    }
+    td .shipped {
+      text-transform: none;
+      letter-spacing: 0.04em;
+    }
     .f-title {
       flex: 1 1 20rem;
       margin: 0;
@@ -458,8 +479,108 @@
             <dt>High</dt>
             <dd>10</dd>
           </div>
+          <div class="fact">
+            <dt>Shipped</dt>
+            <dd>15 / 39</dd>
+          </div>
         </dl>
       </header>
+
+      <div class="note good">
+        <p>
+          <strong>Remediation in progress.</strong>
+          Fifteen findings are fixed and merged. Each carries a
+          <a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pulls?q=is%3Apr+is%3Amerged"
+            >Shipped</a
+          >
+          badge linking its pull request, and several carry a closing note where
+          the fix diverged from what this report prescribed — or where the
+          finding turned out to be wrong.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>PR</th>
+              <th>Findings</th>
+              <th>What it closed</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/78">#78</a>
+              </td>
+              <td>
+                <a href="#m1">M1</a> <a href="#m2">M2</a> <a href="#m3">M3</a>
+                <a href="#m4">M4</a> <a href="#m5">M5</a>
+              </td>
+              <td>
+                Money integrity. <code>orders.total</code> is
+                <code>NOT NULL</code>
+                in both databases, so the three CHECK constraints that reference
+                it are armed for the first time. Editing a price now passes the
+                same guard as creating one — before, <code>PUT</code> read
+                <code>"1.500"</code>
+                as one and a half rupiah.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/79">#79</a>
+              </td>
+              <td>
+                <a href="#s1">S1</a> <a href="#s2">S2</a>
+                <a href="#s14">S14</a>
+              </td>
+              <td>
+                Error bodies no longer carry customer data, and unhandled errors
+                reach stdout. Three leaks beyond S2 were found and closed, one
+                of them returning a password hash.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/80">#80</a>
+              </td>
+              <td>
+                <a href="#s7">S7</a> <a href="#s9">S9</a> <a href="#s10">S10</a>
+                <a href="#s11">S11</a> <a href="#s12">S12</a>
+              </td>
+              <td>
+                A retired service can no longer be sold from a stale till, and
+                every handler claim is read under the lock it writes — which
+                fixed a live lost update S9 did not know about.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/81">#81</a>
+              </td>
+              <td><a href="#c2">C2</a> <a href="#c3">C3</a></td>
+              <td>
+                One error style on the server.
+                <code>Extract&lt;&gt;</code>
+                wrappers in
+                <code>lib/api.ts</code>: 25 to 0, proven a no-op on the wire for
+                all five status classes.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          Still open: <a href="#c1">C1</a> (in review),
+          <a href="#s3">S3</a>–<a href="#s6">S6</a>,
+          <a href="#s8">S8</a>, <a href="#s13">S13</a>, and the web findings.
+          <a href="#w1">W1</a>, <a href="#w2">W2</a>, <a href="#w6">W6</a> and
+          <a href="#w15">W15</a>
+          are deferred: the report page they cover is being rewritten, so
+          nothing under
+          <code>features/reports/</code>
+          has been touched.
+        </p>
+      </div>
 
       <div class="note good">
         <p>
@@ -765,7 +886,12 @@
 
       <article class="f hi" id="m1">
         <div class="f-head">
-          <span class="id">M1</span><span class="sev hi">High</span>
+          <span class="id">M1</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/78"
+            >Shipped #78</a
+          >
           <h3 class="f-title">
             <code>orders.total</code>
             is the only nullable money column, and three CHECK constraints
@@ -859,7 +985,12 @@ check("paid_amount_valid_check",   sql`${table.paid_amount} <= ${table.total}`) 
 
       <article class="f hi" id="m2">
         <div class="f-head">
-          <span class="id">M2</span><span class="sev hi">High</span>
+          <span class="id">M2</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/78"
+            >Shipped #78</a
+          >
           <h3 class="f-title">
             "Money is whole rupiah" is a real invariant that nothing in the
             codebase states — and the database enforces it by silently rounding
@@ -975,11 +1106,23 @@ longitude: decimal("longitude", { precision: 11, scale: 8 }).notNull(),  // :59<
           <em>all monetary columns are whole IDR; there is no sub-unit.</em>
           One comment retires the whole class of question.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Twenty-four columns, not twenty-two — the count here was low.
+            Verified against both live databases rather than the schema file.
+          </p>
+        </div>
       </article>
 
       <article class="f md" id="m3">
         <div class="f-head">
-          <span class="id">M3</span><span class="sev md">Medium</span>
+          <span class="id">M3</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/78"
+            >Shipped #78</a
+          >
           <h3 class="f-title">
             <code>.toFixed(2)</code>
             writes cents into a column that cannot hold them
@@ -1041,11 +1184,26 @@ longitude: decimal("longitude", { precision: 11, scale: 8 }).notNull(),  // :59<
           was defensive rounding, <code>Math.round</code> states that intent
           honestly and matches what the column will do anyway.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Kept <code>Math.round</code> rather than dropping the rounding, so
+            the line says what the column will do. The test that fed it
+            fractional COGS had been quietly changed to whole rupiah, which
+            removed the only case exercising this line; the fraction is back and
+            the assertion now pins the rounded result.
+          </p>
+        </div>
       </article>
 
       <article class="f md" id="m4">
         <div class="f-head">
-          <span class="id">M4</span><span class="sev md">Medium</span>
+          <span class="id">M4</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/78"
+            >Shipped #78</a
+          >
           <h3 class="f-title">
             <code>currencySchema</code>
             is a five-stage round-trip whose validation cannot fail
@@ -1138,7 +1296,12 @@ export const currencySchema = (field: string) =>
 
       <article class="f md" id="m5">
         <div class="f-head">
-          <span class="id">M5</span><span class="sev md">Medium</span>
+          <span class="id">M5</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/78"
+            >Shipped #78</a
+          >
           <h3 class="f-title">
             Money has two TypeScript types depending on which endpoint you
             called
@@ -1228,6 +1391,21 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
           <code>toRupiah(value: string): number</code>
           so the coercion lives in one place instead of forty.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Took the second option, not the preferred one. Serialising money as
+            a number everywhere means rewriting every read path including the
+            reports module, which is being overhauled separately — so
+            <code>createOrder</code>
+            now returns strings like every other endpoint, and one
+            <code>parseMoney</code>/<code>formatMoney</code>
+            pair holds the coercion. That pair also fixed a latent bug this
+            finding did not reach: formatting <code>"45000.00"</code> by
+            stripping non-digits prints <code>Rp&nbsp;4.500.000</code>, a
+            hundred times the price.
+          </p>
+        </div>
       </article>
 
       <!-- ══════════════════════════════════════════════════ -->
@@ -1347,7 +1525,12 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
 
       <article class="f hi" id="c2">
         <div class="f-head">
-          <span class="id">C2</span><span class="sev hi">High</span>
+          <span class="id">C2</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/81"
+            >Shipped #81</a
+          >
           <h3 class="f-title">
             Two error styles on the server produce 25
             <code>Extract&lt;…, { success: true}&gt;</code>
@@ -1418,11 +1601,31 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
           <code>Extract&lt;&gt;</code>
           wrappers on the other side of the boundary.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Thirty-five conversions across twelve files, not thirty-three across
+            eleven —
+            <code>routes/public/orders.ts</code>
+            was missing from the evidence. And twelve of the twenty-five
+            wrappers were <em>already</em> dead before the change: the nine
+            reports routes, two shifts routes and the complaints list never
+            returned inline failures. So the real footprint was thirteen
+            wrappers. Login needed one extra step — it was the only route on raw
+            <code>zValidator</code>, which kept its 400 body in the response
+            type; it now uses the same wrapper as everything else.
+          </p>
+        </div>
       </article>
 
       <article class="f md" id="c3">
         <div class="f-head">
-          <span class="id">C3</span><span class="sev md">Medium</span>
+          <span class="id">C3</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/81"
+            >Shipped #81</a
+          >
           <h3 class="f-title">Three mechanisms for one timezone</h3>
           <div class="tags"><span class="tag">dates</span></div>
         </div>
@@ -1481,7 +1684,12 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
 
       <article class="f hi" id="s1">
         <div class="f-head">
-          <span class="id">S1</span><span class="sev hi">High</span>
+          <span class="id">S1</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/79"
+            >Shipped #79</a
+          >
           <h3 class="f-title">
             Unhandled 500s are silent — the error log is commented out
           </h3>
@@ -1522,7 +1730,12 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
 
       <article class="f hi" id="s2">
         <div class="f-head">
-          <span class="id">S2</span><span class="sev hi">High</span>
+          <span class="id">S2</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/79"
+            >Shipped #79</a
+          >
           <h3 class="f-title">
             Raw Postgres <code>detail</code> is returned to the client — and it
             contains customer PII
@@ -1586,6 +1799,25 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
           <code>utils/errors.ts</code>
           to hang the constraint-name switch off.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Reviewing the first attempt turned up three more leaks, one worse
+            than this finding. The fall-through returned
+            <code>err.message</code>, which Drizzle builds from the failed query
+            and every bound parameter — so a dropped connection mid-save
+            returned the whole submitted row, and on
+            <code>POST /admin/users</code>
+            the new password hash.
+            <code>asPostgresError</code>
+            also inspected only
+            <code>err.cause</code>, so the mapping was dead for every
+            <code>db.query.*</code>
+            read, and the <code>HTTPException</code>
+            branch still handed <code>err.cause</code> to the client. All four
+            are covered by tests verified to fail when the leak is put back.
+          </p>
+        </div>
       </article>
 
       <article class="f hi" id="s3">
@@ -1863,7 +2095,12 @@ if (storeId !== undefined) {
 
       <article class="f md" id="s7">
         <div class="f-head">
-          <span class="id">S7</span><span class="sev md">Medium</span>
+          <span class="id">S7</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/80"
+            >Shipped #80</a
+          >
           <h3 class="f-title">
             <code>createOrder</code>
             rejects inactive products but not inactive services
@@ -1979,7 +2216,12 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
 
       <article class="f lo" id="s9">
         <div class="f-head">
-          <span class="id">S9</span><span class="sev lo">Low</span>
+          <span class="id">S9</span><span class="sev lo">Low</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/80"
+            >Shipped #80</a
+          >
           <h3 class="f-title">
             The handler-claim transaction is written twice
           </h3>
@@ -2018,11 +2260,32 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
           more here than the line count — this is the concurrency-sensitive
           path.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            Only the lock and the claim write were merged. The
+            <code>Forbidden</code>
+            guard and the claim decision stayed at their call sites because they
+            genuinely differ — starting work refuses to take an item off a
+            colleague, while a status change is meant to take over from a worker
+            who went home. Extracting the helper also exposed a third copy that
+            was actually broken:
+            <code>updateOrderServiceHandler</code>
+            read the current handler outside its transaction with no lock, so
+            two supervisors reassigning one garment both logged the same
+            previous handler and the hand-off trail forked.
+          </p>
+        </div>
       </article>
 
       <article class="f lo" id="s10">
         <div class="f-head">
-          <span class="id">S10</span><span class="sev lo">Low</span>
+          <span class="id">S10</span><span class="sev lo">Low</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/80"
+            >Shipped #80</a
+          >
           <h3 class="f-title">
             <code>GET /admin/reports/daily</code>
             has no consumer
@@ -2047,7 +2310,12 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
 
       <article class="f lo" id="s11">
         <div class="f-head">
-          <span class="id">S11</span><span class="sev lo">Low</span>
+          <span class="id">S11</span><span class="sev lo">Low</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/80"
+            >Shipped #80</a
+          >
           <h3 class="f-title">
             <code>is_active</code>
             defaults disagree across tables
@@ -2080,11 +2348,28 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
           settle it, settle it — and the reasoning belongs in
           <code>CONTEXT.md</code>.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped — this finding's premise was wrong.</strong>
+            <code>is_active</code>
+            is a required boolean on every create payload, so omitting it is a
+            400, not a silently unsellable row. No default was changed and no
+            DDL run; the convention the defaults encode is written into
+            <code>CONTEXT.md</code>
+            instead. Read it as: the column defaults are undocumented and
+            disagree across tables.
+          </p>
+        </div>
       </article>
 
       <article class="f lo" id="s12">
         <div class="f-head">
-          <span class="id">S12</span><span class="sev lo">Low</span>
+          <span class="id">S12</span><span class="sev lo">Low</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/80"
+            >Shipped #80</a
+          >
           <h3 class="f-title">
             Two unreachable defensive throws in <code>createOrder</code>
           </h3>
@@ -2101,6 +2386,19 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
           because on first read they suggest the earlier validation might be
           incomplete.
         </p>
+        <div class="note good">
+          <p>
+            <strong>How it shipped.</strong>
+            The throws were load-bearing — they were what narrowed
+            <code>T | undefined</code>
+            to <code>T</code>. Deleting them needed either a cast or a
+            restructure, so the catalog check now returns the rows it resolved.
+            That also deleted two fictional fallbacks the throws had been
+            hiding, including
+            <code>Number(service?.price ?? 0)</code>, which fed the discount
+            desk a zero line on a map miss.
+          </p>
+        </div>
       </article>
 
       <article class="f lo" id="s13">
@@ -2126,7 +2424,12 @@ const missingServices  = serviceIds.filter(id => !serviceMap.has(id));        //
 
       <article class="f lo" id="s14">
         <div class="f-head">
-          <span class="id">S14</span><span class="sev lo">Low</span>
+          <span class="id">S14</span><span class="sev lo">Low</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/79"
+            >Shipped #79</a
+          >
           <h3 class="f-title">
             CORS allows localhost only, and doesn't say why that's fine
           </h3>
@@ -3163,6 +3466,7 @@ const visibleStores = useMemo(() =&gt; {
               <th>Do</th>
               <th>Why now</th>
               <th>Size</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
@@ -3178,6 +3482,13 @@ const visibleStores = useMemo(() =&gt; {
                 Nothing else in this report has this ratio.
               </td>
               <td class="num">5 min</td>
+              <td>
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/78"
+                  >Shipped #78</a
+                >
+              </td>
             </tr>
             <tr>
               <td class="num">2</td>
@@ -3188,6 +3499,13 @@ const visibleStores = useMemo(() =&gt; {
               </td>
               <td>The two that hurt in production. One is a single line.</td>
               <td class="num">&lt; 1h</td>
+              <td>
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/79"
+                  >Shipped #79</a
+                >
+              </td>
             </tr>
             <tr>
               <td class="num">3</td>
@@ -3203,6 +3521,13 @@ const visibleStores = useMemo(() =&gt; {
                 enforces.
               </td>
               <td class="num">2h</td>
+              <td>
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/78"
+                  >Shipped #78</a
+                >
+              </td>
             </tr>
             <tr>
               <td class="num">4</td>
@@ -3217,6 +3542,15 @@ const visibleStores = useMemo(() =&gt; {
                 to read.
               </td>
               <td class="num">half day</td>
+              <td>
+                C2
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/81"
+                  >#81</a
+                >
+                · S6 open
+              </td>
             </tr>
             <tr>
               <td class="num">5</td>
@@ -3230,6 +3564,7 @@ const visibleStores = useMemo(() =&gt; {
                 two enforced ones.
               </td>
               <td class="num">1 day</td>
+              <td>C1 in review · S4 open</td>
             </tr>
             <tr>
               <td class="num">6</td>
@@ -3244,6 +3579,7 @@ const visibleStores = useMemo(() =&gt; {
                 needs a net first.
               </td>
               <td class="num">2 days</td>
+              <td>Open</td>
             </tr>
             <tr>
               <td class="num">7</td>
@@ -3257,6 +3593,7 @@ const visibleStores = useMemo(() =&gt; {
                 code-splitting reports already pays for.
               </td>
               <td class="num">2 days</td>
+              <td>Deferred — report overhaul</td>
             </tr>
             <tr>
               <td class="num">8</td>
@@ -3270,6 +3607,7 @@ const visibleStores = useMemo(() =&gt; {
                 Four independent, contained changes. Any one is an afternoon.
               </td>
               <td class="num">2 days</td>
+              <td>Open</td>
             </tr>
             <tr>
               <td class="num">9</td>
@@ -3281,6 +3619,21 @@ const visibleStores = useMemo(() =&gt; {
               </td>
               <td>Small correctness items worth not carrying.</td>
               <td class="num">&lt; 2h</td>
+              <td>
+                S7
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/80"
+                  >#80</a
+                >
+                · M3
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/78"
+                  >#78</a
+                >
+                · W10 open
+              </td>
             </tr>
             <tr>
               <td class="num">10</td>
@@ -3290,6 +3643,15 @@ const visibleStores = useMemo(() =&gt; {
                 branch.
               </td>
               <td class="num">—</td>
+              <td>
+                S9–S12, S14
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/80"
+                  >#80</a
+                >
+                · web Low open
+              </td>
             </tr>
           </tbody>
         </table>

--- a/packages/server/src/modules/complaints/complaint.service.test.ts
+++ b/packages/server/src/modules/complaints/complaint.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { BadRequestException, NotFoundException } from "@/errors";
 import { normalizeComplaintListQuery } from "@/modules/complaints/complaint.schema";
+import { authorizationDouble } from "@/test-support/authorization-double";
 import { captureRejection } from "@/test-support/capture-rejection";
 import type { JWTPayload } from "@/types";
 
@@ -58,13 +59,7 @@ mock.module("@/modules/orders/order-status-machine", () => ({
   },
 }));
 
-mock.module("@/utils/authorization", () => ({
-  assertStoreAccess: (user: { id: number }, storeId: number) => {
-    authz.assertCalls.push({ userId: user.id, storeId });
-    return Promise.resolve();
-  },
-  getUserStoreIds: () => Promise.resolve(authz.storeIds),
-}));
+mock.module("@/utils/authorization", () => authorizationDouble(authz));
 
 mock.module("@/modules/complaints/complaint.repository", () => ({
   findComplaintSubjectService: () => Promise.resolve(repo.subject),

--- a/packages/server/src/modules/complaints/complaint.service.ts
+++ b/packages/server/src/modules/complaints/complaint.service.ts
@@ -20,7 +20,11 @@ import {
   recomputeOrderRollup,
 } from "@/modules/orders/order-status-machine";
 import type { JWTPayload } from "@/types";
-import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
+import {
+  assertStoreAccess,
+  resolveStoreScope,
+  unhandledStoreScope,
+} from "@/utils/authorization";
 import { buildPaginationMeta } from "@/utils/pagination";
 
 type SubjectService = NonNullable<
@@ -178,14 +182,26 @@ export async function listComplaints(
   query?: GetComplaintsQuery
 ) {
   const normalized = normalizeComplaintListQuery(query);
+  const scope = await resolveStoreScope(user, normalized.store_id);
   let scopedStoreIds: number[] | undefined;
 
-  if (user.role !== "admin") {
-    if (normalized.store_id === undefined) {
-      scopedStoreIds = await getUserStoreIds(user.id);
-    } else {
-      await assertStoreAccess(user, normalized.store_id);
-    }
+  switch (scope.kind) {
+    // Complaints are the branch's own returns desk — a cashier reviewing them
+    // sees the branches they work at, never another branch's grievances.
+    case "some":
+      scopedStoreIds = scope.storeIds;
+      break;
+    // A staff account not yet assigned to a branch: nothing, not everything.
+    case "none":
+      scopedStoreIds = [];
+      break;
+    // An admin reviews every branch, and a named branch is already the
+    // store_id filter the query carries.
+    case "all":
+    case "one":
+      break;
+    default:
+      return unhandledStoreScope(scope);
   }
 
   const { items, total } = await findComplaints(normalized, scopedStoreIds);

--- a/packages/server/src/modules/orders/order-queue.service.test.ts
+++ b/packages/server/src/modules/orders/order-queue.service.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { orderServiceHandlerLogsTable, ordersServicesTable } from "@/db/schema";
 import { BadRequestException, ForbiddenException } from "@/errors";
 import type { PatchOrderServiceStatusInput } from "@/modules/orders/order-admin.schema";
+import { authorizationDouble } from "@/test-support/authorization-double";
 import { captureRejection } from "@/test-support/capture-rejection";
 import type { JWTPayload } from "@/types";
 
@@ -83,10 +84,7 @@ const authz = {
   storeIds: [] as number[],
 };
 
-mock.module("@/utils/authorization", () => ({
-  assertStoreAccess: () => Promise.resolve(),
-  getUserStoreIds: () => Promise.resolve(authz.storeIds),
-}));
+mock.module("@/utils/authorization", () => authorizationDouble(authz));
 
 // Spread the real machine and stub only transitionOrderService: which moves are
 // legal is order-status-machine.test.ts's job; here we pin only what the queue

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -36,7 +36,7 @@ import {
 import { assertCanReassignHandler } from "@/modules/permissions/permissions";
 import type { JWTPayload } from "@/types";
 import type { OrderService } from "@/types/entity";
-import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
+import { resolveStoreScope, unhandledStoreScope } from "@/utils/authorization";
 import { jakartaDayEnd, jakartaDayStart } from "@/utils/date";
 import { buildPaginationMeta } from "@/utils/pagination";
 
@@ -100,20 +100,24 @@ export async function getMyOrderServices(
     );
   }
 
-  if (user.role === "admin") {
-    if (query.store_id !== undefined) {
-      conditions.push(eq(ordersTable.store_id, query.store_id));
-    }
-  } else if (query.store_id === undefined) {
-    const storeIds = await getUserStoreIds(user.id);
-    if (storeIds.length === 0) {
-      return [];
-    }
+  const scope = await resolveStoreScope(user, query.store_id);
 
-    conditions.push(inArray(ordersTable.store_id, storeIds));
-  } else {
-    await assertStoreAccess(user, query.store_id);
-    conditions.push(eq(ordersTable.store_id, query.store_id));
+  switch (scope.kind) {
+    case "one":
+      conditions.push(eq(ordersTable.store_id, scope.storeId));
+      break;
+    case "some":
+      conditions.push(inArray(ordersTable.store_id, scope.storeIds));
+      break;
+    // A worker with no branch yet has no rack to show.
+    case "none":
+      return [];
+    // An admin who named no branch sees their own items across every branch —
+    // this is one person's rack, so it is never the whole company's floor.
+    case "all":
+      break;
+    default:
+      return unhandledStoreScope(scope);
   }
 
   return db
@@ -158,25 +162,27 @@ export async function getOrderServiceQueue(
     ]),
   ];
 
-  if (user.role === "admin") {
-    if (normalized.store_id === undefined) {
-      throw new BadRequestException("Store is required for admin queue access");
-    }
+  const scope = await resolveStoreScope(user, normalized.store_id);
 
-    conditions.push(eq(ordersTable.store_id, normalized.store_id));
-  } else if (normalized.store_id === undefined) {
-    const storeIds = await getUserStoreIds(user.id);
-    if (storeIds.length === 0) {
+  switch (scope.kind) {
+    case "one":
+      conditions.push(eq(ordersTable.store_id, scope.storeId));
+      break;
+    case "some":
+      conditions.push(inArray(ordersTable.store_id, scope.storeIds));
+      break;
+    // A worker with no branch yet gets an empty page, not the company queue.
+    case "none":
       return {
         items: [],
         meta: buildPaginationMeta(0, normalized),
       };
-    }
-
-    conditions.push(inArray(ordersTable.store_id, storeIds));
-  } else {
-    await assertStoreAccess(user, normalized.store_id);
-    conditions.push(eq(ordersTable.store_id, normalized.store_id));
+    // Unlike the other lists, an unscoped floor is useless here: every branch's
+    // work in one queue is a list nobody can work from, so the admin must pick.
+    case "all":
+      throw new BadRequestException("Store is required for admin queue access");
+    default:
+      return unhandledStoreScope(scope);
   }
 
   if (normalized.status !== undefined) {

--- a/packages/server/src/modules/orders/order.service.test.ts
+++ b/packages/server/src/modules/orders/order.service.test.ts
@@ -9,6 +9,7 @@ import {
 } from "bun:test";
 import { ordersTable } from "@/db/schema";
 import { BadRequestException } from "@/errors";
+import { authorizationDouble } from "@/test-support/authorization-double";
 import { captureRejection } from "@/test-support/capture-rejection";
 import type { JWTPayload } from "@/types";
 import type { Store } from "@/types/entity";
@@ -127,17 +128,7 @@ mock.module("@/db", () => ({
   },
 }));
 
-mock.module("@/utils/authorization", () => ({
-  assertStoreAccess: (user: { id: number }, storeId: number) => {
-    authz.assertCalls.push({ userId: user.id, storeId });
-    return Promise.resolve();
-  },
-  getUserStoreIds: (userId: number) => {
-    authz.listCalls.push(userId);
-    return Promise.resolve(authz.storeIds);
-  },
-  assertOrderAccess: () => Promise.resolve({ id: 0, store_id: 0 }),
-}));
+mock.module("@/utils/authorization", () => authorizationDouble(authz));
 
 // Capture the real modules before stubbing so afterAll can hand them back to
 // test files that exercise them for real (their own suites pin the internals).

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -29,7 +29,7 @@ import { findServices } from "@/modules/services/service.repository";
 import type { POSTOrderSchema } from "@/schema";
 import type { JWTPayload } from "@/types";
 import type { Store } from "@/types/entity";
-import { assertStoreAccess, getUserStoreIds } from "@/utils/authorization";
+import { resolveStoreScope, unhandledStoreScope } from "@/utils/authorization";
 import { jakartaNow } from "@/utils/date";
 import { buildPaginationMeta } from "@/utils/pagination";
 import { buildMediaUrl } from "@/utils/s3";
@@ -143,11 +143,26 @@ export async function listOrders(query?: GetOrdersQuery, user?: JWTPayload) {
   const normalized = normalizeOrderListQuery(query);
   let scopedStoreIds: number[] | undefined;
 
-  if (user && user.role !== "admin") {
-    if (normalized.store_id === undefined) {
-      scopedStoreIds = await getUserStoreIds(user.id);
-    } else {
-      await assertStoreAccess(user, normalized.store_id);
+  if (user) {
+    const scope = await resolveStoreScope(user, normalized.store_id);
+
+    switch (scope.kind) {
+      // A cashier browsing "all orders" still only sees the branches they work
+      // at — an open list would leak every branch's takings to any staff.
+      case "some":
+        scopedStoreIds = scope.storeIds;
+        break;
+      // A staff account not yet assigned to a branch: nothing, not everything.
+      case "none":
+        scopedStoreIds = [];
+        break;
+      // An admin browses every branch, and a named branch is already the
+      // store_id filter the query carries.
+      case "all":
+      case "one":
+        break;
+      default:
+        return unhandledStoreScope(scope);
     }
   }
 

--- a/packages/server/src/routes/admin/orders.route.test.ts
+++ b/packages/server/src/routes/admin/orders.route.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+import { ForbiddenException, NotFoundException } from "@/errors";
+import { authorizationDouble } from "@/test-support/authorization-double";
+import type { JWTPayload } from "@/types";
+import { errorHandler } from "@/utils/error-handler";
+
+// Every module the orders routes reach on import prepares a statement against
+// db.query.<table>, so the stub has to answer any table with a preparable query.
+const preparedStub: Record<string, unknown> = {};
+preparedStub.prepare = () => preparedStub;
+preparedStub.execute = () => Promise.resolve(undefined);
+
+mock.module("@/db", () => ({
+  db: {
+    query: new Proxy(
+      {},
+      { get: () => new Proxy({}, { get: () => () => preparedStub }) }
+    ),
+  },
+}));
+
+interface AccessCall {
+  orderId: number;
+  userId: number;
+}
+
+const orderAccessCalls: AccessCall[] = [];
+
+// Asep is rostered at Kemang. Order 777 was taken in at Bintaro, where he does
+// not work; order 999 was never written at all.
+const KEMANG = 1;
+const BINTARO = 2;
+const ORDER_STORE: Record<number, number> = {
+  123: KEMANG,
+  456: KEMANG,
+  777: BINTARO,
+  1000: KEMANG,
+};
+
+mock.module("@/utils/authorization", () => ({
+  ...authorizationDouble({ storeIds: [KEMANG] }),
+  // The real thing answers "missing" before "not yours", and the routes depend on
+  // that order — so the double has to keep it.
+  assertOrderAccess: (user: JWTPayload, orderId: number) => {
+    orderAccessCalls.push({ userId: user.id, orderId });
+
+    const storeId = ORDER_STORE[orderId];
+
+    if (storeId === undefined) {
+      throw new NotFoundException("Order not found");
+    }
+
+    if (user.role !== "admin" && storeId !== KEMANG) {
+      throw new ForbiddenException("You do not have access to this store");
+    }
+
+    return Promise.resolve({ id: orderId, store_id: storeId });
+  },
+}));
+
+// Each service the guarded routes delegate to is stubbed to a marker, so a
+// response body tells us the handler was reached rather than short-circuited.
+const reached: string[] = [];
+const marker = (name: string) => () => {
+  reached.push(name);
+  return Promise.resolve({ ok: name });
+};
+
+mock.module("@/modules/orders/order.service", () => ({
+  createOrder: marker("createOrder"),
+  getOrderDetailById: marker("getOrderDetailById"),
+  listOrders: () => {
+    reached.push("listOrders");
+    return Promise.resolve({ items: [], meta: {} });
+  },
+}));
+
+mock.module("@/modules/orders/order-receipt.service", () => ({
+  getOrderReceiptById: marker("getOrderReceiptById"),
+}));
+
+mock.module("@/modules/orders/order-queue.service", () => ({
+  getMyOrderServices: marker("getMyOrderServices"),
+  getOrderServiceById: () => {
+    reached.push("getOrderServiceById");
+    return Promise.resolve({ order: { store_id: KEMANG } });
+  },
+  getOrderServiceByItemCode: () => {
+    reached.push("getOrderServiceByItemCode");
+    return Promise.resolve({ order: { store_id: KEMANG } });
+  },
+  getOrderServiceQueue: () => {
+    reached.push("getOrderServiceQueue");
+    return Promise.resolve({ items: [], meta: {} });
+  },
+  startOrderServiceWork: marker("startOrderServiceWork"),
+  updateOrderServiceHandler: marker("updateOrderServiceHandler"),
+  updateOrderServiceStatus: marker("updateOrderServiceStatus"),
+}));
+
+const ordersRoutes = (await import("@/routes/admin/orders")).default;
+
+// Asep works the Kemang counter. In production adminMiddleware puts him on the
+// context; here that one step stands in for the whole JWT layer.
+const asep: JWTPayload = {
+  id: 7,
+  name: "Asep",
+  username: "asep",
+  role: "cashier",
+  can_process_pickup: false,
+};
+
+const app = new Hono<{ Variables: { jwtPayload: JWTPayload } }>()
+  .use("*", async (c, next) => {
+    c.set("jwtPayload", asep);
+    await next();
+  })
+  .route("/orders", ordersRoutes);
+
+app.onError(errorHandler);
+
+const call = (path: string, method = "GET") =>
+  app.request(`/orders${path}`, { method });
+
+beforeEach(() => {
+  orderAccessCalls.length = 0;
+  reached.length = 0;
+});
+
+describe("the workshop queue is not an order", () => {
+  // These four sit at /orders/services/... — the same shape as an order id. The
+  // rack screen is the one the workshop watches all day; treating "services" as
+  // an order number takes it down.
+  it("opens the rack for the workshop without asking which order 'services' is", async () => {
+    const res = await call("/services/queue");
+
+    expect(res.status).toBe(200);
+    expect(reached).toContain("getOrderServiceQueue");
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("shows a worker their own jobs without asking which order 'services' is", async () => {
+    const res = await call("/services/me");
+
+    expect(res.status).toBe(200);
+    expect(reached).toContain("getMyOrderServices");
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("looks a garment up by its service id without asking which order 'services' is", async () => {
+    const res = await call("/services/by-id?service_id=5");
+
+    expect(res.status).toBe(200);
+    expect(reached).toContain("getOrderServiceById");
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("looks a garment up by the tag pinned to it without asking which order 'services' is", async () => {
+    const res = await call("/services/by-item-code?item_code=ORD-0007-1");
+
+    expect(res.status).toBe(200);
+    expect(reached).toContain("getOrderServiceByItemCode");
+    expect(orderAccessCalls).toEqual([]);
+  });
+});
+
+describe("opening one order is checked against the branch", () => {
+  it("checks the branch before handing over a ticket", async () => {
+    const res = await call("/123");
+
+    expect(res.status).toBe(200);
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 123 }]);
+  });
+
+  it("checks the branch before printing a receipt", async () => {
+    const res = await call("/123/receipt");
+
+    expect(res.status).toBe(200);
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 123 }]);
+  });
+
+  it("checks the branch before touching a single garment on the ticket", async () => {
+    const res = await call("/123/services/45/start", "POST");
+
+    expect(res.status).toBe(200);
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 123 }]);
+  });
+
+  it("charges the counter one branch check per ticket, not two", async () => {
+    // A second registration matching the bare /orders/:id would re-run the gate
+    // and double the lookup on the most-opened screen in the shop.
+    await call("/123");
+
+    expect(orderAccessCalls).toHaveLength(1);
+  });
+});
+
+describe("a ticket dressed up to look like another branch's", () => {
+  // The counter reads the id after coercion, so /orders/+123 and /orders/%20123
+  // both open order 123. A gate that only recognises plain digits would wave
+  // these through and hand a Bintaro ticket to a Kemang cashier.
+  const disguises = ["/+123", "/%20123", "/123%20", "/%09123", "/1e3", "/0123"];
+
+  for (const disguise of disguises) {
+    it(`still checks the branch for ${disguise}`, async () => {
+      const res = await call(disguise);
+
+      expect(res.status).toBe(200);
+      expect(orderAccessCalls).toHaveLength(1);
+    });
+  }
+
+  it("reads the disguised id as the very order the counter would serve", async () => {
+    await call("/1e3");
+
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 1000 }]);
+  });
+});
+
+describe("what the gate leaves alone", () => {
+  it("does not ask which order a list of orders belongs to", async () => {
+    const res = await call("");
+
+    expect(res.status).toBe(200);
+    expect(reached).toContain("listOrders");
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("does not ask which order a brand-new order belongs to", async () => {
+    // The order does not exist yet; its branch is checked from the body instead.
+    const res = await app.request("/orders", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).not.toBe(404);
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("turns away a typo without going to look for an order", async () => {
+    const res = await call("/abc");
+
+    expect(res.status).toBe(400);
+    expect(orderAccessCalls).toEqual([]);
+  });
+
+  it("turns away order zero without going to look for it", async () => {
+    const res = await call("/0");
+
+    expect(res.status).toBe(400);
+    expect(orderAccessCalls).toEqual([]);
+  });
+});
+
+describe("an order the cashier may not have", () => {
+  it("says the ticket does not exist before it says whose branch it is", async () => {
+    // 404 before 403: an order nobody wrote is missing, not forbidden.
+    const res = await call("/999");
+
+    expect(res.status).toBe(404);
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 999 }]);
+  });
+
+  it("refuses a ticket that belongs to another branch", async () => {
+    const res = await call("/777");
+
+    expect(res.status).toBe(403);
+    expect(orderAccessCalls).toEqual([{ userId: 7, orderId: 777 }]);
+  });
+});

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
 import { StatusCodes } from "http-status-codes";
+import { z } from "zod";
 import { NotFoundException } from "@/errors";
 import { GETOrdersQuerySchema } from "@/modules/orders/order.schema";
 import {
@@ -63,7 +65,42 @@ import { assertOrderAccess, assertStoreAccess } from "@/utils/authorization";
 import { success } from "@/utils/http";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
 
-const app = new Hono()
+interface OrderAccessEnv {
+  Variables: {
+    jwtPayload: JWTPayload;
+    order?: Awaited<ReturnType<typeof assertOrderAccess>>;
+  };
+}
+
+// The id is read the way the handlers below validate it, not as plain digits.
+// /orders/+123 and /orders/%20123 both reach a handler as order 123, so a gate
+// that recognised only digits would wave them through unchecked.
+const orderIdParam = z.coerce.number().int().positive();
+
+// Every screen that opens a single order — the ticket, its receipt, its photos,
+// its refund — has to prove the person works at that branch: a cashier at Kemang
+// can never open a Bintaro order. One gate covers all of them, because the way
+// this leaks is a new /orders/:id screen whose author forgot line one.
+//
+// A path that is not an order id passes through untouched: the workshop queue at
+// /orders/services/queue is not order "services", and does its own branch check.
+const requireOrderAccess = createMiddleware<OrderAccessEnv>(async (c, next) => {
+  const orderId = orderIdParam.safeParse(c.req.param("id"));
+
+  if (orderId.success && !c.get("order")) {
+    const order = await assertOrderAccess(c.get("jwtPayload"), orderId.data);
+    c.set("order", order);
+  }
+
+  await next();
+});
+
+const app = new Hono<OrderAccessEnv>()
+  // Both shapes, because which one matches a bare /orders/123 depends on the
+  // router Hono picks for the whole API. Whichever fires first files the order
+  // and the other steps aside, so the branch is looked up once.
+  .use("/:id", requireOrderAccess)
+  .use("/:id/*", requireOrderAccess)
   .get("/", zodValidator("query", GETOrdersQuerySchema), async (c) => {
     const query = c.req.valid("query");
     const user = c.get("jwtPayload") as JWTPayload;
@@ -154,10 +191,7 @@ const app = new Hono()
     return c.json(success(created, "Order created"), StatusCodes.CREATED);
   })
   .get("/:id", idParamSchema, async (c) => {
-    const user = c.get("jwtPayload") as JWTPayload;
     const { id } = c.req.valid("param");
-
-    await assertOrderAccess(user, id);
 
     const detail = await getOrderDetailById(id);
 
@@ -168,10 +202,7 @@ const app = new Hono()
     return c.json(success(detail, "Order detail retrieved successfully"));
   })
   .get("/:id/receipt", idParamSchema, async (c) => {
-    const user = c.get("jwtPayload") as JWTPayload;
     const { id } = c.req.valid("param");
-
-    await assertOrderAccess(user, id);
 
     const receipt = await getOrderReceiptById(id);
 
@@ -189,8 +220,6 @@ const app = new Hono()
       const user = c.get("jwtPayload") as JWTPayload;
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const payment = await updateOrderPayment({
         orderId: id,
@@ -214,8 +243,6 @@ const app = new Hono()
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const updated = await updateOrderCollectedBy({
         orderId: id,
         collectedBy: body.collected_by,
@@ -238,8 +265,6 @@ const app = new Hono()
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const signed = await createOrderPickupEventPresign({
         orderId: id,
         body,
@@ -260,8 +285,6 @@ const app = new Hono()
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const result = await createOrderPickupEvent({
         orderId: id,
         body,
@@ -281,8 +304,6 @@ const app = new Hono()
       const user = c.get("jwtPayload") as JWTPayload;
       const { id, serviceId } = c.req.valid("param");
 
-      await assertOrderAccess(user, id);
-
       const result = await startOrderServiceWork({
         orderId: id,
         serviceId,
@@ -300,8 +321,6 @@ const app = new Hono()
       const user = c.get("jwtPayload") as JWTPayload;
       const { id, serviceId } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const result = await updateOrderServiceHandler({
         orderId: id,
@@ -322,8 +341,6 @@ const app = new Hono()
       const { id, serviceId } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const result = await updateOrderServiceStatus({
         orderId: id,
         serviceId,
@@ -339,12 +356,8 @@ const app = new Hono()
     orderServiceParamSchema,
     zodValidator("json", POSTOrderServicePhotoPresignSchema),
     async (c) => {
-      const user = c.get("jwtPayload") as JWTPayload;
-
       const { id, serviceId } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const signed = await createOrderServicePhotoPresign({
         orderId: id,
@@ -360,11 +373,8 @@ const app = new Hono()
     idParamSchema,
     zodValidator("json", POSTOrderDropoffPhotoPresignSchema),
     async (c) => {
-      const user = c.get("jwtPayload") as JWTPayload;
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const signed = await createOrderDropoffPhotoPresign({
         orderId: id,
@@ -385,8 +395,6 @@ const app = new Hono()
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const photo = await saveOrderDropoffPhoto({
         orderId: id,
         body,
@@ -405,8 +413,6 @@ const app = new Hono()
       const { id, serviceId } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      await assertOrderAccess(user, id);
-
       const photo = await saveOrderServicePhoto({
         orderId: id,
         serviceId,
@@ -423,8 +429,6 @@ const app = new Hono()
     async (c) => {
       const user = c.get("jwtPayload") as JWTPayload;
       const { id, serviceId, photoId } = c.req.valid("param");
-
-      await assertOrderAccess(user, id);
 
       const result = await deleteOrderServicePhoto({
         orderId: id,
@@ -444,8 +448,6 @@ const app = new Hono()
       const user = c.get("jwtPayload") as JWTPayload;
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const result = await createOrderRefund({
         orderId: id,
@@ -467,8 +469,6 @@ const app = new Hono()
       const user = c.get("jwtPayload") as JWTPayload;
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
-
-      await assertOrderAccess(user, id);
 
       const result = await cancelOrder({
         orderId: id,

--- a/packages/server/src/test-support/authorization-double.ts
+++ b/packages/server/src/test-support/authorization-double.ts
@@ -1,0 +1,52 @@
+import type { JWTPayload } from "@/types";
+import type { StoreScope } from "@/utils/authorization";
+
+interface StoreMembershipState {
+  assertCalls?: { storeId: number; userId: number }[];
+  listCalls?: number[];
+  storeIds: number[];
+}
+
+// The store-scope gate as a service suite sees it: fake branch memberships, so a
+// suite can stand up "a cashier who works at two branches" or "a new hire with
+// none" by setting `storeIds`. Mirrors the decision table in
+// utils/authorization.ts, which is pinned for real in utils/authorization.test.ts
+// — keep the two in step.
+export const authorizationDouble = (state: StoreMembershipState) => {
+  const assertStoreAccess = (user: JWTPayload, storeId: number) => {
+    state.assertCalls?.push({ storeId, userId: user.id });
+    return Promise.resolve();
+  };
+
+  const getUserStoreIds = (userId: number) => {
+    state.listCalls?.push(userId);
+    return Promise.resolve(state.storeIds);
+  };
+
+  const resolveStoreScope = async (
+    user: JWTPayload,
+    storeId?: number
+  ): Promise<StoreScope> => {
+    if (storeId !== undefined) {
+      await assertStoreAccess(user, storeId);
+      return { kind: "one", storeId };
+    }
+
+    if (user.role === "admin") {
+      return { kind: "all" };
+    }
+
+    const storeIds = await getUserStoreIds(user.id);
+
+    return storeIds.length === 0
+      ? { kind: "none" }
+      : { kind: "some", storeIds };
+  };
+
+  return {
+    assertOrderAccess: () => Promise.resolve({ id: 0, store_id: 0 }),
+    assertStoreAccess,
+    getUserStoreIds,
+    resolveStoreScope,
+  };
+};

--- a/packages/server/src/utils/authorization.test.ts
+++ b/packages/server/src/utils/authorization.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { ForbiddenException } from "@/errors";
+import { captureRejection } from "@/test-support/capture-rejection";
+import type { JWTPayload } from "@/types";
+
+// One question every list screen asks: which branches may this person see? The
+// answer depends only on who is asking and whether they named a branch, so the
+// fake database here is just the `user_stores` sheet — the branches this staff
+// member is rostered at.
+const roster = {
+  storeIds: [] as number[],
+};
+
+const prepared = (execute: (params: Record<string, number>) => unknown) => ({
+  prepare: () => ({
+    execute: (params: Record<string, number>) => execute(params),
+  }),
+});
+
+mock.module("@/db", () => ({
+  db: {
+    query: {
+      userStoresTable: {
+        findMany: () =>
+          prepared(() =>
+            Promise.resolve(roster.storeIds.map((store_id) => ({ store_id })))
+          ),
+        findFirst: () =>
+          prepared((params) =>
+            Promise.resolve(
+              roster.storeIds.includes(params.store_id) ? { id: 1 } : undefined
+            )
+          ),
+      },
+      // assertOrderAccess builds its lookup at import time; nothing here reads it.
+      ordersTable: {
+        findFirst: () => prepared(() => Promise.resolve(undefined)),
+      },
+    },
+  },
+}));
+
+const { resolveStoreScope } = await import("@/utils/authorization");
+
+const staff = (id: number, role: JWTPayload["role"]): JWTPayload => ({
+  can_process_pickup: false,
+  id,
+  name: "Staff",
+  role,
+  username: `staff-${id}`,
+});
+
+// Sari works the till at Kemang (store 1); Pak Rudi runs all six branches.
+const CASHIER = staff(9, "cashier");
+const ADMIN = staff(1, "admin");
+
+const KEMANG = 1;
+const BINTARO = 2;
+
+beforeEach(() => {
+  roster.storeIds = [KEMANG];
+});
+
+describe("resolveStoreScope", () => {
+  it("hands an admin who named no branch the whole company", async () => {
+    expect(await resolveStoreScope(ADMIN)).toEqual({ kind: "all" });
+  });
+
+  it("fences a cashier who named no branch to the branches they are rostered at", async () => {
+    roster.storeIds = [KEMANG, BINTARO];
+
+    expect(await resolveStoreScope(CASHIER)).toEqual({
+      kind: "some",
+      storeIds: [KEMANG, BINTARO],
+    });
+  });
+
+  it("leaves a new hire not yet rostered anywhere with no branch at all", async () => {
+    // An empty roster is not permission to see everything — it is a staff
+    // account waiting to be assigned to a branch.
+    roster.storeIds = [];
+
+    expect(await resolveStoreScope(CASHIER)).toEqual({ kind: "none" });
+  });
+
+  it("lets a cashier open the branch they work at", async () => {
+    expect(await resolveStoreScope(CASHIER, KEMANG)).toEqual({
+      kind: "one",
+      storeId: KEMANG,
+    });
+  });
+
+  it("refuses a cashier the branch they do not work at", async () => {
+    // Sari at Kemang must never reach a Bintaro order, however she asks.
+    const error = await captureRejection(resolveStoreScope(CASHIER, BINTARO));
+
+    expect(error).toBeInstanceOf(ForbiddenException);
+    expect(error).toHaveProperty(
+      "message",
+      "You do not have access to this store"
+    );
+  });
+
+  it("lets an admin open a branch they are not rostered at", async () => {
+    // Admins are on nobody's roster; naming a branch still narrows them to it.
+    roster.storeIds = [];
+
+    expect(await resolveStoreScope(ADMIN, BINTARO)).toEqual({
+      kind: "one",
+      storeId: BINTARO,
+    });
+  });
+});

--- a/packages/server/src/utils/authorization.ts
+++ b/packages/server/src/utils/authorization.ts
@@ -40,6 +40,60 @@ export async function assertStoreAccess(user: JWTPayload, storeId: number) {
   }
 }
 
+interface AllStoresScope {
+  kind: "all";
+}
+
+interface OneStoreScope {
+  kind: "one";
+  storeId: number;
+}
+
+interface SomeStoresScope {
+  kind: "some";
+  storeIds: number[];
+}
+
+interface NoStoresScope {
+  kind: "none";
+}
+
+export type StoreScope =
+  | AllStoresScope
+  | OneStoreScope
+  | SomeStoresScope
+  | NoStoresScope;
+
+// Every list screen asks the same question: which branches may this person see?
+// Naming a branch is an access question — a cashier at Kemang either works there
+// or is refused. Naming none is a scoping question — staff see their own
+// branches, an admin sees the company, and a new hire with no branch yet has
+// nothing to show. Each screen decides what it does with the answer.
+export async function resolveStoreScope(
+  user: JWTPayload,
+  storeId?: number
+): Promise<StoreScope> {
+  if (storeId !== undefined) {
+    await assertStoreAccess(user, storeId);
+    return { kind: "one", storeId };
+  }
+
+  if (user.role === "admin") {
+    return { kind: "all" };
+  }
+
+  const storeIds = await getUserStoreIds(user.id);
+
+  return storeIds.length === 0 ? { kind: "none" } : { kind: "some", storeIds };
+}
+
+// A scope no screen handled has to stop the request. Falling through would run
+// the query with no branch filter at all, which is every branch's takings — so
+// adding a fifth kind of scope must fail to compile, not quietly serve the lot.
+export function unhandledStoreScope(scope: never): never {
+  throw new Error(`Unhandled store scope: ${JSON.stringify(scope)}`);
+}
+
 const findOrderForAccessPrepared = db.query.ordersTable
   .findFirst({
     where: { id: { eq: sql.placeholder("id") } },


### PR DESCRIPTION
Audit finding **C1**, plus the report status update.

Store scoping was enforced in three layers four different ways, with no single place answering *"is this endpoint store-scoped, and what happens when no store is named?"*

### `resolveStoreScope` — four transcriptions become four declared cases

```
storeId named?  ──yes──> await assertStoreAccess ──> { one, storeId }
       │
       no
       ├── role admin ──> { all }
       └── getUserStoreIds ──> [] ? { none } : { some, storeIds }
```

The four call sites switch on it and **keep their own answer for each case**, because they legitimately differ — the order list fences the query, a worker's own rack returns `[]`, the workshop queue returns an empty *page*, and it alone refuses an admin who named no branch. Making those differences declared was the point; erasing them would have been the failure mode, and a reviewer built the full 4-site × 6-case matrix to confirm every cell is unchanged.

### Each switch now fails closed

Both reviewers independently flagged the highest-severity issue: all four switches ended `default: break`. A fifth scope kind would have fallen through to *a query with no branch filter at all* — every branch's takings, silently, which is precisely the leak C1 exists to prevent.

They now route to a `never`-typed guard, so a fifth kind **fails the build**:

```
$ # after adding a 5th StoreScope kind
complaint.service.ts(204,34):    error TS2345: 'FranchiseScope' is not assignable to 'never'
order-queue.service.ts(120,34):  error TS2345: 'FranchiseScope' is not assignable to 'never'
order-queue.service.ts(185,34):  error TS2345: 'FranchiseScope' is not assignable to 'never'
order.service.ts(165,36):        error TS2345: 'FranchiseScope' is not assignable to 'never'
```

### One order-access gate — and why not the digit-constrained pattern

`assertOrderAccess` was transcribed **16** times (not 17 — the extra grep hit was the import), once per `/orders/:id` route. One middleware now runs it and files the order on the context.

I originally specified `.use("/:id{[0-9]+}/*")` to avoid the middleware swallowing the four static `/services/*` siblings. **That would have opened five access-control holes**, because the router matches the raw path segment while the handlers read the id through `z.coerce.number()`. I reproduced it:

```
                gate      handler
/orders/+123    SKIPPED   order 123     <<< BYPASS
/orders/%20123  SKIPPED   order 123     <<< BYPASS
/orders/123.0   SKIPPED   order 123     <<< BYPASS
/orders/1e3     SKIPPED   order 1000    <<< BYPASS
/orders/0x10    SKIPPED   order 16      <<< BYPASS
```

A Kemang cashier could have read a Bintaro order by adding a plus sign — introduced *by* the change meant to prevent exactly that. The gate instead parses the id **exactly as the handlers validate it**, so anything reaching a handler as an order has been checked, and a path that isn't an order id (`/orders/services/queue`) passes through untouched.

### Tests

21 route tests, named for the shop situation. Every guard is load-bearing:

```
baseline                21 pass   0 fail
digit-constrained       15 pass   6 fail
no idempotence guard    12 pass   9 fail
missing /:id/*          19 pass   2 fail
restored                21 pass   0 fail
```

They cover the four static siblings, the five disguised ids, one-check-per-ticket, 404-before-403 ordering, and list/create staying ungated.

### Verification

`ultracite check` clean · `type-check`, `test` and `build` all run with `turbo --force` · **314 server + 78 web, 0 fail** (up from 293+78).

`routes/admin/reports.ts` untouched — its 10 repeated calls belong to S4. `as JWTPayload` count went 62 → 58; all four removals are orphans this change created, none added. No `apps/web/` file touched.

### Also in this PR

`docs(audit)` — 15 findings marked shipped with PR links, a status column on the priority list, and closing notes on the 8 findings whose fix diverged from what the report prescribed (S11's premise was outright wrong; C2 overstated its own footprint by 12 already-dead wrappers).