### PR TITLE
perf(server): compile to a bytecode binary, halve cold boot

### DIFF
--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,5 +1,5 @@
-# Build context is the repo root: the server resolves `catalog:` versions
-# from the root package.json, so the workspace manifests must be present.
+# Build context is the repo root: `catalog:` versions resolve from the root
+# package.json, so every workspace manifest has to be present.
 FROM oven/bun:1.3-alpine AS build
 
 WORKDIR /app
@@ -11,40 +11,30 @@ RUN bun install --filter '@fresclean/api' --production --frozen-lockfile
 
 COPY packages/server packages/server
 
-# `bun build` folds `process.env.NODE_ENV` into a literal at build time, so this
-# has to be set BEFORE the compile below — not just on the final stage. It picks
-# the database in src/db/index.ts and the S3 key prefix in src/utils/s3.ts, and a
-# binary compiled without it is welded to dev: it would serve production traffic
-# off the dev database and file photos under `dev/`, with nothing logged.
-#
-# Folded in means FROZEN: setting NODE_ENV on the container at runtime no longer
-# does anything, unlike when this image ran from source. So the image is
-# production-only, previews included — a preview deployment reads
-# DATABASE_URL_PROD and files photos under `prod/`. Deployment protection is what
-# keeps traffic off those, not configuration.
+# `bun build` folds process.env.NODE_ENV into a literal, so this has to come
+# before the compile. It picks the database (src/db/index.ts) and the S3 prefix
+# (src/utils/s3.ts), and is frozen once compiled — setting it on the container at
+# runtime does nothing, previews included.
 ENV NODE_ENV=production
 
-# --bytecode is what shortens cold starts: it moves JS parsing out of every boot
-# and into this build step. --target is left at its default (the host triple,
-# bun-linux-*-musl here) and must stay a `bun` target — auth calls Bun.password,
-# which has no Node equivalent.
+# --bytecode moves JS parsing into this build instead of every cold start. Leave
+# --target at its default bun triple: auth uses Bun.password, which Node lacks.
 RUN bun build --compile --bytecode packages/server/src/index.ts --outfile /app/server
 
-# Guard the fold above. With no database env set, the binary must ask for the
-# production URL; if it asks for DATABASE_URL_DEV the build is silently wrong.
-RUN timeout 30 /app/server 2>&1 | grep -q 'DATABASE_URL_PROD is required' \
-  || { echo 'build guard: NODE_ENV did not fold to production'; exit 1; }
+# Fails the build if the fold above ever stops landing on production.
+RUN timeout 30 /app/server 2>&1 | grep -q 'DATABASE_URL_PROD is required'
 
 FROM alpine:3
 
-# Bun's standalone binary links libstdc++/libgcc even on musl; without them it
-# dies at exec with "Error relocating: symbol not found". ca-certificates is not
-# needed on top of these — Bun carries its own CA roots, so outbound TLS to Neon
-# and S3 still verifies on a base image that has no system trust store.
-RUN apk add --no-cache libstdc++ libgcc
+# Bun's standalone binary links libstdc++/libgcc even on musl.
+RUN apk add --no-cache libstdc++ libgcc \
+  && adduser -S -D -u 10001 app
 
 WORKDIR /app
+
+# Copied as root, run as `app`: the process can execute the binary, not rewrite it.
 COPY --from=build /app/server /app/server
+USER app
 
 ENV NODE_ENV=production
 CMD ["/app/server"]

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -27,14 +27,10 @@ RUN timeout 30 /app/server 2>&1 | grep -q 'DATABASE_URL_PROD is required'
 FROM alpine:3
 
 # Bun's standalone binary links libstdc++/libgcc even on musl.
-RUN apk add --no-cache libstdc++ libgcc \
-  && adduser -S -D -u 10001 app
+RUN apk add --no-cache libstdc++ libgcc
 
 WORKDIR /app
-
-# Copied as root, run as `app`: the process can execute the binary, not rewrite it.
 COPY --from=build /app/server /app/server
-USER app
 
 ENV NODE_ENV=production
 CMD ["/app/server"]

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,6 +1,6 @@
 # Build context is the repo root: the server resolves `catalog:` versions
 # from the root package.json, so the workspace manifests must be present.
-FROM oven/bun:1.3-alpine
+FROM oven/bun:1.3-alpine AS build
 
 WORKDIR /app
 
@@ -11,5 +11,34 @@ RUN bun install --filter '@fresclean/api' --production
 
 COPY packages/server packages/server
 
+# `bun build` folds `process.env.NODE_ENV` into a literal at build time, so this
+# has to be set BEFORE the compile below — not just on the final stage. It picks
+# the database in src/db/index.ts and the S3 key prefix in src/utils/s3.ts, and a
+# binary compiled without it is welded to dev: it would serve production traffic
+# off the dev database and file photos under `dev/`, with nothing logged.
 ENV NODE_ENV=production
