### PR TITLE
refactor(web): stop the queue re-rendering on every keystroke, collapse the nav

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -146,6 +146,13 @@ const operationsNavigation: NavItem[] = [
 	{ to: "/stores", label: "Stores", icon: StorefrontIcon, roles: ["admin"] },
 ] as const;
 
+const NAV_GROUPS = [
+	{ label: "Operations", items: operationsNavigation },
+	{ label: "Work", items: workNavigation },
+	{ label: "Customers", items: customersNavigation },
+	{ label: "Catalog", items: catalogNavigation },
+];
+
 interface AppShellProps extends PropsWithChildren {
 	title: string;
 	description?: string;
@@ -228,7 +235,7 @@ export function AppShell({ title, children }: AppShellProps) {
 	// Nav visibility follows the DB-fresh role from /admin/users/me, not the
 	// stale JWT claim — role changes apply without re-login.
 	const meQuery = useQuery(meQueryOptions());
-	const role = meQuery.data?.role as Role | undefined;
+	const role = meQuery.data?.role;
 
 	useEffect(() => {
 		document.title = `${title} | Fresclean POS`;
@@ -239,18 +246,12 @@ export function AppShell({ title, children }: AppShellProps) {
 		void navigate({ to: "/auth/login" });
 	};
 
-	const allowedWorkNavigation = workNavigation.filter((item) =>
-		role ? item.roles.includes(role) : false,
-	);
-	const allowedCustomersNavigation = customersNavigation.filter((item) =>
-		role ? item.roles.includes(role) : false,
-	);
-	const allowedCatalogNavigation = catalogNavigation.filter((item) =>
-		role ? item.roles.includes(role) : false,
-	);
-	const allowedOperationsNavigation = operationsNavigation.filter((item) =>
-		role ? item.roles.includes(role) : false,
-	);
+	const allowedGroups = role
+		? NAV_GROUPS.map((group) => ({
+				label: group.label,
+				items: group.items.filter((item) => item.roles.includes(role)),
+			})).filter((group) => group.items.length > 0)
+		: [];
 
 	return (
 		<SidebarProvider>
@@ -268,41 +269,14 @@ export function AppShell({ title, children }: AppShellProps) {
 				<SidebarSeparator />
 
 				<SidebarContent>
-					{allowedOperationsNavigation.length > 0 ? (
-						<SidebarGroup>
-							<SidebarGroupLabel>Operations</SidebarGroupLabel>
+					{allowedGroups.map((group) => (
+						<SidebarGroup key={group.label}>
+							<SidebarGroupLabel>{group.label}</SidebarGroupLabel>
 							<SidebarGroupContent>
-								<SidebarNavLinks items={allowedOperationsNavigation} />
+								<SidebarNavLinks items={group.items} />
 							</SidebarGroupContent>
 						</SidebarGroup>
-					) : null}
-
-					{allowedWorkNavigation.length > 0 ? (
-						<SidebarGroup>
-							<SidebarGroupLabel>Work</SidebarGroupLabel>
-							<SidebarGroupContent>
-								<SidebarNavLinks items={allowedWorkNavigation} />
-							</SidebarGroupContent>
-						</SidebarGroup>
-					) : null}
-
-					{allowedCustomersNavigation.length > 0 ? (
-						<SidebarGroup>
-							<SidebarGroupLabel>Customers</SidebarGroupLabel>
-							<SidebarGroupContent>
-								<SidebarNavLinks items={allowedCustomersNavigation} />
-							</SidebarGroupContent>
-						</SidebarGroup>
-					) : null}
-
-					{allowedCatalogNavigation.length > 0 ? (
-						<SidebarGroup>
-							<SidebarGroupLabel>Catalog</SidebarGroupLabel>
-							<SidebarGroupContent>
-								<SidebarNavLinks items={allowedCatalogNavigation} />
-							</SidebarGroupContent>
-						</SidebarGroup>
-					) : null}
+					))}
 				</SidebarContent>
 
 				<SidebarFooter>

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,8 +1,9 @@
 import {
 	createContext,
 	type ReactNode,
-	useContext,
+	use,
 	useEffect,
+	useMemo,
 	useState,
 } from "react";
 
@@ -19,12 +20,26 @@ type ThemeProviderState = {
 	setTheme: (theme: Theme) => void;
 };
 
-const initialState: ThemeProviderState = {
-	theme: "system",
-	setTheme: () => null,
+const ThemeProviderContext = createContext<ThemeProviderState | null>(null);
+
+// Reading localStorage throws outright, not returns null, when the browser is
+// set to block all cookies. A counter tablet locked down that way still boots —
+// it just forgets the theme between reloads.
+const readStoredTheme = (storageKey: string): Theme | null => {
+	try {
+		return localStorage.getItem(storageKey) as Theme | null;
+	} catch {
+		return null;
+	}
 };
 
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+const writeStoredTheme = (storageKey: string, theme: Theme) => {
+	try {
+		localStorage.setItem(storageKey, theme);
+	} catch {
+		// nothing to recover; the in-memory theme still applies
+	}
+};
 
 export function ThemeProvider({
 	children,
@@ -33,7 +48,7 @@ export function ThemeProvider({
 	...props
 }: ThemeProviderProps) {
 	const [theme, setTheme] = useState<Theme>(
-		() => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+		() => readStoredTheme(storageKey) || defaultTheme,
 	);
 
 	useEffect(() => {
@@ -54,25 +69,28 @@ export function ThemeProvider({
 		root.classList.add(theme);
 	}, [theme]);
 
-	const value = {
-		theme,
-		setTheme: (nextTheme: Theme) => {
-			localStorage.setItem(storageKey, nextTheme);
-			setTheme(nextTheme);
-		},
-	};
+	const value = useMemo(
+		() => ({
+			theme,
+			setTheme: (nextTheme: Theme) => {
+				writeStoredTheme(storageKey, nextTheme);
+				setTheme(nextTheme);
+			},
+		}),
+		[theme, storageKey],
+	);
 
 	return (
-		<ThemeProviderContext.Provider {...props} value={value}>
+		<ThemeProviderContext {...props} value={value}>
 			{children}
-		</ThemeProviderContext.Provider>
+		</ThemeProviderContext>
 	);
 }
 
 export const useTheme = () => {
-	const context = useContext(ThemeProviderContext);
+	const context = use(ThemeProviderContext);
 
-	if (context === undefined) {
+	if (!context) {
 		throw new Error("useTheme must be used within a ThemeProvider");
 	}
 

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -22,6 +22,27 @@ import { cn } from "@/lib/utils";
 import { formatMoney, parseMoney } from "@/shared/money";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
+interface ServiceFieldSpec {
+	key: "brand" | "color" | "model" | "size" | "notes";
+	label: string;
+	placeholder: string;
+	className?: string;
+}
+
+// Free-text descriptors the cashier reads off the item at the counter.
+const SERVICE_FIELDS: ServiceFieldSpec[] = [
+	{ key: "color", label: "Color", placeholder: "e.g. Black" },
+	{ key: "brand", label: "Brand", placeholder: "e.g. Adidas" },
+	{ key: "model", label: "Model", placeholder: "e.g. Yeezy" },
+	{ key: "size", label: "Size", placeholder: "e.g. 42" },
+	{
+		key: "notes",
+		label: "Item notes",
+		placeholder: "e.g. Loose sole, no bleach",
+		className: "sm:col-span-2",
+	},
+];
+
 // Step ② — the goods: review/annotate cart lines, order notes, and the
 // drop-off photo. The photo lives here (with the items it depicts, captured at
 // intake — see CONTEXT.md) and gates the step forward (see CheckoutFooter).
@@ -121,7 +142,7 @@ export const CheckoutItemsStep = () => {
 					</div>
 				))}
 
-				{serviceRows.map((line, index) => (
+				{serviceRows.map((line) => (
 					<div
 						className="grid gap-3 border border-border/70 p-3"
 						key={line.line_id}
@@ -144,113 +165,26 @@ export const CheckoutItemsStep = () => {
 							/>
 						</div>
 						<div className="grid gap-3 sm:grid-cols-2">
-							<Field>
-								<FieldLabel htmlFor={`service-color-${line.line_id}`}>
-									Color
-								</FieldLabel>
-								<Input
-									className="h-11"
-									id={`service-color-${line.line_id}`}
-									onChange={(event) =>
-										updateServiceField(
-											line.line_id,
-											"color",
-											event.target.value,
-										)
-									}
-									placeholder="e.g. Black"
-									value={line.color}
-								/>
-							</Field>
-							<Field
-								data-invalid={
-									!!form.formState.errors.serviceCart?.[index]?.brand
-								}
-							>
-								<FieldLabel htmlFor={`service-brand-${line.line_id}`}>
-									Brand
-								</FieldLabel>
-								<Input
-									className="h-11"
-									id={`service-brand-${line.line_id}`}
-									onChange={(event) =>
-										updateServiceField(
-											line.line_id,
-											"brand",
-											event.target.value,
-										)
-									}
-									placeholder="e.g. Adidas"
-									value={line.brand}
-								/>
-								<FieldError
-									errors={[form.formState.errors.serviceCart?.[index]?.brand]}
-								/>
-							</Field>
-							<Field
-								data-invalid={
-									!!form.formState.errors.serviceCart?.[index]?.model
-								}
-							>
-								<FieldLabel htmlFor={`service-model-${line.line_id}`}>
-									Model
-								</FieldLabel>
-								<Input
-									className="h-11"
-									id={`service-model-${line.line_id}`}
-									onChange={(event) =>
-										updateServiceField(
-											line.line_id,
-											"model",
-											event.target.value,
-										)
-									}
-									placeholder="e.g. Yeezy"
-									value={line.model}
-								/>
-								<FieldError
-									errors={[form.formState.errors.serviceCart?.[index]?.model]}
-								/>
-							</Field>
-							<Field
-								data-invalid={
-									!!form.formState.errors.serviceCart?.[index]?.size
-								}
-							>
-								<FieldLabel htmlFor={`service-size-${line.line_id}`}>
-									Size
-								</FieldLabel>
-								<Input
-									className="h-11"
-									id={`service-size-${line.line_id}`}
-									onChange={(event) =>
-										updateServiceField(line.line_id, "size", event.target.value)
-									}
-									placeholder="e.g. 42"
-									value={line.size}
-								/>
-								<FieldError
-									errors={[form.formState.errors.serviceCart?.[index]?.size]}
-								/>
-							</Field>
-							<Field className="sm:col-span-2">
-								<FieldLabel htmlFor={`service-notes-${line.line_id}`}>
-									Item notes
-								</FieldLabel>
-								<Input
-									className="h-11"
-									id={`service-notes-${line.line_id}`}
-									onChange={(event) =>
-										updateServiceField(
-											line.line_id,
-											"notes",
-											event.target.value,
-										)
-									}
-									placeholder="e.g. Loose sole, no bleach"
-									value={line.notes}
-								/>
-							</Field>
+							{SERVICE_FIELDS.map((field) => (
+								<Field className={field.className} key={field.key}>
+									<FieldLabel htmlFor={`service-${field.key}-${line.line_id}`}>
+										{field.label}
+									</FieldLabel>
+									<Input
+										className="h-11"
+										id={`service-${field.key}-${line.line_id}`}
+										onChange={(event) =>
+											updateServiceField(
+												line.line_id,
+												field.key,
+												event.target.value,
+											)
+										}
+										placeholder={field.placeholder}
+										value={line[field.key]}
+									/>
+								</Field>
+							))}
 						</div>
 						<div className="flex items-center justify-end gap-3">
 							<p className="text-sm font-semibold">

--- a/apps/web/src/features/transactions/hooks/use-transactions-page.ts
+++ b/apps/web/src/features/transactions/hooks/use-transactions-page.ts
@@ -129,9 +129,6 @@ export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 		enabled: !!currentUser,
 	});
 
-	const userStoreIds =
-		meQuery.data?.userStores?.map((item) => item.store_id) ?? [];
-
 	// DB-fresh role — JWT claim goes stale on mid-session role changes.
 	const isAdmin = meQuery.data?.role === "admin";
 
@@ -140,8 +137,10 @@ export function useTransactionsPageBootstrap(): TransactionsPageBootstrap {
 		if (isAdmin) {
 			return stores;
 		}
+		const userStoreIds =
+			meQuery.data?.userStores?.map((item) => item.store_id) ?? [];
 		return stores.filter((store) => userStoreIds.includes(store.id));
-	}, [isAdmin, storesQuery.data, userStoreIds]);
+	}, [isAdmin, storesQuery.data, meQuery.data]);
 
 	useEffect(() => {
 		const canResolveStoreSelection =

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -117,9 +117,6 @@ export type OrderReceipt = InferResponseType<
 export type Campaign = InferResponseType<
 	typeof rpc.api.admin.campaigns.$get
 >["data"][number];
-export type CampaignDetail = InferResponseType<
-	(typeof rpc.api.admin.campaigns)[":id"]["$get"]
->["data"];
 export type ResolvedVoucher = InferResponseType<
 	(typeof rpc.api.admin.campaigns)["resolve-code"]["$post"]
 >["data"];
@@ -380,11 +377,6 @@ export type UpdateOrderServiceStatusPayload = {
 		| "cancelled";
 };
 
-export type UpdateOrderServiceHandlerPayload = {
-	handler_id: number | null;
-	note?: string;
-};
-
 export type UpdateOrderPaymentPayload = {
 	payment_method_id: number;
 };
@@ -464,7 +456,6 @@ export const queryKeys = {
 	orderDetail: (id: number) => ["order-detail", id] as const,
 	campaigns: (query?: FetchCampaignsQuery) =>
 		["campaigns", query ?? {}] as const,
-	campaignDetail: (id: number) => ["campaign-detail", id] as const,
 	campaignVoucherCodes: (id: number) => ["campaigns", id, "codes"] as const,
 	complaints: (query?: FetchComplaintsQuery) =>
 		["complaints", query ?? {}] as const,
@@ -613,14 +604,6 @@ export async function fetchCampaigns(query?: FetchCampaignsQuery) {
 	return response.data;
 }
 
-export async function fetchCampaignById(id: number) {
-	return parseSuccessData<CampaignDetail>(
-		rpcWithAuth().api.admin.campaigns[":id"].$get({
-			param: { id: String(id) },
-		}),
-	);
-}
-
 export async function createCampaign(payload: CampaignPayload) {
 	return parseResponse(
 		rpcWithAuth().api.admin.campaigns.$post({ json: payload }),
@@ -652,14 +635,6 @@ export async function updateCampaign(
 		rpcWithAuth().api.admin.campaigns[":id"].$put({
 			param: { id: String(id) },
 			json: payload,
-		}),
-	);
-}
-
-export async function deleteCampaign(id: number) {
-	return parseResponse(
-		rpcWithAuth().api.admin.campaigns[":id"].$delete({
-			param: { id: String(id) },
 		}),
 	);
 }
@@ -867,21 +842,6 @@ export async function updateOrderServiceStatus(
 			param: { id: String(orderId), serviceId: String(serviceId) },
 			json: payload,
 		}),
-	);
-}
-
-export async function updateOrderServiceHandler(
-	orderId: number,
-	serviceId: number,
-	payload: UpdateOrderServiceHandlerPayload,
-) {
-	return parseResponse(
-		rpcWithAuth().api.admin.orders[":id"].services[":serviceId"].handler.$patch(
-			{
-				param: { id: String(orderId), serviceId: String(serviceId) },
-				json: payload,
-			},
-		),
 	);
 }
 

--- a/apps/web/src/routes/_admin/worker.index.tsx
+++ b/apps/web/src/routes/_admin/worker.index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 import { PageHeader } from "@/components/page-header";
@@ -130,12 +130,6 @@ function WorkerQueuePage() {
 	const navigate = useNavigate({ from: Route.fullPath });
 	const search = Route.useSearch();
 	const loadMoreRef = useRef<HTMLDivElement | null>(null);
-	const [now, setNow] = useState(() => Date.now());
-
-	useEffect(() => {
-		const interval = setInterval(() => setNow(Date.now()), 60_000);
-		return () => clearInterval(interval);
-	}, []);
 
 	const [itemCode, setItemCode] = useState("");
 	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
@@ -343,15 +337,18 @@ function WorkerQueuePage() {
 		([] as QueueOrderServiceItem[]);
 	const totalItems = queueQuery.data?.pages[0]?.meta.total ?? 0;
 
-	const navigateToQueueDetail = (item: QueueOrderServiceItem) => {
-		void navigate({
-			to: "/worker/$orderId/$serviceId",
-			params: {
-				orderId: String(item.order_id),
-				serviceId: String(item.id),
-			},
-		});
-	};
+	const navigateToQueueDetail = useCallback(
+		(item: QueueOrderServiceItem) => {
+			void navigate({
+				to: "/worker/$orderId/$serviceId",
+				params: {
+					orderId: String(item.order_id),
+					serviceId: String(item.id),
+				},
+			});
+		},
+		[navigate],
+	);
 
 	const updateStoreFilter = (value: string) => {
 		void navigate({
@@ -569,8 +566,7 @@ function WorkerQueuePage() {
 							key={item.id}
 							item={item}
 							currentUserId={currentUser?.id}
-							now={now}
-							onOpen={() => navigateToQueueDetail(item)}
+							onOpen={navigateToQueueDetail}
 						/>
 					))}
 
@@ -615,17 +611,42 @@ function WorkerQueuePage() {
 	);
 }
 
-function QueueRow({
-	item,
-	currentUserId,
-	now,
-	onOpen,
-}: {
+interface WaitingBadgeProps {
+	orderCreatedAt: string;
+}
+
+const WaitingBadge = ({ orderCreatedAt }: WaitingBadgeProps) => {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		const interval = setInterval(() => setNow(Date.now()), 60_000);
+		return () => clearInterval(interval);
+	}, []);
+
+	const elapsedMs = Math.max(0, now - new Date(orderCreatedAt).getTime());
+	const ageTone = getElapsedTone(elapsedMs);
+	const ageLabel = formatElapsedDuration(elapsedMs);
+
+	return (
+		<span
+			className={cn(
+				"inline-flex items-center gap-1 border px-2 py-0.5 font-mono text-[11px] tabular-nums",
+				AGE_TONE_CLASS[ageTone],
+			)}
+		>
+			<HourglassIcon className="size-3" />
+			{`Waiting ${ageLabel}`}
+		</span>
+	);
+};
+
+interface QueueRowProps {
 	item: QueueOrderServiceItem;
 	currentUserId?: number;
-	now: number;
-	onOpen: () => void;
-}) {
+	onOpen: (item: QueueOrderServiceItem) => void;
+}
+
+const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
 	const isHandledByCurrentUser =
 		currentUserId !== undefined && item.handler_id === currentUserId;
 	const isHandledByAnotherWorker =
@@ -634,12 +655,6 @@ function QueueRow({
 		!isHandledByCurrentUser;
 
 	const isTerminal = TERMINAL_QUEUE_STATUSES.has(item.status);
-	const elapsedMs = Math.max(
-		0,
-		now - new Date(item.order_created_at).getTime(),
-	);
-	const ageTone = getElapsedTone(elapsedMs);
-	const ageLabel = formatElapsedDuration(elapsedMs);
 
 	return (
 		<button
@@ -648,7 +663,7 @@ function QueueRow({
 				"group grid gap-3 border border-border bg-background px-4 py-4 text-left transition-colors hover:bg-muted/40",
 				item.is_priority && "border-warning/40 bg-warning/5",
 			)}
-			onClick={onOpen}
+			onClick={() => onOpen(item)}
 		>
 			<div className="flex items-start justify-between gap-3">
 				<div className="grid gap-2">
@@ -669,15 +684,7 @@ function QueueRow({
 									: "Open"}
 						</Badge>
 						{isTerminal ? null : (
-							<span
-								className={cn(
-									"inline-flex items-center gap-1 border px-2 py-0.5 font-mono text-[11px] tabular-nums",
-									AGE_TONE_CLASS[ageTone],
-								)}
-							>
-								<HourglassIcon className="size-3" />
-								{`Waiting ${ageLabel}`}
-							</span>
+							<WaitingBadge orderCreatedAt={item.order_created_at} />
 						)}
 					</div>
 					<div className="grid gap-1">
@@ -701,4 +708,5 @@ function QueueRow({
 			</div>
 		</button>
 	);
-}
+});
+QueueRow.displayName = "QueueRow";

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -9,6 +9,9 @@ interface AuthState {
 	clearToken: () => void;
 }
 
+let cachedToken: string | null = null;
+let cachedUser: JWTPayload | null = null;
+
 export const useAuthStore = create<AuthState>()(
 	persist(
 		(set) => ({
@@ -28,8 +31,15 @@ export function getCurrentUser(): JWTPayload | null {
 		return null;
 	}
 
+	if (token === cachedToken) {
+		return cachedUser;
+	}
+
 	try {
-		return jwtDecode<JWTPayload>(token);
+		const user = jwtDecode<JWTPayload>(token);
+		cachedToken = token;
+		cachedUser = user;
+		return user;
 	} catch {
 		return null;
 	}

--- a/apps/web/src/stores/transaction-preferences-store.ts
+++ b/apps/web/src/stores/transaction-preferences-store.ts
@@ -33,6 +33,13 @@ export const useTransactionPreferencesStore =
 			}),
 			{
 				name: "transaction-preferences",
+				// Which branch a till defaults to. Change the shape of
+				// selectedStoreIdByUser and you must bump this and add `migrate`, or
+				// zustand hands the new code the old shape and the POS quietly opens
+				// on the wrong store. Bumping it on its own is not free: with no
+				// migrate, zustand discards the stored state, so every device forgets
+				// its store once.
+				version: 0,
 			},
 		),
 	);


### PR DESCRIPTION
Closes **W4, W5, W11, W12, W13, W14, W16** and **partially W10** from the [code-quality audit](../blob/main/docs/audit/2026-08-05-code-quality-audit.html).

## Read this first: I did not ship W10 as written

W10 asked for `version: 1` on the three persisted zustand stores. **That would have logged out every user on every device, forgotten every printer, and erased `selectedStoreIdByUser` — the exact till-default data the finding wanted to protect.** Verified from `node_modules/zustand/esm/middleware.mjs`, not assumed:

```js
version: 0,                                    // line 334 — the default

return storage.setItem(options.name, {         // line ~360
  state, version: options.version              // every write stamps the version
});

if (deserializedStorageValue.version !== options.version) {   // line ~392
  if (options.migrate) { ... }
  console.error("State loaded from storage couldn't be migrated since no migrate function was provided");
} else {
  return [false, deserializedStorageValue.state];
}
return [false, void 0];                        // ← persisted state DISCARDED
```

Every entry already in production reads `"version": 0`. Bumping to `1` with no `migrate` makes `0 !== 1` on the next load, and zustand throws the stored state away.

And it buys nothing forward: discard-on-mismatch **already works** at the implicit `version: 0`. The field only matters at the moment you change a persisted shape — bump it *then*, with a `migrate` if the data should survive.

What I shipped instead: an explicit `version: 0` on `transaction-preferences` only — the store holding `selectedStoreIdByUser` — with a comment stating the rule, so the next person to change that shape sees the field and bumps it deliberately. Zero runtime change. The other half of W10 (unguarded `localStorage`) is fixed for real, below.

## W4 — the queue

The audit blames the 60s tick. That is not the expensive part. The **"Find order item" input is controlled by state in the same component**, so every keystroke re-rendered every mounted row of an infinite-scroll list — the busiest screen for the busiest role.

`WaitingBadge` owns its own tick, so the page-level `now` is gone and `QueueRow` is `memo`'d. I traced all three remaining props rather than assuming the memo bites:

- `item` — `queueQuery.data` is the same reference between keystrokes (`itemCode` is not in the query key), and React Query's `replaceEqualDeep` keeps deep-equal items referentially identical across refetches
- `currentUserId` — a primitive `number | undefined`
- `onOpen` — `useCallback([navigate])`, and `useNavigate` is itself `useCallback([_defaultOpts?.from, router])` where `from` is the constant `Route.fullPath`

Trade: N unsynchronised 60s timers instead of one. At queue-page scale that is cheaper than the N row re-renders it replaces, and the only observable effect is badges ticking a few seconds out of phase.

## W11 — the checkout fields were missing a guard, or so it looked

Brand, Model and Size rendered a `<FieldError>`; Color and Notes did not. Before collapsing the five into `SERVICE_FIELDS` I read the schema (`use-transactions-page.ts:72`): all five are bare `z.string()` with no rules, and the only `superRefine` writes to `path: ["productCart"]`. **Those three `FieldError`s could never fire.** The drift was dead wiring on three fields, not a missing guard on two — so it is gone rather than made uniform.

## The rest

- **W5** — `NAV_GROUPS` + one map replaces four filters and four 8-line blocks. The JSX render order (Operations, Work, Customers, Catalog) differs from the declaration order of the old consts; the list follows the render order. The `as Role | undefined` cast was verified redundant against the inferred RPC type and dropped.
- **W12** — `theme-provider.tsx` moves to `use()` and the React 19 `<Context>` form, memoizes its value, and drops a guard that could never fire.
- **W10 (real half)** — reading `localStorage` *throws* rather than returning null when the browser blocks storage; the theme provider took the app down at boot. Guarded both ends.
- **W13** — `getCurrentUser()` caches the decode keyed on the token string. Honest framing: this saves microseconds, not a measurable win. It is identity hygiene, and the cache is self-validating — a changed token misses, so `setToken` needs no hook and `clearToken` got none.
- **W14** — the memo's dep was a fresh array literal, so it could never hit. It depends on `meQuery.data` now, which restores the whole downstream chain (`visibleStores` → `pageContext` → context consumers) during checkout.
- **W16** — `fetchCampaignById`, `deleteCampaign`, `updateOrderServiceHandler` deleted. I checked the remaining hits myself: all are same-named *server* functions in `packages/server`, not these client wrappers. Their orphaned types went too.

## Verification

- `bun run type-check`, `bun run build`, `bun x ultracite check` — clean
- `bun test` — 505 pass, 0 fail
- `/simplify`: 4 review agents. Beyond the `version` revert: deleted `queryKeys.campaignDetail`, which my own W16 deletion had orphaned; hoisted the role check out of the nav map; dropped a single-use `NavGroup` interface whose `readonly` was inert against the existing annotations; reverted the redundant cache-clear in `clearToken`; corrected a comment that blamed Safari private browsing (Safari 11+ supports `localStorage` there — the real cause is a block-all-cookies setting); cut a refactor-justification comment.
- Skipped: extracting a shared `useNow` hook (the other two tickers are 1s stopwatches with different semantics — one real consumer); moving the service-field key union next to `useCart.ts` (touches files outside these findings).

## Follow-ups worth filing

- zustand's `persist` guards storage *reads* but not *writes* — `storage.setItem` runs synchronously inside every `set()`, so a quota-exhausted tablet throws into `setToken` at login. Low severity (event handler, not boot), fixed with a guarded `storage` option.
- The service-field key union is spelled twice: `SERVICE_FIELDS` and `updateServiceField` in `cart/useCart.ts`. Removing a key errors; *adding* one and forgetting `SERVICE_FIELDS` silently renders nothing.
- Nav `roles` duplicate the per-route role gating, so sidebar visibility and route access can drift.
