### PR TITLE
refactor(reports): name the paid-order window once, not eleven times

### DIFF
--- a/docs/audit/2026-08-05-code-quality-audit.html
+++ b/docs/audit/2026-08-05-code-quality-audit.html
@@ -481,7 +481,7 @@
           </div>
           <div class="fact">
             <dt>Shipped</dt>
-            <dd>19 / 39</dd>
+            <dd>22 / 39</dd>
           </div>
         </dl>
       </header>
@@ -489,7 +489,7 @@
       <div class="note good">
         <p>
           <strong>Remediation in progress.</strong>
-          Nineteen findings are fixed and merged. Each carries a
+          Twenty-two findings are fixed and merged. Each carries a
           <a
             class="shipped"
             href="https://github.com/jovanhartono/fc-pos/pulls?q=is%3Apr+is%3Amerged"
@@ -599,11 +599,40 @@
                 signed-in user could read off the network tab.
               </td>
             </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/84">#84</a>
+              </td>
+              <td>
+                <a href="#s3">S3</a> <a href="#s4">S4</a>
+              </td>
+              <td>
+                One gate on the reports router replaces the check ten handlers
+                each had to remember, and it reads
+                <code>store_id</code>
+                off the raw querystring because per-route validators run after
+                it. The money math stopped being untested: 41 snapshots record
+                every statement the reports repository sends, in full, scoped
+                and company-wide.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/jovanhartono/fc-pos/pull/85">#85</a>
+              </td>
+              <td><a href="#s5">S5</a></td>
+              <td>
+                What counts as a stretch's takings was written down eleven times
+                and is now written once. Those 41 snapshots are what made it
+                safe — a shared builder emitting the same AST produces
+                byte-identical SQL, so the file shrank by 166 lines without
+                Postgres being asked a single different question.
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>
-          Still open: <a href="#s3">S3</a>, <a href="#s4">S4</a>,
-          <a href="#s5">S5</a>, and the web findings.
+          Still open: the web findings.
           <a href="#w1">W1</a>, <a href="#w2">W2</a>, <a href="#w6">W6</a> and
           <a href="#w15">W15</a>
           are deferred: the report page they cover is being rewritten, so
@@ -1858,7 +1887,12 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
 
       <article class="f hi" id="s3">
         <div class="f-head">
-          <span class="id">S3</span><span class="sev hi">High</span>
+          <span class="id">S3</span><span class="sev hi">High</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/84"
+            >Shipped #84</a
+          >
           <h3 class="f-title">
             The reports module is 2,975 lines of money math with one test file
           </h3>
@@ -1955,7 +1989,12 @@ Number(line.product.price) * line.qty               // checkout-items-step.tsx:1
 
       <article class="f md" id="s4">
         <div class="f-head">
-          <span class="id">S4</span><span class="sev md">Medium</span>
+          <span class="id">S4</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/84"
+            >Shipped #84</a
+          >
           <h3 class="f-title">Ten report handlers, one body</h3>
           <div class="tags"><span class="tag">duplication</span></div>
         </div>
@@ -1999,7 +2038,12 @@ return c.json(success(data));</code></pre>
 
       <article class="f md" id="s5">
         <div class="f-head">
-          <span class="id">S5</span><span class="sev md">Medium</span>
+          <span class="id">S5</span><span class="sev md">Medium</span
+          ><a
+            class="shipped"
+            href="https://github.com/jovanhartono/fc-pos/pull/85"
+            >Shipped #85</a
+          >
           <h3 class="f-title">
             The paid-order window is copy-pasted 11 times; the store filter, 24
           </h3>