-CMD ["bun", "run", "packages/server/src/index.ts"]
+
+# --bytecode is what shortens cold starts: it moves JS parsing out of every boot
+# and into this build step. --target is left at its default (the host triple,
+# bun-linux-*-musl here) and must stay a `bun` target — auth calls Bun.password,
+# which has no Node equivalent.
+RUN bun build --compile --bytecode packages/server/src/index.ts --outfile /app/server
+
+# Guard the fold above. With no database env set, the binary must ask for the
+# production URL; if it asks for DATABASE_URL_DEV the build is silently wrong.
+RUN timeout 30 /app/server 2>&1 | grep -q 'DATABASE_URL_PROD is required' \
+  || { echo 'build guard: NODE_ENV did not fold to production'; exit 1; }
+
+FROM alpine:3
+
+# Bun's standalone binary links libstdc++/libgcc even on musl; without them it
+# dies at exec with "Error relocating: symbol not found". ca-certificates is not
+# needed on top of these — Bun carries its own CA roots, so outbound TLS to Neon
+# and S3 still verifies on a base image that has no system trust store.
+RUN apk add --no-cache libstdc++ libgcc
+
+WORKDIR /app
+COPY --from=build /app/server /app/server
+
+ENV NODE_ENV=production
+CMD ["/app/server"]

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages/server/package.json packages/server/
 COPY apps/web/package.json apps/web/
-RUN bun install --filter '@fresclean/api' --production
+RUN bun install --filter '@fresclean/api' --production --frozen-lockfile
 
 COPY packages/server packages/server
 
@@ -16,6 +16,12 @@ COPY packages/server packages/server
 # the database in src/db/index.ts and the S3 key prefix in src/utils/s3.ts, and a
 # binary compiled without it is welded to dev: it would serve production traffic
 # off the dev database and file photos under `dev/`, with nothing logged.
+#
+# Folded in means FROZEN: setting NODE_ENV on the container at runtime no longer
+# does anything, unlike when this image ran from source. So the image is
+# production-only, previews included — a preview deployment reads
+# DATABASE_URL_PROD and files photos under `prod/`. Deployment protection is what
+# keeps traffic off those, not configuration.
 ENV NODE_ENV=production
 
 # --bytecode is what shortens cold starts: it moves JS parsing out of every boot


### PR DESCRIPTION
Since the container scales to zero, every idle period ends with a fresh process paying full module resolution and JS parse (394 modules). This compiles the entry to a standalone binary with `--bytecode`, moving both into the image build.

## Measured

App boot, inside already-running containers on linux/arm64, 10 runs, `nerdctl exec` floor (39ms) subtracted:

| | app boot |
|---|---|
| `bun run src/index.ts` | 194 ms |
| compiled `--bytecode` | **87 ms** |

Image, same machine, both built from this repo:

| | on disk | pull (compressed) |
|---|---|---|
| before | 172.5 MB | 52.41 MB |
| after | 112.1 MB | **43.15 MB** |

`--bytecode` is the whole win. `--compile` on its own measured identical to plain bundling (65.4 vs 65.3 ms native) because it only skips resolution, not parsing. Per [Bun's docs](https://bun.com/docs/bundler/bytecode), ESM requires `--compile` for bytecode regardless, so the pair is the only option here.

## The risky part, and why the guard exists

`bun build` folds `process.env.NODE_ENV` into a literal at build time — the string `NODE_ENV` appears **zero** times in the resulting bundle. Both env-dependent switches get frozen:

| source | compiles to |
|---|---|
| `db/index.ts:5` `isProduction` | `var isProduction = false` |
| `s3.ts:29` prefix | `var STORAGE_ENV_PREFIX = "dev/"` |

Those are the two flags `CLAUDE.md` says must agree. A binary built without `NODE_ENV=production` **in the builder stage** would serve production traffic off the dev database and file photos under `dev/` — and it fails loudly only if `DATABASE_URL_DEV` is unset. If both URLs are present in Vercel's production env, it boots clean and is silently wrong.

Hence `ENV NODE_ENV=production` before the compile, plus a `RUN` that fails the build if the fold ever regresses.

## Verified

- Guard step passes on this build; flipping `NODE_ENV` off makes it fail.
- Container boots, logs `Started server`, and routes under `/api` (`basePath("/api")`).
- Final image contains **no `node` and no `bun`** on PATH — just the binary. The old base image shipped a node fallback shim at `/usr/local/bun-node-fallback-bin/node`; that's now gone.
- `--target` stays at its default `bun` host triple. It must remain a bun target — `routes/auth.ts:38` uses `Bun.password`, which has no Node equivalent.
- Outbound TLS still verifies on bare `alpine:3` with no `ca-certificates` (Bun carries its own CA roots) — tested against two independent chains. `libstdc++`/`libgcc` **are** required; without them the binary dies at exec with `Error relocating: symbol not found`.

## Worth a second opinion

- **Is `DATABASE_URL_DEV` set in the Vercel production environment?** If it is, that's the silent-failure path above. Worth removing regardless of this PR.
- The `RUN` guard is droppable if you find it too clever — it string-matches an error message, so a reworded throw in `db/index.ts` would break the build confusingly.
- Not exercised: Neon's WSS handshake and the S3 presign path, both of which need real credentials. Generic HTTPS from the new base image works.
- ~100 ms of app boot sits inside a cold start dominated by container scheduling; end-to-end `run` → first response measured 2008 ms vs 1899 ms here. The remaining bar is the first-request Neon handshake, which this PR doesn't touch.
