### PR TITLE
refactor(reports): one store gate for the router, pin the money math

### DIFF
--- a/packages/server/src/modules/reports/__snapshots__/report-range.repository.sql.test.ts.snap
+++ b/packages/server/src/modules/reports/__snapshots__/report-range.repository.sql.test.ts.snap
@@ -1,0 +1,595 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`what each money report asks Postgres for one store asks the same question for services revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for products revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_products"."subtotal"), 0) from "orders_products" inner join "orders" on "orders_products"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for services COGS 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_services"."cogs_snapshot"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for products COGS 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_products"."cogs_snapshot"), 0) from "orders_products" inner join "orders" on "orders_products"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for order discount 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("discount"), 0) from "orders" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for category revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "categories"."id", "categories"."name", COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" inner join "services" on "orders_services"."service_id" = "services"."id" inner join "categories" on "services"."category_id" = "categories"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "categories"."id", "categories"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for store x category revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select "orders"."store_id", "stores"."name", "stores"."code", "categories"."id", "categories"."name", COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" inner join "stores" on "orders"."store_id" = "stores"."id" inner join "services" on "orders_services"."service_id" = "services"."id" inner join "categories" on "services"."category_id" = "categories"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by "orders"."store_id", "stores"."name", "stores"."code", "categories"."id", "categories"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for orders taken in 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(*)::int from "orders" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2) and ("orders"."store_id" = $3)) group by to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for orders handed back 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("order_pickup_events"."picked_up_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(DISTINCT "order_pickup_events"."order_id")::int from "order_pickup_events" inner join "orders" on "order_pickup_events"."order_id" = "orders"."id" where (("order_pickup_events"."picked_up_at" >= $1) and ("order_pickup_events"."picked_up_at" < $2) and ("orders"."store_id" = $3)) group by to_char("order_pickup_events"."picked_up_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for distinct handlers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      "processing",
+      "queued",
+      3,
+    ],
+    "sql": "select COUNT(DISTINCT "order_service_status_logs"."changed_by")::int from "order_service_status_logs" inner join "orders_services" on "order_service_status_logs"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("order_service_status_logs"."created_at" >= $1) and ("order_service_status_logs"."created_at" < $2) and ("order_service_status_logs"."to_status" = $3) and ("order_service_status_logs"."from_status" = $4) and ("orders"."store_id" = $5))",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for payment mix 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "orders"."payment_method_id", "payment_methods"."name", COALESCE(SUM("orders"."paid_amount"), 0), COUNT(*)::int from "orders" left join "payment_methods" on "orders"."payment_method_id" = "payment_methods"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "orders"."payment_method_id", "payment_methods"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for new customers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(*)::int from "customers" where (("customers"."created_at" >= $1) and ("customers"."created_at" < $2) and ("customers"."origin_store_id" = $3)) group by to_char("customers"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for returning customer orders 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "customers"."created_at", COUNT(*)::int from "orders" inner join "customers" on "orders"."customer_id" = "customers"."id" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2) and (("orders"."customer_id" is not null)) and ("orders"."store_id" = $3)) group by to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "customers"."id", "customers"."created_at"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for top customers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+      10,
+    ],
+    "sql": "select "customers"."id", "customers"."name", "customers"."phone_number", COUNT(*)::int, COALESCE(SUM("orders"."paid_amount"), 0) from "orders" inner join "customers" on "orders"."customer_id" = "customers"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and (("orders"."customer_id" is not null)) and ("orders"."store_id" = $3)) group by "customers"."id", "customers"."name", "customers"."phone_number" order by SUM("orders"."paid_amount") desc limit $4",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for customers on file before the stretch 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select count(*) from "customers" where (("customers"."created_at" < $1) and ("customers"."origin_store_id" = $2))",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for repeat customer stats 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select COUNT(*)::int, COUNT(*) FILTER (WHERE order_count > 1)::int from (select "customer_id", COUNT(*) as "order_count" from "orders" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2) and (("orders"."customer_id" is not null)) and ("orders"."store_id" = $3)) group by "orders"."customer_id") "customer_orders"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for refund amounts 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("order_refunds"."total_amount"), 0), COUNT(DISTINCT "order_refunds"."id")::int from "order_refunds" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2) and ("orders"."store_id" = $3)) group by to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for refund reasons 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "order_refund_items"."reason", COALESCE(SUM("order_refund_items"."amount"), 0), COUNT(*)::int from "order_refund_items" inner join "order_refunds" on "order_refund_items"."order_refund_id" = "order_refunds"."id" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2) and ("orders"."store_id" = $3)) group by to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "order_refund_items"."reason"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for worker productivity 1`] = `
+[
+  {
+    "params": [
+      "ready_for_pickup",
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select distinct on ("order_service_status_logs"."order_service_id") "order_service_status_logs"."order_service_id" from "order_service_status_logs" inner join "orders_services" on "order_service_status_logs"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("order_service_status_logs"."to_status" = $1) and ("order_service_status_logs"."created_at" >= $2) and ("order_service_status_logs"."created_at" < $3) and ("orders"."store_id" = $4)) order by "order_service_status_logs"."order_service_id", "order_service_status_logs"."created_at" desc",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select "order_refund_items"."order_service_id", COUNT(DISTINCT "order_refund_items"."id")::int from "order_refund_items" inner join "order_refunds" on "order_refund_items"."order_refund_id" = "order_refunds"."id" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2) and (("order_refund_items"."order_service_id" is not null)) and ("orders"."store_id" = $3)) group by "order_refund_items"."order_service_id"",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select "user_id", COALESCE(SUM(EXTRACT(EPOCH FROM ("clock_out_at" - "clock_in_at")) / 60), 0)::int from "shifts" where ((("shifts"."clock_out_at" is not null)) and ("shifts"."clock_in_at" >= $1) and ("shifts"."clock_in_at" < $2) and ("shifts"."store_id" = $3)) group by "shifts"."user_id"",
+  },
+  {
+    "params": [
+      "quality_check",
+      "processing",
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select "rework_log"."order_service_id", COUNT(*)::int from "order_service_status_logs" "rework_log" inner join "orders_services" on "rework_log"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("rework_log"."from_status" = $1) and ("rework_log"."to_status" = $2) and ("rework_log"."created_at" >= $3) and ("rework_log"."created_at" < $4) and ("orders"."store_id" = $5)) group by "rework_log"."order_service_id"",
+  },
+  {
+    "params": [
+      "worker",
+    ],
+    "sql": "select "id", "name", "role" from "users" where "users"."role" = $1",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for one store asks the same question for campaign effectiveness 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select "campaigns"."id", "campaigns"."name", "campaigns"."code", COALESCE(SUM("order_campaigns"."applied_amount"), 0) from "order_campaigns" inner join "orders" on "order_campaigns"."order_id" = "orders"."id" inner join "campaigns" on "order_campaigns"."campaign_id" = "campaigns"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3)) group by "campaigns"."id", "campaigns"."name", "campaigns"."code"",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      3,
+    ],
+    "sql": "select distinct "order_campaigns"."campaign_id", "orders"."id", "orders"."paid_amount", "orders"."total" from "order_campaigns" inner join "orders" on "order_campaigns"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and ("orders"."store_id" = $3))",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for services revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for products revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_products"."subtotal"), 0) from "orders_products" inner join "orders" on "orders_products"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for services COGS 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_services"."cogs_snapshot"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for products COGS 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("orders_products"."cogs_snapshot"), 0) from "orders_products" inner join "orders" on "orders_products"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for order discount 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("discount"), 0) from "orders" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for category revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "categories"."id", "categories"."name", COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" inner join "services" on "orders_services"."service_id" = "services"."id" inner join "categories" on "services"."category_id" = "categories"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "categories"."id", "categories"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for store x category revenue 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "orders"."store_id", "stores"."name", "stores"."code", "categories"."id", "categories"."name", COALESCE(SUM("orders_services"."subtotal"), 0) from "orders_services" inner join "orders" on "orders_services"."order_id" = "orders"."id" inner join "stores" on "orders"."store_id" = "stores"."id" inner join "services" on "orders_services"."service_id" = "services"."id" inner join "categories" on "services"."category_id" = "categories"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by "orders"."store_id", "stores"."name", "stores"."code", "categories"."id", "categories"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for orders taken in 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(*)::int from "orders" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2)) group by to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for orders handed back 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("order_pickup_events"."picked_up_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(DISTINCT "order_pickup_events"."order_id")::int from "order_pickup_events" inner join "orders" on "order_pickup_events"."order_id" = "orders"."id" where (("order_pickup_events"."picked_up_at" >= $1) and ("order_pickup_events"."picked_up_at" < $2)) group by to_char("order_pickup_events"."picked_up_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for distinct handlers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      "processing",
+      "queued",
+    ],
+    "sql": "select COUNT(DISTINCT "order_service_status_logs"."changed_by")::int from "order_service_status_logs" inner join "orders_services" on "order_service_status_logs"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("order_service_status_logs"."created_at" >= $1) and ("order_service_status_logs"."created_at" < $2) and ("order_service_status_logs"."to_status" = $3) and ("order_service_status_logs"."from_status" = $4))",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for payment mix 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "orders"."payment_method_id", "payment_methods"."name", COALESCE(SUM("orders"."paid_amount"), 0), COUNT(*)::int from "orders" left join "payment_methods" on "orders"."payment_method_id" = "payment_methods"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "orders"."payment_method_id", "payment_methods"."name"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for new customers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COUNT(*)::int from "customers" where (("customers"."created_at" >= $1) and ("customers"."created_at" < $2)) group by to_char("customers"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for returning customer orders 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "customers"."created_at", COUNT(*)::int from "orders" inner join "customers" on "orders"."customer_id" = "customers"."id" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2) and (("orders"."customer_id" is not null))) group by to_char("orders"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "customers"."id", "customers"."created_at"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for top customers 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+      10,
+    ],
+    "sql": "select "customers"."id", "customers"."name", "customers"."phone_number", COUNT(*)::int, COALESCE(SUM("orders"."paid_amount"), 0) from "orders" inner join "customers" on "orders"."customer_id" = "customers"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)) and (("orders"."customer_id" is not null))) group by "customers"."id", "customers"."name", "customers"."phone_number" order by SUM("orders"."paid_amount") desc limit $3",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for customers on file before the stretch 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+    ],
+    "sql": "select count(*) from "customers" where "customers"."created_at" < $1",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for repeat customer stats 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select COUNT(*)::int, COUNT(*) FILTER (WHERE order_count > 1)::int from (select "customer_id", COUNT(*) as "order_count" from "orders" where (("orders"."created_at" >= $1) and ("orders"."created_at" < $2) and (("orders"."customer_id" is not null))) group by "orders"."customer_id") "customer_orders"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for refund amounts 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), COALESCE(SUM("order_refunds"."total_amount"), 0), COUNT(DISTINCT "order_refunds"."id")::int from "order_refunds" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2)) group by to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD')",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for refund reasons 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "order_refund_items"."reason", COALESCE(SUM("order_refund_items"."amount"), 0), COUNT(*)::int from "order_refund_items" inner join "order_refunds" on "order_refund_items"."order_refund_id" = "order_refunds"."id" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2)) group by to_char("order_refunds"."created_at" AT TIME ZONE 'Asia/Jakarta', 'YYYY-MM-DD'), "order_refund_items"."reason"",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for worker productivity 1`] = `
+[
+  {
+    "params": [
+      "ready_for_pickup",
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select distinct on ("order_service_status_logs"."order_service_id") "order_service_status_logs"."order_service_id" from "order_service_status_logs" inner join "orders_services" on "order_service_status_logs"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("order_service_status_logs"."to_status" = $1) and ("order_service_status_logs"."created_at" >= $2) and ("order_service_status_logs"."created_at" < $3)) order by "order_service_status_logs"."order_service_id", "order_service_status_logs"."created_at" desc",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "order_refund_items"."order_service_id", COUNT(DISTINCT "order_refund_items"."id")::int from "order_refund_items" inner join "order_refunds" on "order_refund_items"."order_refund_id" = "order_refunds"."id" inner join "orders" on "order_refunds"."order_id" = "orders"."id" where (("order_refunds"."created_at" >= $1) and ("order_refunds"."created_at" < $2) and (("order_refund_items"."order_service_id" is not null))) group by "order_refund_items"."order_service_id"",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "user_id", COALESCE(SUM(EXTRACT(EPOCH FROM ("clock_out_at" - "clock_in_at")) / 60), 0)::int from "shifts" where ((("shifts"."clock_out_at" is not null)) and ("shifts"."clock_in_at" >= $1) and ("shifts"."clock_in_at" < $2)) group by "shifts"."user_id"",
+  },
+  {
+    "params": [
+      "quality_check",
+      "processing",
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "rework_log"."order_service_id", COUNT(*)::int from "order_service_status_logs" "rework_log" inner join "orders_services" on "rework_log"."order_service_id" = "orders_services"."id" inner join "orders" on "orders_services"."order_id" = "orders"."id" where (("rework_log"."from_status" = $1) and ("rework_log"."to_status" = $2) and ("rework_log"."created_at" >= $3) and ("rework_log"."created_at" < $4)) group by "rework_log"."order_service_id"",
+  },
+  {
+    "params": [
+      "worker",
+    ],
+    "sql": "select "id", "name", "role" from "users" where "users"."role" = $1",
+  },
+]
+`;
+
+exports[`what each money report asks Postgres for the whole company asks the same question for campaign effectiveness 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "campaigns"."id", "campaigns"."name", "campaigns"."code", COALESCE(SUM("order_campaigns"."applied_amount"), 0) from "order_campaigns" inner join "orders" on "order_campaigns"."order_id" = "orders"."id" inner join "campaigns" on "order_campaigns"."campaign_id" = "campaigns"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by "campaigns"."id", "campaigns"."name", "campaigns"."code"",
+  },
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select distinct "order_campaigns"."campaign_id", "orders"."id", "orders"."paid_amount", "orders"."total" from "order_campaigns" inner join "orders" on "order_campaigns"."order_id" = "orders"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null)))",
+  },
+]
+`;
+
+exports[`the store nobody can scope asks for every store's takings, because it takes no store 1`] = `
+[
+  {
+    "params": [
+      "2026-07-31T17:00:00.000Z",
+      "2026-08-31T17:00:00.000Z",
+    ],
+    "sql": "select "orders"."store_id", "stores"."name", "stores"."code", COALESCE(SUM("orders"."paid_amount"), 0), COUNT(*)::int from "orders" inner join "stores" on "orders"."store_id" = "stores"."id" where (("orders"."paid_at" >= $1) and ("orders"."paid_at" < $2) and (("orders"."paid_at" is not null))) group by "orders"."store_id", "stores"."name", "stores"."code" order by "stores"."code" asc",
+  },
+]
+`;

--- a/packages/server/src/modules/reports/report-range.repository.sql.test.ts
+++ b/packages/server/src/modules/reports/report-range.repository.sql.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import type { DateRange } from "@/modules/reports/report-range.util";
+
+// The reports repository is about to be collapsed from 21 hand-written queries
+// into a few shared builders, and its contract is "ask Postgres the same
+// question, with less code to read". So these record the whole statement each
+// report sends today, byte for byte.
+//
+// Substring checks cannot hold that line: adding `or paid_at is null` beside an
+// intact window, or moving the window into a LEFT JOIN ... ON, leaves every
+// substring in place while quietly changing which orders count as takings. A
+// snapshot sees both.
+
+const queries: { params: unknown[]; sql: string }[] = [];
+
+mock.module("@/db", () => ({
+  db: drizzle((sql, params) => {
+    queries.push({ sql, params });
+    return Promise.resolve({ rows: [] });
+  }),
+}));
+
+const repo = await import("@/modules/reports/report-range.repository");
+
+// August 2026 as Jakarta sees it: opens 01 Aug 00:00 WIB, closes the instant
+// 01 Sep 00:00 WIB begins.
+const AUGUST: DateRange = {
+  start: new Date("2026-07-31T17:00:00.000Z"),
+  end: new Date("2026-08-31T17:00:00.000Z"),
+};
+
+const KEMANG = 3;
+const DAY = "day" as const;
+
+beforeEach(() => {
+  queries.length = 0;
+});
+
+const askedFor = async (run: () => Promise<unknown>) => {
+  await run();
+
+  expect(queries.length).toBeGreaterThan(0);
+
+  return queries.map((query) => ({
+    params: query.params,
+    sql: query.sql.replace(/\s+/g, " ").trim(),
+  }));
+};
+
+type Query = (storeId?: number) => Promise<unknown>;
+
+const QUERIES: [string, Query][] = [
+  [
+    "services revenue",
+    (storeId) =>
+      repo.listServicesRevenueSeries({
+        granularity: DAY,
+        range: AUGUST,
+        storeId,
+      }),
+  ],
+  [
+    "products revenue",
+    (storeId) =>
+      repo.listProductsRevenueSeries({
+        granularity: DAY,
+        range: AUGUST,
+        storeId,
+      }),
+  ],
+  [
+    "services COGS",
+    (storeId) =>
+      repo.listServicesCogsSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "products COGS",
+    (storeId) =>
+      repo.listProductsCogsSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "order discount",
+    (storeId) =>
+      repo.listOrderDiscountSeries({
+        granularity: DAY,
+        range: AUGUST,
+        storeId,
+      }),
+  ],
+  [
+    "category revenue",
+    (storeId) =>
+      repo.listCategoryRevenueSeries({
+        granularity: DAY,
+        range: AUGUST,
+        storeId,
+      }),
+  ],
+  [
+    "store x category revenue",
+    (storeId) => repo.listStoreCategoryRevenueRows({ range: AUGUST, storeId }),
+  ],
+  [
+    "orders taken in",
+    (storeId) =>
+      repo.listOrdersInSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "orders handed back",
+    (storeId) =>
+      repo.listOrdersOutSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "distinct handlers",
+    (storeId) => repo.findDistinctHandlerCount({ range: AUGUST, storeId }),
+  ],
+  [
+    "payment mix",
+    (storeId) =>
+      repo.listPaymentMixSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "new customers",
+    (storeId) =>
+      repo.listNewCustomersSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "returning customer orders",
+    (storeId) =>
+      repo.listReturningCustomerOrdersSeries({
+        granularity: DAY,
+        range: AUGUST,
+        storeId,
+      }),
+  ],
+  [
+    "top customers",
+    (storeId) => repo.listTopCustomers({ range: AUGUST, storeId }),
+  ],
+  [
+    "customers on file before the stretch",
+    (storeId) =>
+      repo.findCumulativeCustomersBefore({ before: AUGUST.start, storeId }),
+  ],
+  [
+    "repeat customer stats",
+    (storeId) => repo.findRepeatCustomerStats({ range: AUGUST, storeId }),
+  ],
+  [
+    "refund amounts",
+    (storeId) =>
+      repo.listRefundAmountSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "refund reasons",
+    (storeId) =>
+      repo.listRefundReasonSeries({ granularity: DAY, range: AUGUST, storeId }),
+  ],
+  [
+    "worker productivity",
+    (storeId) => repo.listWorkerProductivityRows({ range: AUGUST, storeId }),
+  ],
+  [
+    "campaign effectiveness",
+    (storeId) => repo.listCampaignEffectivenessRows({ range: AUGUST, storeId }),
+  ],
+];
+
+describe("what each money report asks Postgres for one store", () => {
+  for (const [name, run] of QUERIES) {
+    it(`asks the same question for ${name}`, async () => {
+      expect(await askedFor(() => run(KEMANG))).toMatchSnapshot();
+    });
+  }
+});
+
+describe("what each money report asks Postgres for the whole company", () => {
+  // Naming no store is the other half of the contract: a dedupe that leaves a
+  // store filter behind when nobody asked for one is as wrong as one that drops
+  // it, and only recording both shapes catches that.
+  for (const [name, run] of QUERIES) {
+    it(`asks the same question for ${name}`, async () => {
+      expect(await askedFor(() => run())).toMatchSnapshot();
+    });
+  }
+});
+
+describe("the store nobody can scope", () => {
+  it("asks for every store's takings, because it takes no store", async () => {
+    // listStoreRevenueRows has no storeId parameter, so the store_breakdown panel
+    // on a Kemang-scoped financial report carries every store's takings. Every
+    // reader of these reports is an admin today, so this is recorded rather than
+    // fixed — but a filter appearing here should be a deliberate change.
+    expect(
+      await askedFor(() => repo.listStoreRevenueRows({ range: AUGUST }))
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/server/src/modules/reports/report-range.repository.test.ts
+++ b/packages/server/src/modules/reports/report-range.repository.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import type { DateRange } from "@/modules/reports/report-range.util";
+
+// Every takings figure on the reports page is a SUM inside Postgres, so the
+// question these tests answer is not "what did the shop earn" but "which rows
+// did we ask Postgres to add up, and from which column". A pg-proxy driver
+// stands in for the database: Drizzle still builds the real statement, we
+// capture it, and hand back rows we chose. Nothing connects.
+//
+// pg-proxy speaks the raw wire shape, so a fake row is a positional array in
+// the order the query selects its columns — not a named object.
+
+const queries: { params: unknown[]; sql: string }[] = [];
+const rowQueue: unknown[][] = [];
+
+mock.module("@/db", () => ({
+  db: drizzle((sql, params) => {
+    queries.push({ sql, params });
+    return Promise.resolve({ rows: rowQueue.shift() ?? [] });
+  }),
+}));
+
+const {
+  listCampaignEffectivenessRows,
+  listPaymentMixSeries,
+  listRefundAmountSeries,
+  listServicesRevenueSeries,
+} = await import("@/modules/reports/report-range.repository");
+
+// August 2026 as Jakarta sees it: opens 01 Aug 00:00 WIB, closes the instant
+// 01 Sep 00:00 WIB begins.
+const AUGUST: DateRange = {
+  start: new Date("2026-07-31T17:00:00.000Z"),
+  end: new Date("2026-08-31T17:00:00.000Z"),
+};
+
+const KEMANG = 3;
+
+beforeEach(() => {
+  queries.length = 0;
+  rowQueue.length = 0;
+});
+
+const only = () => {
+  expect(queries).toHaveLength(1);
+  return queries[0];
+};
+
+// report-range.repository.sql.test.ts snapshots all 21 statements in full, so
+// what each query asks Postgres is pinned there. These two stay behind as the
+// tripwire for a blind `--update-snapshots`: the paid window and the store filter
+// are the two rules that decide what counts as takings, and a regenerated
+// snapshot would record them wrong just as happily as right.
+describe("which orders count as takings", () => {
+  it("counts a stretch from the moment the till took the money", async () => {
+    // >= on the closing instant would bill the 1st of September twice, once to
+    // each month.
+    await listServicesRevenueSeries({ range: AUGUST, granularity: "day" });
+
+    expect(only().sql).toContain('"orders"."paid_at" >= $1');
+    expect(only().sql).toContain('"orders"."paid_at" < $2');
+    expect(only().params[0]).toBe(AUGUST.start.toISOString());
+    expect(only().params[1]).toBe(AUGUST.end.toISOString());
+  });
+
+  it("keeps one store's takings to that store alone", async () => {
+    await listServicesRevenueSeries({
+      granularity: "day",
+      range: AUGUST,
+      storeId: KEMANG,
+    });
+
+    expect(only().sql).toContain('"orders"."store_id" = $');
+    expect(only().params).toContain(KEMANG);
+  });
+});
+
+describe("grouping takings into chart bars", () => {
+  // Postgres must cut the day at Jakarta midnight, not UTC midnight, or the
+  // shop's evening trade lands on tomorrow's bar.
+  const formats = [
+    { fmt: "YYYY-MM-DD", granularity: "day" as const },
+    { fmt: "IYYY-IW", granularity: "week" as const },
+    { fmt: "YYYY-MM", granularity: "month" as const },
+    { fmt: "YYYY", granularity: "year" as const },
+  ];
+
+  for (const { fmt, granularity } of formats) {
+    it(`cuts ${granularity} bars at Jakarta midnight`, async () => {
+      await listServicesRevenueSeries({ range: AUGUST, granularity });
+
+      const expr = `to_char("orders"."paid_at" AT TIME ZONE 'Asia/Jakarta', '${fmt}')`;
+      expect(only().sql).toContain(`select ${expr},`);
+      expect(only().sql).toContain(`group by ${expr}`);
+    });
+  }
+});
+
+describe("reading rupiah back out of Postgres", () => {
+  // numeric(12,0) arrives as a string. Left as one, the report's additions turn
+  // into string joins and a day's takings render as "500000120000".
+  it("turns a day's service takings into a number the report can add", async () => {
+    rowQueue.push([
+      ["2026-08-01", "500000"],
+      ["2026-08-02", "0"],
+    ]);
+
+    const rows = await listServicesRevenueSeries({
+      range: AUGUST,
+      granularity: "day",
+    });
+
+    expect(rows).toEqual([
+      { bucket: "2026-08-01", revenue: 500_000 },
+      { bucket: "2026-08-02", revenue: 0 },
+    ]);
+  });
+
+  it("turns refunds handed back into numbers, counted alongside their amount", async () => {
+    rowQueue.push([["2026-08-03", "75000", 2]]);
+
+    const rows = await listRefundAmountSeries({
+      range: AUGUST,
+      granularity: "day",
+    });
+
+    expect(rows).toEqual([
+      { bucket: "2026-08-03", amount: 75_000, refunds: 2 },
+    ]);
+  });
+
+  it("files takings with no recorded payment method under Unknown", async () => {
+    // Legacy orders paid before the method was mandatory still carry money the
+    // mix chart has to place somewhere.
+    rowQueue.push([["2026-08-01", null, null, "250000", 4]]);
+
+    const rows = await listPaymentMixSeries({
+      range: AUGUST,
+      granularity: "day",
+    });
+
+    expect(rows).toEqual([
+      {
+        bucket: "2026-08-01",
+        payment_method_id: 0,
+        payment_method_name: "Unknown",
+        revenue: 250_000,
+        orders: 4,
+      },
+    ]);
+  });
+
+  it("averages a promo's order value without rounding to whole rupiah", async () => {
+    // Three Rp10.000-ish orders on one voucher: the average lands between
+    // rupiah and is reported as-is, sen and all.
+    rowQueue.push([[7, "Grand Opening", "OPEN26", "9000"]]);
+    rowQueue.push([
+      [7, 101, "9000", "10000"],
+      [7, 102, "9001", "10001"],
+      [7, 103, "9001", "10001"],
+    ]);
+
+    const rows = await listCampaignEffectivenessRows({ range: AUGUST });
+
+    expect(rows).toEqual([
+      {
+        campaign_id: 7,
+        campaign_name: "Grand Opening",
+        campaign_code: "OPEN26",
+        orders: 3,
+        revenue: 27_002,
+        discount_cost: 9000,
+        avg_order_value: 30_002 / 3,
+      },
+    ]);
+  });
+});

--- a/packages/server/src/modules/reports/report-range.service.test.ts
+++ b/packages/server/src/modules/reports/report-range.service.test.ts
@@ -1,0 +1,460 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { drizzle } from "drizzle-orm/pg-proxy";
+import { getJakartaDayRange } from "@/modules/reports/report-range.util";
+
+// Turning day-rows into the figures on the reports page is plain arithmetic:
+// fill the days the shop was shut, walk a day's takings down from what was
+// charged to what the shop kept, then compare against the stretch before.
+//
+// A pg-proxy driver stands in for the database — Drizzle builds the real
+// statement, we recognise which figure it asks for and answer with rows we
+// chose. Money arrives as strings because that is what numeric(12,0) sends, so
+// these fixtures exercise the whole path from Postgres text to rendered rupiah.
+// What each query *means* is pinned in report-range.repository.test.ts.
+
+const FROM = "2026-08-01";
+const TO = "2026-08-03";
+
+// Aug 1–3 is a 3-day stretch, so the comparison stretch is Jul 29–31.
+const NOW_START = getJakartaDayRange(FROM).start.toISOString();
+
+type Rows = unknown[][];
+type Period = "before" | "now";
+
+const noRows = (): Record<Period, Rows> => ({ now: [], before: [] });
+
+const answers = {
+  storeCategory: noRows(),
+  storeRevenue: noRows(),
+  categoryRevenue: noRows(),
+  discount: noRows(),
+  paymentMix: noRows(),
+  products: noRows(),
+  productsCogs: noRows(),
+  refundReasons: noRows(),
+  refunds: noRows(),
+  services: noRows(),
+  servicesCogs: noRows(),
+};
+
+// The summed column is what tells two otherwise identical queries apart, which
+// is exactly the distinction a repository dedupe could lose.
+const figureOf = (sql: string): keyof typeof answers => {
+  if (sql.includes('SUM("orders_products"."subtotal")')) {
+    return "products";
+  }
+  if (sql.includes('SUM("orders_products"."cogs_snapshot")')) {
+    return "productsCogs";
+  }
+  if (sql.includes('SUM("orders_services"."cogs_snapshot")')) {
+    return "servicesCogs";
+  }
+  if (sql.includes('SUM("order_refunds"."total_amount")')) {
+    return "refunds";
+  }
+  if (sql.includes('SUM("order_refund_items"."amount")')) {
+    return "refundReasons";
+  }
+  if (sql.includes('SUM("discount")')) {
+    return "discount";
+  }
+  if (sql.includes('SUM("orders"."paid_amount")')) {
+    return "storeRevenue";
+  }
+  if (sql.includes('SUM("orders_services"."subtotal")')) {
+    if (sql.includes('"stores"')) {
+      return "storeCategory";
+    }
+    if (sql.includes('"categories"')) {
+      return "categoryRevenue";
+    }
+    return "services";
+  }
+  throw new Error(`No fixture knows what this query asks for: ${sql}`);
+};
+
+const sent: { params: unknown[]; sql: string }[] = [];
+
+mock.module("@/db", () => ({
+  db: drizzle((sql, params) => {
+    sent.push({ params, sql });
+    const figure = sql.includes('"payment_methods"')
+      ? "paymentMix"
+      : figureOf(sql);
+    const period: Period = params[0] === NOW_START ? "now" : "before";
+    return Promise.resolve({ rows: answers[figure][period] });
+  }),
+}));
+
+const { getFinancialReport, getPaymentMixReport, getRefundTrendReport } =
+  await import("@/modules/reports/report-range.service");
+
+const financial = () => getFinancialReport({ from: FROM, to: TO });
+
+const takings = (bucket: string, amount: number) => [bucket, String(amount)];
+
+beforeEach(() => {
+  sent.length = 0;
+  for (const key of Object.keys(answers) as (keyof typeof answers)[]) {
+    answers[key] = noRows();
+  }
+
+  // Saturday: a full day of laundry plus soap sold off the shelf, with a
+  // Rp20.000 promo off the whole order.
+  // Sunday: shut — Postgres returns no row for it at all.
+  // Monday: services only, and Rp75.000 handed back for Saturday's ruined shirt.
+  answers.services.now = [
+    takings("2026-08-01", 500_000),
+    takings("2026-08-03", 300_000),
+  ];
+  answers.products.now = [takings("2026-08-01", 120_000)];
+  answers.servicesCogs.now = [
+    takings("2026-08-01", 150_000),
+    takings("2026-08-03", 90_000),
+  ];
+  answers.productsCogs.now = [takings("2026-08-01", 60_000)];
+  answers.discount.now = [takings("2026-08-01", 20_000)];
+  answers.refunds.now = [["2026-08-03", "75000", 1]];
+
+  answers.services.before = [takings("2026-07-29", 700_000)];
+  answers.products.before = [takings("2026-07-29", 100_000)];
+  answers.servicesCogs.before = [takings("2026-07-29", 200_000)];
+  answers.productsCogs.before = [takings("2026-07-29", 50_000)];
+});
+
+describe("the day-by-day money chart", () => {
+  it("gives the Sunday the shop was shut a bar at zero", async () => {
+    // Dropping the day with no trade would slide Monday's bar into Sunday's slot
+    // and shorten the chart.
+    const report = await financial();
+
+    expect(report.series.map((row) => row.bucket)).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+      "2026-08-03",
+    ]);
+    expect(report.series[1]).toEqual({
+      bucket: "2026-08-02",
+      services: 0,
+      products: 0,
+      gross_revenue: 0,
+      discount: 0,
+      net_revenue: 0,
+      cogs: 0,
+      gross_profit: 0,
+      refunds: 0,
+      net_income: 0,
+    });
+  });
+
+  it("walks Saturday from what was charged down to what the shop kept", async () => {
+    const report = await financial();
+
+    expect(report.series[0]).toEqual({
+      bucket: "2026-08-01",
+      services: 500_000,
+      products: 120_000,
+      gross_revenue: 620_000,
+      discount: 20_000,
+      net_revenue: 600_000,
+      cogs: 210_000,
+      gross_profit: 390_000,
+      refunds: 0,
+      net_income: 390_000,
+    });
+  });
+
+  it("charges Monday's refund to Monday, leaving Saturday's sale untouched", async () => {
+    // The refund undoes a Saturday shirt but was handed back on Monday, so
+    // Monday's bar carries it. Saturday's profit is not restated.
+    const report = await financial();
+
+    expect(report.series[2]).toEqual({
+      bucket: "2026-08-03",
+      services: 300_000,
+      products: 0,
+      gross_revenue: 300_000,
+      discount: 0,
+      net_revenue: 300_000,
+      cogs: 90_000,
+      gross_profit: 210_000,
+      refunds: 75_000,
+      net_income: 135_000,
+    });
+    expect(report.series[0].net_income).toBe(390_000);
+  });
+
+  it("keeps takings Postgres filed outside the charted days off the chart", async () => {
+    // A bucket label the range never enumerates. An ISO-week disagreement at
+    // New Year is how this happens for real.
+    answers.services.now = [
+      ...answers.services.now,
+      takings("2026-08-04", 999_000),
+    ];
+
+    const report = await financial();
+
+    expect(report.series).toHaveLength(3);
+    expect(report.series.reduce((sum, row) => sum + row.services, 0)).toBe(
+      800_000
+    );
+  });
+});
+
+describe("the headline figures for the whole stretch", () => {
+  it("adds the three days up into one set of totals", async () => {
+    const report = await financial();
+
+    expect(report.summary.current).toEqual({
+      services_total: 800_000,
+      products_total: 120_000,
+      gross_revenue: 920_000,
+      discount: 20_000,
+      net_revenue: 900_000,
+      cogs: 300_000,
+      gross_profit: 600_000,
+      refunds: 75_000,
+      net_income: 525_000,
+      net_margin: 525_000 / 900_000,
+    });
+  });
+
+  it("reports no margin on a giveaway stretch instead of dividing by nothing", async () => {
+    // Grand-opening weekend: everything charged was discounted away. A margin of
+    // 0 beats NaN on the card.
+    answers.services.now = [takings("2026-08-01", 100_000)];
+    answers.products.now = [];
+    answers.servicesCogs.now = [];
+    answers.productsCogs.now = [];
+    answers.discount.now = [takings("2026-08-01", 100_000)];
+    answers.refunds.now = [];
+
+    const report = await financial();
+
+    expect(report.summary.current.net_revenue).toBe(0);
+    expect(report.summary.current.net_margin).toBe(0);
+  });
+
+  it("adds a day's takings instead of stringing them together", async () => {
+    // numeric(12,0) arrives as text. Left as text, Saturday's Rp500.000 of
+    // laundry and Rp120.000 of soap would render as "500000120000".
+    const report = await financial();
+
+    expect(report.summary.current.gross_revenue).toBe(920_000);
+    expect(typeof report.summary.current.gross_revenue).toBe("number");
+  });
+});
+
+describe("this stretch against the one before it", () => {
+  it("shows takings up but profit down after a big refund", async () => {
+    // Rp920.000 charged against Rp800.000 the stretch before — but Rp75.000 went
+    // back out, so the shop kept less. Both facts have to survive.
+    const report = await financial();
+
+    expect(report.previous).toEqual({ from: "2026-07-29", to: "2026-07-31" });
+    expect(report.summary.deltas.gross_revenue).toEqual({
+      current: 920_000,
+      previous: 800_000,
+      delta_pct: 0.15,
+    });
+    expect(report.summary.deltas.net_income).toEqual({
+      current: 525_000,
+      previous: 550_000,
+      delta_pct: (525_000 - 550_000) / 550_000,
+    });
+  });
+
+  it("leaves growth blank where the earlier stretch had none of that money", async () => {
+    // No refunds and no discounts last stretch. Anything but blank claims an
+    // infinite jump on the card.
+    const report = await financial();
+
+    expect(report.summary.deltas.refunds).toEqual({
+      current: 75_000,
+      previous: 0,
+      delta_pct: null,
+    });
+    expect(report.summary.deltas.discount).toEqual({
+      current: 20_000,
+      previous: 0,
+      delta_pct: null,
+    });
+  });
+});
+
+describe("splitting the takings between stores", () => {
+  const store = (
+    id: number,
+    name: string,
+    code: string,
+    revenue: number,
+    orders: number
+  ) => [id, name, code, String(revenue), orders];
+
+  it("gives each store its share of the takings, biggest first", async () => {
+    answers.storeRevenue.now = [
+      store(2, "Bintaro", "BIN", 300_000, 4),
+      store(3, "Cipete", "CIP", 0, 0),
+      store(1, "Kemang", "KEM", 600_000, 9),
+    ];
+
+    const report = await financial();
+
+    expect(
+      report.store_breakdown.map((row) => [row.store_name, row.share])
+    ).toEqual([
+      ["Kemang", 600_000 / 900_000],
+      ["Bintaro", 300_000 / 900_000],
+      ["Cipete", 0],
+    ]);
+  });
+
+  it("gives a store no share of a stretch nobody banked anything", async () => {
+    answers.storeRevenue.now = [store(1, "Kemang", "KEM", 0, 0)];
+
+    const report = await financial();
+
+    expect(report.store_breakdown[0].share).toBe(0);
+  });
+});
+
+describe("which services earn the money", () => {
+  it("charts the five biggest categories and lumps the rest into Other", async () => {
+    // Seven categories on the price list, six bars on the chart: sepatu, karpet
+    // and boneka are a rounding error next to cuci setrika.
+    const priceList: [number, string, number][] = [
+      [1, "Cuci Setrika", 400_000],
+      [2, "Cuci Kering", 200_000],
+      [3, "Setrika Saja", 100_000],
+      [4, "Dry Clean", 50_000],
+      [5, "Sepatu", 25_000],
+      [6, "Karpet", 10_000],
+      [7, "Boneka", 5000],
+    ];
+    answers.categoryRevenue.now = priceList.map(([id, name, revenue]) => [
+      "2026-08-01",
+      id,
+      name,
+      String(revenue),
+    ]);
+
+    const report = await financial();
+
+    expect(report.category_keys).toEqual([
+      { key: "cat_1", label: "Cuci Setrika" },
+      { key: "cat_2", label: "Cuci Kering" },
+      { key: "cat_3", label: "Setrika Saja" },
+      { key: "cat_4", label: "Dry Clean" },
+      { key: "cat_5", label: "Sepatu" },
+      { key: "cat_other", label: "Other" },
+    ]);
+    expect(report.category_series[0]).toEqual({
+      bucket: "2026-08-01",
+      cat_1: 400_000,
+      cat_2: 200_000,
+      cat_3: 100_000,
+      cat_4: 50_000,
+      cat_5: 25_000,
+      cat_other: 15_000,
+    });
+    // The treemap keeps every category, so the small ones stay auditable.
+    expect(report.category_treemap).toHaveLength(7);
+  });
+});
+
+describe("how the shop was paid", () => {
+  it("splits the takings by tender and shares them out", async () => {
+    answers.paymentMix.now = [
+      ["2026-08-01", 1, "Cash", "400000", 5],
+      ["2026-08-03", 1, "Cash", "200000", 3],
+      ["2026-08-01", 2, "QRIS", "300000", 2],
+    ];
+
+    const report = await getPaymentMixReport({ from: FROM, to: TO });
+
+    expect(report.summary.grand_total).toBe(900_000);
+    expect(report.summary.total_orders).toBe(10);
+    expect(
+      report.summary.methods.map((m) => [m.payment_method_name, m.share])
+    ).toEqual([
+      ["Cash", 600_000 / 900_000],
+      ["QRIS", 300_000 / 900_000],
+    ]);
+    expect(report.series).toEqual([
+      { bucket: "2026-08-01", pm_1: 400_000, pm_2: 300_000 },
+      { bucket: "2026-08-02", pm_1: 0, pm_2: 0 },
+      { bucket: "2026-08-03", pm_1: 200_000, pm_2: 0 },
+    ]);
+  });
+});
+
+describe("what the shop handed back", () => {
+  it("totals the refunds by reason and leaves untouched reasons at zero", async () => {
+    answers.refundReasons.now = [
+      ["2026-08-03", "damaged", "50000", 1],
+      ["2026-08-03", "lost", "25000", 1],
+    ];
+
+    const report = await getRefundTrendReport({ from: FROM, to: TO });
+
+    expect(report.summary.total_amount).toBe(75_000);
+    expect(report.summary.total_refunds).toBe(1);
+    expect(report.summary.reason_totals).toEqual({
+      damaged: { amount: 50_000, items: 1 },
+      lost: { amount: 25_000, items: 1 },
+      cannot_process: { amount: 0, items: 0 },
+      other: { amount: 0, items: 0 },
+    });
+    expect(report.reason_series[2]).toEqual({
+      bucket: "2026-08-03",
+      damaged: 50_000,
+      lost: 25_000,
+      cannot_process: 0,
+      other: 0,
+    });
+    expect(report.reason_series[0]).toEqual({
+      bucket: "2026-08-01",
+      damaged: 0,
+      lost: 0,
+      cannot_process: 0,
+      other: 0,
+    });
+  });
+});
+
+describe("asking one store for its takings", () => {
+  const KEMANG = 3;
+  const storeFilter = '"orders"."store_id" = $';
+
+  // The gate on the route proves the reader was allowed to name Kemang. Nothing
+  // between the gate and Postgres proved the report then *asked* for Kemang —
+  // so a report can be scoped to one store and answer with the whole company.
+  it("carries the store down into every figure it adds up", async () => {
+    await getFinancialReport({ from: FROM, to: TO, store_id: KEMANG });
+
+    const unscoped = sent.filter((query) => !query.sql.includes(storeFilter));
+
+    // Store revenue is the one known exception, and by construction rather than
+    // oversight: listStoreRevenueRows takes no store parameter, so the
+    // store_breakdown panel is company-wide however the report was scoped.
+    for (const query of unscoped) {
+      expect(figureOf(query.sql)).toBe("storeRevenue");
+    }
+  });
+
+  it("asks Postgres for the store that was named, not some other one", async () => {
+    await getFinancialReport({ from: FROM, to: TO, store_id: KEMANG });
+
+    for (const query of sent.filter((q) => q.sql.includes(storeFilter))) {
+      expect(query.params).toContain(KEMANG);
+    }
+  });
+
+  it("asks for every store when none was named", async () => {
+    await getFinancialReport({ from: FROM, to: TO });
+
+    for (const query of sent) {
+      expect(query.sql).not.toContain(storeFilter);
+    }
+  });
+});

--- a/packages/server/src/modules/reports/report.schema.ts
+++ b/packages/server/src/modules/reports/report.schema.ts
@@ -1,16 +1,21 @@
 import { z } from "zod";
 import { dateStringSchema } from "@/schema/common";
 
+// The store gate on the reports router reads store_id off the raw querystring,
+// because per-route validators run after it. Both must read "which store" by
+// the same rules, so there is one rule.
+export const storeIdQuerySchema = z.coerce.number().int().positive();
+
 export const GETDailyReportQuerySchema = z.object({
   date: dateStringSchema("date"),
-  store_id: z.coerce.number().int().positive().optional(),
+  store_id: storeIdQuerySchema.optional(),
 });
 
 export type GetDailyReportQuery = z.infer<typeof GETDailyReportQuerySchema>;
 
 export const GETReportOverviewQuerySchema = z.object({
   date: dateStringSchema("date"),
-  store_id: z.coerce.number().int().positive().optional(),
+  store_id: storeIdQuerySchema.optional(),
   trend_days: z.coerce.number().int().min(1).max(60).default(14),
 });
 
@@ -27,7 +32,7 @@ export const GETReportRangeQuerySchema = z
   .object({
     from: dateStringSchema("from"),
     to: dateStringSchema("to"),
-    store_id: z.coerce.number().int().positive().optional(),
+    store_id: storeIdQuerySchema.optional(),
     granularity: granularitySchema,
   })
   .refine((value) => value.from <= value.to, {
@@ -38,7 +43,7 @@ export const GETReportRangeQuerySchema = z
 export type GetReportRangeQuery = z.infer<typeof GETReportRangeQuerySchema>;
 
 export const GETAgingQueueQuerySchema = z.object({
-  store_id: z.coerce.number().int().positive().optional(),
+  store_id: storeIdQuerySchema.optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
   offset: z.coerce.number().int().min(0).optional(),
 });

--- a/packages/server/src/routes/admin/reports.route.test.ts
+++ b/packages/server/src/routes/admin/reports.route.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+import { ForbiddenException } from "@/http-exceptions";
+import type { JWTPayload } from "@/types";
+import { errorHandler } from "@/utils/error-handler";
+
+// Every report service and the store gate are both replaced below, so nothing
+// in this router's graph ever reaches db — it only has to exist to be imported.
+mock.module("@/db", () => ({ db: {} }));
+
+const KEMANG = 1;
+const BINTARO = 2;
+
+const gateCalls: { storeId: number; userId: number }[] = [];
+
+// Stands in for the store gate having answered "no". The real one waves an
+// admin through, so a suite run as admin would never see a refusal — but the
+// question here is what the reports router does when the gate refuses, not who
+// the gate refuses. That decision is pinned in utils/authorization.test.ts.
+mock.module("@/utils/authorization", () => ({
+  assertStoreAccess: (user: JWTPayload, storeId: number) => {
+    gateCalls.push({ storeId, userId: user.id });
+
+    if (storeId !== KEMANG) {
+      throw new ForbiddenException("You do not have access to this store");
+    }
+
+    return Promise.resolve();
+  },
+}));
+
+// Each report is stubbed to a marker that records the store it was told to
+// report on, so a test can compare what the gate checked against what the report
+// would actually have been run for.
+const produced: { report: string; storeId?: number }[] = [];
+
+const marker =
+  (report: string) =>
+  (query: { store_id?: number } = {}) => {
+    produced.push({ report, storeId: query.store_id });
+    return Promise.resolve({ ok: report });
+  };
+
+mock.module("@/modules/reports/report.service", () => ({
+  getAgingQueueReport: (query: { store_id?: number } = {}) => {
+    produced.push({ report: "aging-queue", storeId: query.store_id });
+    return Promise.resolve({ items: [], meta: {} });
+  },
+  getReportOverview: marker("overview"),
+}));
+
+mock.module("@/modules/reports/report-range.service", () => ({
+  getCampaignEffectivenessReport: marker("campaign-effectiveness"),
+  getCustomerAcquisitionReport: marker("customer-acquisition"),
+  getFinancialReport: marker("financial"),
+  getOrdersFlowReport: marker("orders-flow"),
+  getPaymentMixReport: marker("payment-mix"),
+  getRefundTrendReport: marker("refund-trend"),
+  getWorkerProductivityReport: marker("worker-productivity"),
+}));
+
+const reportsRoutes = (await import("@/routes/admin/reports")).default;
+
+const owner: JWTPayload = {
+  id: 11,
+  name: "Bu Sri",
+  username: "sri",
+  role: "admin",
+  can_process_pickup: false,
+};
+
+const app = new Hono<{ Variables: { jwtPayload: JWTPayload } }>()
+  .use("*", async (c, next) => {
+    c.set("jwtPayload", owner);
+    await next();
+  })
+  .route("/reports", reportsRoutes);
+
+app.onError(errorHandler);
+
+// Every report is dated except the aging queue, which asks what is still on the
+// rack right now.
+const REPORTS = [
+  { path: "/overview", params: "date=2026-08-05" },
+  { path: "/financial", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/orders-flow", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/payment-mix", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/customer-acquisition", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/refund-trend", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/worker-productivity", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/campaign-effectiveness", params: "from=2026-08-01&to=2026-08-05" },
+  { path: "/aging-queue", params: "" },
+];
+
+const call = (path: string, params: string) =>
+  app.request(`/reports${path}${params ? `?${params}` : ""}`);
+
+const withStore = (params: string, storeId: string) =>
+  params ? `${params}&store_id=${storeId}` : `store_id=${storeId}`;
+
+beforeEach(() => {
+  gateCalls.length = 0;
+  produced.length = 0;
+});
+
+describe("naming a store on a report is checked against the store", () => {
+  for (const { path, params } of REPORTS) {
+    it(`checks the store before running ${path}`, async () => {
+      const res = await call(path, withStore(params, String(KEMANG)));
+
+      expect(res.status).toBe(200);
+      expect(gateCalls).toEqual([{ storeId: KEMANG, userId: 11 }]);
+    });
+
+    it(`refuses ${path} for a store that is not theirs`, async () => {
+      const res = await call(path, withStore(params, String(BINTARO)));
+
+      expect(res.status).toBe(403);
+      expect(produced).toEqual([]);
+    });
+  }
+});
+
+describe("a store dressed up to look like another", () => {
+  // The report reads the store after coercion, so store_id=+1 and store_id=%201
+  // both report on Kemang. A gate that recognised only plain digits would wave
+  // these past and hand Kemang's takings to whoever asked.
+  const disguises = ["+1", "%201", "1.0", "1e0", "01", "1%20"];
+
+  for (const disguise of disguises) {
+    it(`checks the store for store_id=${disguise}`, async () => {
+      const res = await call(
+        "/financial",
+        withStore("from=2026-08-01&to=2026-08-05", disguise)
+      );
+
+      expect(res.status).toBe(200);
+      expect(gateCalls).toEqual([{ storeId: KEMANG, userId: 11 }]);
+      expect(produced).toEqual([{ report: "financial", storeId: KEMANG }]);
+    });
+  }
+});
+
+describe("a store the gate cannot read", () => {
+  // A store it cannot read is refused, not dropped: running the report with no
+  // store filter would answer with every store's takings.
+  const unreadable = ["0", "-1", "abc", "", "1.5", "9999999999999999999999"];
+
+  for (const value of unreadable) {
+    it(`refuses store_id=${value} before any report is produced`, async () => {
+      const res = await call(
+        "/financial",
+        withStore("from=2026-08-01&to=2026-08-05", value)
+      );
+
+      expect(res.status).toBe(400);
+      expect(produced).toEqual([]);
+    });
+  }
+
+  it("refuses a store named twice rather than picking one", async () => {
+    const res = await app.request("/reports/aging-queue?store_id=1&store_id=2");
+
+    expect(res.status).toBe(400);
+    expect(produced).toEqual([]);
+  });
+});
+
+describe("what the gate covers and what it leaves alone", () => {
+  it("gates a report path nobody has written yet", async () => {
+    // The gate hangs off the router, not off each report, so the tenth report
+    // added here is checked before its author writes a line.
+    const res = await call("/not-a-report-yet", "store_id=2");
+
+    expect(res.status).toBe(403);
+    expect(gateCalls).toEqual([{ storeId: BINTARO, userId: 11 }]);
+  });
+
+  it("refuses an unreadable store on a report path nobody has written yet", async () => {
+    const res = await call("/not-a-report-yet", "store_id=abc");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("does not ask which store a company-wide report belongs to", async () => {
+    const res = await call("/financial", "from=2026-08-01&to=2026-08-05");
+
+    expect(res.status).toBe(200);
+    expect(gateCalls).toEqual([]);
+    expect(produced).toEqual([{ report: "financial", storeId: undefined }]);
+  });
+});

--- a/packages/server/src/routes/admin/reports.ts
+++ b/packages/server/src/routes/admin/reports.ts
@@ -1,9 +1,12 @@
 import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { BadRequestException } from "@/http-exceptions";
 import { assertIsAdmin } from "@/modules/permissions/permissions";
 import {
   GETAgingQueueQuerySchema,
   GETReportOverviewQuerySchema,
   GETReportRangeQuerySchema,
+  storeIdQuerySchema,
 } from "@/modules/reports/report.schema";
 import {
   getAgingQueueReport,
@@ -23,23 +26,40 @@ import { assertStoreAccess } from "@/utils/authorization";
 import { success } from "@/utils/http";
 import { zodValidator } from "@/utils/zod-validator-wrapper";
 
+// Admin-only today, and assertStoreAccess waves admins through, so this gate
+// refuses nobody yet. It also only covers requests that *name* a store — leaving
+// store_id off still answers for the whole company, so opening reports to shop
+// staff needs resolveStoreScope in the services too. One gate for the router,
+// because the way that leaks is a tenth report whose author forgot the check.
+// store_id comes off the raw querystring, since per-route validators run after
+// this, so it parses with the schema they use or the request is refused.
+const requireStoreAccess = createMiddleware<AdminEnv>(async (c, next) => {
+  const raw = c.req.query("store_id");
+
+  if (raw !== undefined) {
+    const storeId = storeIdQuerySchema.safeParse(raw);
+
+    if (!storeId.success) {
+      throw new BadRequestException("store_id must be a positive whole number");
+    }
+
+    await assertStoreAccess(c.get("jwtPayload"), storeId.data);
+  }
+
+  await next();
+});
+
 const app = new Hono<AdminEnv>()
   .use(async (c, next) => {
     assertIsAdmin(c.get("jwtPayload"));
     await next();
   })
+  .use(requireStoreAccess)
   .get(
     "/overview",
     zodValidator("query", GETReportOverviewQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-
-      const data = await getReportOverview(query);
+      const data = await getReportOverview(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -47,12 +67,7 @@ const app = new Hono<AdminEnv>()
     "/financial",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getFinancialReport(query);
+      const data = await getFinancialReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -60,12 +75,7 @@ const app = new Hono<AdminEnv>()
     "/orders-flow",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getOrdersFlowReport(query);
+      const data = await getOrdersFlowReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -73,12 +83,7 @@ const app = new Hono<AdminEnv>()
     "/payment-mix",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getPaymentMixReport(query);
+      const data = await getPaymentMixReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -86,12 +91,7 @@ const app = new Hono<AdminEnv>()
     "/customer-acquisition",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getCustomerAcquisitionReport(query);
+      const data = await getCustomerAcquisitionReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -99,12 +99,7 @@ const app = new Hono<AdminEnv>()
     "/refund-trend",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getRefundTrendReport(query);
+      const data = await getRefundTrendReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -112,12 +107,7 @@ const app = new Hono<AdminEnv>()
     "/worker-productivity",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getWorkerProductivityReport(query);
+      const data = await getWorkerProductivityReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -125,12 +115,7 @@ const app = new Hono<AdminEnv>()
     "/campaign-effectiveness",
     zodValidator("query", GETReportRangeQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const data = await getCampaignEffectivenessReport(query);
+      const data = await getCampaignEffectivenessReport(c.req.valid("query"));
       return c.json(success(data));
     }
   )
@@ -138,12 +123,7 @@ const app = new Hono<AdminEnv>()
     "/aging-queue",
     zodValidator("query", GETAgingQueueQuerySchema),
     async (c) => {
-      const user = c.get("jwtPayload");
-      const query = c.req.valid("query");
-      if (query.store_id !== undefined) {
-        await assertStoreAccess(user, query.store_id);
-      }
-      const result = await getAgingQueueReport(query);
+      const result = await getAgingQueueReport(c.req.valid("query"));
       return c.json(success(result.items, undefined, result.meta));
     }
   );


### PR DESCRIPTION
Implements audit findings **S4** and **S3**. Both are server-side report internals — flagging up front that a reports-page overhaul may supersede the endpoint surface, though the tests here are what make the next batch's dedupe safe either way.

## S4 — nine transcribed copies of one authorisation rule

Each report handler repeated the same block after its validator. A tenth report added without it is an access hole nothing catches. Now one middleware covers the router.

The difficulty worth recording: the orders route solved this with `.use("/:id", …)` because the order id is a **path** param. Here `store_id` is a **query** param that arrives validated, and per-route validators run *after* route-level `.use()`. So the gate sees the raw querystring — and if it parsed that with different rules than the schema, it would recreate the bypass class the orders gate shipped and had to fix. The field schema is hoisted to `storeIdQuerySchema` and shared, so the gate and the validators cannot disagree.

Measured, not reasoned — the store the gate checked vs the store the handler resolved:

| `store_id` | status | gate saw | handler ran for |
|---|---|---|---|
| `1`, `+1`, `%201`, `1.0`, `1e0`, `01`, `1%20`, `0x1` | 200 | 1 | 1 |
| `0`, `-1`, `abc`, empty, `1.5`, `1,2` | 400 | not run | not reached |
| `store_id=1&store_id=2` | 400 | 1 | not reached |

No divergence. The duplicate-key row is the only place the two read differently — the gate takes Hono's first value while the validator receives an array and rejects it — and it ends in refusal, so it cannot serve data.

**The honest caveat:** `assertIsAdmin` runs first on this router, and `assertStoreAccess` returns immediately for admins. So all nine copies were *already* no-ops, and so is the gate. This is a dedupe of existing defence-in-depth, not a live fix. Two reviewers caught my comment claiming otherwise; it now states what the gate actually does, including that it only covers requests that **name** a store — omitting `store_id` still answers company-wide, so opening reports to shop staff needs `resolveStoreScope` in the services too.

Guard sites: **9 → 1**. Router net −13 lines.

## S3 — tests for the money math, ahead of the dedupe

The audit's §06 ordering says S3 before S5 because *"the dedupe touches the definition of revenue"*. My original plan had these backwards; corrected.

The premise that this couldn't be done without a database turned out to be wrong: a `drizzle-orm/pg-proxy` driver lets Drizzle build the **real** statement, which we capture and answer with chosen rows. Nothing connects.

**The load-bearing part is the SQL snapshots, and there is evidence for why.** The substring assertions written first were proven blind to the most likely refactor mistakes. Every mutation below was reinstated in the source and both suites run against it:

| S5 refactor mistake | substring assertions | full-SQL snapshots |
|---|---|---|
| includes unpaid orders (`or paid_at is null`) | 0 fail — **blind** | **41 fail** |
| `and(...)` → `or(...)` across the condition list | 0 fail — **blind** | **40 fail** |
| drops the `isNotNull` guard | 0 fail — **blind** | **21 fail** |
| `<=` instead of `<` on the closing instant | 12 fail | **22 fail** |
| store filter dropped | 12 fail | **20 fail** |
| **service stops forwarding `storeId`** | 0 fail — **blind** | **1 fail** (new test) |

Adding a disjunct beside an intact window keeps every substring in place. A snapshot of the whole statement does not, and for a refactor whose contract is *"same question, less code"* that is exactly the right contract — a shared builder producing the same AST emits identical SQL.

The last row was the gap a reviewer found: the repository tests proved *"pass a store and the SQL filters"*, the route tests proved *"the gate is consulted"*, and **nothing proved the layer between them forwards it**. Three service-level tests now close that.

## Found and recorded, not fixed

`listStoreRevenueRows` takes no `storeId` at all, so `store_breakdown` on a store-scoped financial report carries every store's takings — proven live against dev: a report scoped to Kemang returned BSD, Bekasi and Bogor revenue. `perStoreForRange` has the same shape for the overview's `per_store`.

Not fixed here, deliberately: every reader is an admin today, and the web financial panel currently *depends* on that panel being company-wide. It is pinned by a snapshot and a by-construction exception in the service tests, so a filter appearing there will be a deliberate decision rather than a surprise. Whether a store-scoped report should show a company breakdown is a question for the reports rewrite.

## Cleanup pass

`/simplify` over the diff, four angles. Applied:

- **`Store`, not `branch`** — `CONTEXT.md:227` says *"Use Store everywhere. Avoid: Branch"*. The new tests used "branch" 55 times including identifiers. Renamed; only snapshot **keys** changed, and the recorded SQL is byte-identical (51 statements, verified).
- **Dead `try/catch` removed** — it claimed to absorb readers that index into empty results. Ran all 21 functions × both scopes: **zero** rejections. It could only ever have hidden a real crash.
- **13-line `Proxy`-of-`Proxy` db stub deleted** — its comment claimed the repositories reach `db` at import. They don't; `db: {}` passes 34/34.
- **32 subsumed substring tests removed** — three reviewers independently found them strictly implied by the snapshots. Two representatives stay as a tripwire against a blind `--update-snapshots`. Re-ran every mutation afterwards: all six still caught.

Skipped, with reasons: a shared pg-proxy test harness (three copies, but S5 will rework these files — recorded as follow-up); `AUGUST` via `getJakartaRange` (hardcoded instants keep a characterization test independent of the helper it checks); `storeIdQuerySchema` → `schema/common` (no coupling to protect yet).

Also surfaced, pre-existing, recorded for their own PRs: `perStoreForRange` awaits 5 independent queries serially (overview is 16 statements but **5 round trips deep**); `listCampaignEffectivenessRows` serialises 2; the financial report sends 15 statements where 11 would do, since services revenue and services COGS are the same query differing only in the summed column — an S5 opportunity the snapshots now make safe to take; `fetchWorkerUsers` ignores `storeId`.

## Verification

All forced, no cache replays:

| gate | result |
|---|---|
| `bun x ultracite check` | 368 files clean |
| `bunx turbo type-check --force` | 3/3, **0 cached** |
| `bunx turbo test --force` | server **416 pass / 0 fail** (35 files, up from 314), web **78 pass / 0 fail** |

No existing test was modified. Nothing under `apps/web/src/features/reports/**` was touched.