@@ -2053,6 +2097,45 @@ if (storeId !== undefined) {
           for the four revenue/COGS series. Roughly 250 lines go, and the
           definition of revenue becomes a thing you can point at.
         </p>
+
+        <div class="note good">
+          <p>
+            <strong>How it shipped — 166 lines, not 250.</strong>
+            The deeper repeat turned out to be the half-open
+            <code>[start, end)</code>
+            window itself, restated 14 times across four different time columns
+            —
+            <code>paid_at</code>, <code>created_at</code>,
+            <code>picked_up_at</code>, <code>clock_in_at</code>. That became
+            <code>timeWindow(column, range)</code>, and
+            <code>paidOrderWindow</code>
+            is built on it. Writing
+            <code>lte</code>
+            where
+            <code>lt</code>
+            belongs bills the closing day to two stretches at once; that call
+            now lives in one line instead of fourteen.
+          </p>
+          <p>
+            The missing 84 lines are the merges this report also implies —
+            services revenue and services COGS are the same statement bar the
+            summed column — and each of those
+            <em>changes</em>
+            the SQL Postgres receives. The 41 snapshots recorded in
+            <a href="#s3">S3</a>
+            are what made this refactor safe precisely because they refuse any
+            such change, so cashing in the rest would have meant spending the
+            guard to do it. They are left for their own reviewed PRs.
+          </p>
+          <p>
+            One hole surfaced on the way.
+            <code>fetchAttribution</code>'s store filter sat outside snapshot
+            coverage — deleting it outright passed all 416 tests, because the
+            fake driver returns no rows and the report short-circuits before
+            that query is built. A test that seeds one finished item now closes
+            it.
+          </p>
+        </div>
       </article>
 
       <article class="f md" id="s6">
@@ -3669,7 +3752,12 @@ const visibleStores = useMemo(() =&gt; {
                   href="https://github.com/jovanhartono/fc-pos/pull/82"
                   >#82</a
                 >
-                · S4 open
+                · S4
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/84"
+                  >#84</a
+                >
               </td>
             </tr>
             <tr>
@@ -3685,7 +3773,20 @@ const visibleStores = useMemo(() =&gt; {
                 needs a net first.
               </td>
               <td class="num">2 days</td>
-              <td>Open</td>
+              <td>
+                S3
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/84"
+                  >#84</a
+                >
+                · S5
+                <a
+                  class="shipped"
+                  href="https://github.com/jovanhartono/fc-pos/pull/85"
+                  >#85</a
+                >
+              </td>
             </tr>
             <tr>
               <td class="num">7</td>

--- a/packages/server/src/modules/reports/report-range.repository.test.ts
+++ b/packages/server/src/modules/reports/report-range.repository.test.ts
@@ -26,6 +26,7 @@ const {
   listPaymentMixSeries,
   listRefundAmountSeries,
   listServicesRevenueSeries,
+  listWorkerProductivityRows,
 } = await import("@/modules/reports/report-range.repository");
 
 // August 2026 as Jakarta sees it: opens 01 Aug 00:00 WIB, closes the instant
@@ -73,6 +74,22 @@ describe("which orders count as takings", () => {
 
     expect(only().sql).toContain('"orders"."store_id" = $');
     expect(only().params).toContain(KEMANG);
+  });
+
+  it("keeps the worker who finished an item to the store it was finished at", async () => {
+    // Who worked on an item is only asked once the report knows which items
+    // finished, so with no finished items the question is never put to Postgres
+    // and the snapshots never see it. One finished item makes it run.
+    rowQueue.push([[42]]);
+
+    await listWorkerProductivityRows({ range: AUGUST, storeId: KEMANG });
+
+    const attribution = queries.find((query) =>
+      query.sql.includes('distinct on ("processing_attribution"')
+    );
+
+    expect(attribution?.sql).toContain('"orders"."store_id" = $');
+    expect(attribution?.params).toContain(KEMANG);
   });
 });
 

--- a/packages/server/src/modules/reports/report-range.repository.ts
+++ b/packages/server/src/modules/reports/report-range.repository.ts
@@ -10,7 +10,7 @@ import {
   lt,
   sql,
 } from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import { alias, type PgColumn } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import {
   campaignsTable,
@@ -36,138 +36,78 @@ import {
   jakartaBucketExpr,
 } from "@/modules/reports/report-range.util";
 
-interface BaseRangeArgs {
-  granularity: Granularity;
+interface RangeArgs {
   range: DateRange;
   storeId?: number;
 }
 
-// ───────────────────────── Revenue trend (R1) ─────────────────────────
+interface SeriesRangeArgs extends RangeArgs {
+  granularity: Granularity;
+}
 
-export async function listServicesRevenueSeries({
-  range,
-  storeId,
-  granularity,
-}: BaseRangeArgs) {
-  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
+function storeScope(column: PgColumn, storeId?: number) {
+  return storeId === undefined ? undefined : eq(column, storeId);
+}
+
+// The closing instant belongs to the next stretch, not this one — otherwise
+// 1 September's first order is billed to August and to September both.
+function timeWindow(column: PgColumn, range: DateRange) {
+  return [gte(column, range.start), lt(column, range.end)];
+}
+
+function paidOrderWindow({ range, storeId }: RangeArgs) {
+  return [
+    ...timeWindow(ordersTable.paid_at, range),
     isNotNull(ordersTable.paid_at),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
+}
 
-  const rows = await db
+async function sumByBucket(
+  lineTable: typeof ordersServicesTable | typeof ordersProductsTable,
+  amount: "subtotal" | "cogs_snapshot",
+  { range, storeId, granularity }: SeriesRangeArgs
+) {
+  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
+  return await db
     .select({
       bucket,
-      revenue: sql<string>`COALESCE(SUM(${ordersServicesTable.subtotal}), 0)`,
+      total: sql<string>`COALESCE(SUM(${lineTable[amount]}), 0)`,
     })
-    .from(ordersServicesTable)
-    .innerJoin(ordersTable, eq(ordersServicesTable.order_id, ordersTable.id))
-    .where(and(...conditions))
+    .from(lineTable)
+    .innerJoin(ordersTable, eq(lineTable.order_id, ordersTable.id))
+    .where(and(...paidOrderWindow({ range, storeId })))
     .groupBy(bucket);
+}
 
+// ───────────────────────── Revenue trend (R1) ─────────────────────────
+
+export async function listServicesRevenueSeries(args: SeriesRangeArgs) {
+  const rows = await sumByBucket(ordersServicesTable, "subtotal", args);
   return rows.map((row) => ({
     bucket: row.bucket,
-    revenue: Number(row.revenue),
+    revenue: Number(row.total),
   }));
 }
 
-export async function listProductsRevenueSeries({
-  range,
-  storeId,
-  granularity,
-}: BaseRangeArgs) {
-  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
-  const rows = await db
-    .select({
-      bucket,
-      revenue: sql<string>`COALESCE(SUM(${ordersProductsTable.subtotal}), 0)`,
-    })
-    .from(ordersProductsTable)
-    .innerJoin(ordersTable, eq(ordersProductsTable.order_id, ordersTable.id))
-    .where(and(...conditions))
-    .groupBy(bucket);
-
+export async function listProductsRevenueSeries(args: SeriesRangeArgs) {
+  const rows = await sumByBucket(ordersProductsTable, "subtotal", args);
   return rows.map((row) => ({
     bucket: row.bucket,
-    revenue: Number(row.revenue),
+    revenue: Number(row.total),
   }));
 }
 
 // ───────────────────────── COGS (Financial) ─────────────────────────
 
-export async function listServicesCogsSeries({
-  range,
-  storeId,
-  granularity,
-}: BaseRangeArgs) {
-  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
-  const rows = await db
-    .select({
-      bucket,
-      cogs: sql<string>`COALESCE(SUM(${ordersServicesTable.cogs_snapshot}), 0)`,
-    })
-    .from(ordersServicesTable)
-    .innerJoin(ordersTable, eq(ordersServicesTable.order_id, ordersTable.id))
-    .where(and(...conditions))
-    .groupBy(bucket);
-
-  return rows.map((row) => ({
-    bucket: row.bucket,
-    cogs: Number(row.cogs),
-  }));
+export async function listServicesCogsSeries(args: SeriesRangeArgs) {
+  const rows = await sumByBucket(ordersServicesTable, "cogs_snapshot", args);
+  return rows.map((row) => ({ bucket: row.bucket, cogs: Number(row.total) }));
 }
 
-export async function listProductsCogsSeries({
-  range,
-  storeId,
-  granularity,
-}: BaseRangeArgs) {
-  const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
-  const rows = await db
-    .select({
-      bucket,
-      cogs: sql<string>`COALESCE(SUM(${ordersProductsTable.cogs_snapshot}), 0)`,
-    })
-    .from(ordersProductsTable)
-    .innerJoin(ordersTable, eq(ordersProductsTable.order_id, ordersTable.id))
-    .where(and(...conditions))
-    .groupBy(bucket);
-
-  return rows.map((row) => ({
-    bucket: row.bucket,
-    cogs: Number(row.cogs),
-  }));
+export async function listProductsCogsSeries(args: SeriesRangeArgs) {
+  const rows = await sumByBucket(ordersProductsTable, "cogs_snapshot", args);
+  return rows.map((row) => ({ bucket: row.bucket, cogs: Number(row.total) }));
 }
 
 // ───────────────────────── Discount (Financial) ─────────────────────────
@@ -176,24 +116,15 @@ export async function listOrderDiscountSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
   const rows = await db
     .select({
       bucket,
       discount: sql<string>`COALESCE(SUM(${ordersTable.discount}), 0)`,
     })
     .from(ordersTable)
-    .where(and(...conditions))
+    .where(and(...paidOrderWindow({ range, storeId })))
     .groupBy(bucket);
 
   return rows.map((row) => ({
@@ -205,12 +136,6 @@ export async function listOrderDiscountSeries({
 // ───────────────────────── Store revenue (branch donut) ─────────────────────────
 
 export async function listStoreRevenueRows({ range }: { range: DateRange }) {
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-
   const rows = await db
     .select({
       store_id: ordersTable.store_id,
@@ -221,7 +146,7 @@ export async function listStoreRevenueRows({ range }: { range: DateRange }) {
     })
     .from(ordersTable)
     .innerJoin(storesTable, eq(ordersTable.store_id, storesTable.id))
-    .where(and(...conditions))
+    .where(and(...paidOrderWindow({ range })))
     .groupBy(ordersTable.store_id, storesTable.name, storesTable.code)
     .orderBy(asc(storesTable.code));
 
@@ -240,17 +165,8 @@ export async function listCategoryRevenueSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
   const rows = await db
     .select({
       bucket,
@@ -268,7 +184,7 @@ export async function listCategoryRevenueSeries({
       categoriesTable,
       eq(servicesTable.category_id, categoriesTable.id)
     )
-    .where(and(...conditions))
+    .where(and(...paidOrderWindow({ range, storeId })))
     .groupBy(bucket, categoriesTable.id, categoriesTable.name);
 
   return rows.map((row) => ({
@@ -284,19 +200,7 @@ export async function listCategoryRevenueSeries({
 export async function listStoreCategoryRevenueRows({
   range,
   storeId,
-}: {
-  range: DateRange;
-  storeId?: number;
-}) {
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
+}: RangeArgs) {
   const rows = await db
     .select({
       store_id: ordersTable.store_id,
@@ -317,7 +221,7 @@ export async function listStoreCategoryRevenueRows({
       categoriesTable,
       eq(servicesTable.category_id, categoriesTable.id)
     )
-    .where(and(...conditions))
+    .where(and(...paidOrderWindow({ range, storeId })))
     .groupBy(
       ordersTable.store_id,
       storesTable.name,
@@ -342,15 +246,12 @@ export async function listOrdersInSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(ordersTable.created_at, granularity);
   const conditions = [
-    gte(ordersTable.created_at, range.start),
-    lt(ordersTable.created_at, range.end),
+    ...timeWindow(ordersTable.created_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -371,18 +272,15 @@ export async function listOrdersOutSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(
     orderPickupEventsTable.picked_up_at,
     granularity
   );
   const conditions = [
-    gte(orderPickupEventsTable.picked_up_at, range.start),
-    lt(orderPickupEventsTable.picked_up_at, range.end),
+    ...timeWindow(orderPickupEventsTable.picked_up_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -400,22 +298,13 @@ export async function listOrdersOutSeries({
   }));
 }
 
-export async function findDistinctHandlerCount({
-  range,
-  storeId,
-}: {
-  range: DateRange;
-  storeId?: number;
-}) {
+export async function findDistinctHandlerCount({ range, storeId }: RangeArgs) {
   const conditions = [
-    gte(orderServiceStatusLogsTable.created_at, range.start),
-    lt(orderServiceStatusLogsTable.created_at, range.end),
+    ...timeWindow(orderServiceStatusLogsTable.created_at, range),
     eq(orderServiceStatusLogsTable.to_status, "processing"),
     eq(orderServiceStatusLogsTable.from_status, "queued"),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const [row] = await db
     .select({
@@ -438,17 +327,8 @@ export async function listPaymentMixSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(ordersTable.paid_at, granularity);
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
-
   const rows = await db
     .select({
       bucket,
@@ -462,7 +342,7 @@ export async function listPaymentMixSeries({
       paymentMethodsTable,
       eq(ordersTable.payment_method_id, paymentMethodsTable.id)
     )
-    .where(and(...conditions))
+    .where(and(...paidOrderWindow({ range, storeId })))
     .groupBy(bucket, ordersTable.payment_method_id, paymentMethodsTable.name);
 
   return rows.map((row) => ({
@@ -480,15 +360,12 @@ export async function listNewCustomersSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(customersTable.created_at, granularity);
   const conditions = [
-    gte(customersTable.created_at, range.start),
-    lt(customersTable.created_at, range.end),
+    ...timeWindow(customersTable.created_at, range),
+    storeScope(customersTable.origin_store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(customersTable.origin_store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -509,16 +386,13 @@ export async function listReturningCustomerOrdersSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(ordersTable.created_at, granularity);
   const conditions = [
-    gte(ordersTable.created_at, range.start),
-    lt(ordersTable.created_at, range.end),
+    ...timeWindow(ordersTable.created_at, range),
     isNotNull(ordersTable.customer_id),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -547,15 +421,15 @@ export async function listTopCustomers({
   storeId?: number;
   limit?: number;
 }) {
+  // Spelled out rather than reusing paidOrderWindow: that helper puts the store
+  // filter before "has a customer", and reordering these renumbers the binds
+  // against the LIMIT below.
   const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
+    ...timeWindow(ordersTable.paid_at, range),
     isNotNull(ordersTable.paid_at),
     isNotNull(ordersTable.customer_id),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -592,10 +466,10 @@ export async function findCumulativeCustomersBefore({
   before: Date;
   storeId?: number;
 }) {
-  const conditions = [lt(customersTable.created_at, before)];
-  if (storeId !== undefined) {
-    conditions.push(eq(customersTable.origin_store_id, storeId));
-  }
+  const conditions = [
+    lt(customersTable.created_at, before),
+    storeScope(customersTable.origin_store_id, storeId),
+  ];
 
   const [row] = await db
     .select({ total: count() })
@@ -605,21 +479,12 @@ export async function findCumulativeCustomersBefore({
   return Number(row?.total ?? 0);
 }
 
-export async function findRepeatCustomerStats({
-  range,
-  storeId,
-}: {
-  range: DateRange;
-  storeId?: number;
-}) {
+export async function findRepeatCustomerStats({ range, storeId }: RangeArgs) {
   const conditions = [
-    gte(ordersTable.created_at, range.start),
-    lt(ordersTable.created_at, range.end),
+    ...timeWindow(ordersTable.created_at, range),
     isNotNull(ordersTable.customer_id),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const [row] = await db
     .select({
@@ -650,15 +515,12 @@ export async function listRefundAmountSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(orderRefundsTable.created_at, granularity);
   const conditions = [
-    gte(orderRefundsTable.created_at, range.start),
-    lt(orderRefundsTable.created_at, range.end),
+    ...timeWindow(orderRefundsTable.created_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -682,15 +544,12 @@ export async function listRefundReasonSeries({
   range,
   storeId,
   granularity,
-}: BaseRangeArgs) {
+}: SeriesRangeArgs) {
   const bucket = jakartaBucketExpr(orderRefundsTable.created_at, granularity);
   const conditions = [
-    gte(orderRefundsTable.created_at, range.start),
-    lt(orderRefundsTable.created_at, range.end),
+    ...timeWindow(orderRefundsTable.created_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
 
   const rows = await db
     .select({
@@ -732,10 +591,8 @@ async function fetchAttribution(
     eq(processingLog.to_status, "processing"),
     eq(processingLog.from_status, "queued"),
     inArray(processingLog.order_service_id, orderServiceIds),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
   return await db
     .selectDistinctOn([processingLog.order_service_id], {
       worker_id: processingLog.changed_by,
@@ -754,12 +611,9 @@ async function fetchAttribution(
 function fetchCompletions(range: DateRange, storeId?: number) {
   const conditions = [
     eq(orderServiceStatusLogsTable.to_status, "ready_for_pickup"),
-    gte(orderServiceStatusLogsTable.created_at, range.start),
-    lt(orderServiceStatusLogsTable.created_at, range.end),
+    ...timeWindow(orderServiceStatusLogsTable.created_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
   // Rework cycles (quality_check → processing → ready_for_pickup) can emit
   // multiple ready_for_pickup logs per item; DISTINCT keeps items_completed
   // aligned with physically distinct finished items.
@@ -782,14 +636,11 @@ function fetchCompletions(range: DateRange, storeId?: number) {
 
 function fetchRefundsPerItem(range: DateRange, storeId?: number) {
   const conditions = [
-    gte(orderRefundsTable.created_at, range.start),
-    lt(orderRefundsTable.created_at, range.end),
+    ...timeWindow(orderRefundsTable.created_at, range),
     // product refund lines have no handler; worker attribution is service-only
     isNotNull(orderRefundItemsTable.order_service_id),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
   return db
     .select({
       order_service_id: sql<number>`${orderRefundItemsTable.order_service_id}`,
@@ -808,12 +659,9 @@ function fetchRefundsPerItem(range: DateRange, storeId?: number) {
 function fetchShiftMinutes(range: DateRange, storeId?: number) {
   const conditions = [
     isNotNull(shiftsTable.clock_out_at),
-    gte(shiftsTable.clock_in_at, range.start),
-    lt(shiftsTable.clock_in_at, range.end),
+    ...timeWindow(shiftsTable.clock_in_at, range),
+    storeScope(shiftsTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(shiftsTable.store_id, storeId));
-  }
   return db
     .select({
       user_id: shiftsTable.user_id,
@@ -834,12 +682,9 @@ function fetchReworkCounts(
   const conditions = [
     eq(reworkLog.from_status, "quality_check"),
     eq(reworkLog.to_status, "processing"),
-    gte(reworkLog.created_at, range.start),
-    lt(reworkLog.created_at, range.end),
+    ...timeWindow(reworkLog.created_at, range),
+    storeScope(ordersTable.store_id, storeId),
   ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
   return db
     .select({
       order_service_id: reworkLog.order_service_id,
@@ -909,10 +754,7 @@ function aggregatePerWorker(
 export async function listWorkerProductivityRows({
   range,
   storeId,
-}: {
-  range: DateRange;
-  storeId?: number;
-}) {
+}: RangeArgs) {
   const processingLog = alias(
     orderServiceStatusLogsTable,
     "processing_attribution"
@@ -987,18 +829,10 @@ export async function listWorkerProductivityRows({
 export async function listCampaignEffectivenessRows({
   range,
   storeId,
-}: {
-  range: DateRange;
-  storeId?: number;
-}) {
-  const conditions = [
-    gte(ordersTable.paid_at, range.start),
-    lt(ordersTable.paid_at, range.end),
-    isNotNull(ordersTable.paid_at),
-  ];
-  if (storeId !== undefined) {
-    conditions.push(eq(ordersTable.store_id, storeId));
-  }
+}: RangeArgs) {
+  // What a promo cost and what it brought in have to be counted over the same
+  // orders, or the discount is charged against a different set of takings.
+  const window = paidOrderWindow({ range, storeId });
 
   const discountRows = await db
     .select({
@@ -1013,7 +847,7 @@ export async function listCampaignEffectivenessRows({
       campaignsTable,
       eq(orderCampaignsTable.campaign_id, campaignsTable.id)
     )
-    .where(and(...conditions))
+    .where(and(...window))
     .groupBy(campaignsTable.id, campaignsTable.name, campaignsTable.code);
 
   const orderRows = await db
@@ -1025,7 +859,7 @@ export async function listCampaignEffectivenessRows({
     })
     .from(orderCampaignsTable)
     .innerJoin(ordersTable, eq(orderCampaignsTable.order_id, ordersTable.id))
-    .where(and(...conditions));
+    .where(and(...window));
 
   const orderMetrics = new Map<
     number,


### PR DESCRIPTION
Closes **S5** from the [code quality audit](docs/audit/2026-08-05-code-quality-audit.html).

## What was wrong

`report-range.repository.ts` wrote down *"which orders count as this stretch's takings"* eleven separate times, and *"keep this to one store"* twenty-four times. Changing what counts as revenue meant eleven edits landing together — and a missed one produces a report that is quietly wrong rather than visibly broken.

## Four helpers now hold those rules

| Helper | Sites | What it names |
| --- | --- | --- |
| `timeWindow(column, range)` | 14 | The half-open `[start, end)` convention, across `paid_at`, `created_at`, `picked_up_at`, `clock_in_at`. Writing `lte` instead of `lt` bills the closing day to two stretches at once — that decision is now one line. |
| `paidOrderWindow({ range, storeId })` | 9 | Paid, inside the window, optionally one store. |
| `storeScope(column, storeId)` | 24 | Returns `undefined` when no store is named and lets `and()` drop the slot — the idiom `packages/server/CLAUDE.md` already prescribes for optional filters. Taking the column as a parameter lets it also serve `customers.origin_store_id` and `shifts.store_id`. |
| `sumByBucket(table, "subtotal" \| "cogs_snapshot", args)` | 4 | The four revenue/COGS series were the same 30-line query four times. The column arrives as a key indexed off the table, so a mismatched table/column pair cannot be written. |

**1065 → 899 lines.**

## No SQL changed, and that is the whole contract

The 41 committed snapshots in `report-range.repository.sql.test.ts` record every statement in full, store-scoped and company-wide. They pass **untouched** — same file, same md5. A shared builder producing the same AST emits identical SQL, so a snapshot failure would have meant the refactor changed the question, not that the baseline was stale. `bun test -u` was never run.

The guard was mutation-tested rather than trusted:

| Mutation | Result |
| --- | --- |
| `lt` → `lte` in `timeWindow` | 39 snapshots fail |
| Reorder the window's predicates | 19 fail |
| Drop the store filter | 20 fail |
| Leak a store filter company-wide | 21 fail |
| Bind the wrong store id | 20 fail |

## One hole turned up

`fetchAttribution`'s store filter sat **outside** snapshot coverage — deleting it outright passed all 416 tests, because the fake driver returns no rows so the report short-circuits before that query is ever built. Added a test that seeds one finished item; deleting the filter now fails. Pre-existing gap on `main`, not opened here, but it covered a line this PR touched.

## Judgement calls

- `listTopCustomers` keeps its window spelled out. `paidOrderWindow` would order the store filter before *"has a customer"* and renumber the binds against its `LIMIT`. A comment names the constraint so the next dedupe pass doesn't trip over it.
- The ~10 remaining time-window blocks hang off different columns with different predicate sets. They got `timeWindow` and `storeScope` and nothing more — one helper per site is not a helper.

## Deliberately not done

Each of these changes emitted SQL and would blunt the guard, so they belong in their own reviewed PRs:

- Merging the services/products revenue and COGS statements (same statement bar the summed column)
- Merging `listCategoryRevenueSeries` with `listStoreCategoryRevenueRows`
- Hoisting `storeScope` into `report.repository.ts`, which has 11 more copies of the same guard

## Verification

- `bun test` — **417 pass, 0 fail**, 41 snapshots, 1443 expect() calls
- `bunx tsc --noEmit` — clean
- `bun x ultracite check` — clean
- Snapshot file `975bde035f206b61284091e3255c333a`, unchanged from `main`