### PR TITLE
fix(web): hold the photo dialog open until the batch finishes

### DIFF
--- a/apps/web/src/features/orders/components/photo-capture-context.tsx
+++ b/apps/web/src/features/orders/components/photo-capture-context.tsx
@@ -78,6 +78,9 @@ interface PhotoCaptureState {
 	isBusy: boolean;
 	isNoteOpen: boolean;
 	isShooting: boolean;
+	// Narrower than isBusy: a scale-down can still be abandoned, a batch part-way onto the
+	// order cannot.
+	isUploading: boolean;
 	lastPhoto: PendingPhoto | undefined;
 	note: string;
 	photoCount: number;
@@ -463,6 +466,17 @@ export const PhotoCaptureProvider = ({
 	const isBusy = uploadMutation.isPending || isNormalizing;
 	const photoCount = pendingPhotos.length;
 
+	// Once photos start landing on the order there is no taking them back, so the dialog stays
+	// up until the batch finishes rather than leaving half of it filed with nobody told. Its own
+	// close on success uses the prop directly — the mutation still reads as pending there, so
+	// routing that through here would leave the dialog stuck open.
+	const requestOpenChange = (next: boolean) => {
+		if (!next && uploadMutation.isPending) {
+			return;
+		}
+		onOpenChange(next);
+	};
+
 	const confirm = () => {
 		if (onCapture) {
 			onCapture(pendingPhotos.map((photo) => photo.file));
@@ -505,7 +519,7 @@ export const PhotoCaptureProvider = ({
 			addFiles,
 			captureCameraPhoto,
 			confirm,
-			onOpenChange,
+			onOpenChange: requestOpenChange,
 			openCamera,
 			openFileInput,
 			removePhoto,
@@ -536,6 +550,7 @@ export const PhotoCaptureProvider = ({
 			isBusy,
 			isNoteOpen,
 			isShooting,
+			isUploading: uploadMutation.isPending,
 			lastPhoto: pendingPhotos.at(-1),
 			note,
 			photoCount,

--- a/apps/web/src/features/orders/components/photo-capture-dialog.tsx
+++ b/apps/web/src/features/orders/components/photo-capture-dialog.tsx
@@ -20,7 +20,8 @@ const TopChrome = () => {
 		<div className="grid shrink-0 grid-cols-[1fr_auto_1fr] items-center gap-3 px-4 pt-[calc(env(safe-area-inset-top)_+_0.75rem)] pb-3">
 			<button
 				aria-label="Close"
-				className="grid size-9 place-items-center justify-self-start rounded-full bg-white/10 text-white transition hover:bg-white/20"
+				className="grid size-9 place-items-center justify-self-start rounded-full bg-white/10 text-white transition hover:bg-white/20 disabled:opacity-40"
+				disabled={state.isUploading}
 				onClick={() => actions.onOpenChange(false)}
 				type="button"
 			>


### PR DESCRIPTION
Closing the photo dialog while a batch was uploading cancelled nothing, and made things worse: `resetDialogState` aborted the pushes still in flight, then `resolveUploadedKey` read each abort as a dead push and re-uploaded the file from scratch. On shop 4G, dismissing doubled the remaining traffic instead of stopping it — and the batch still finished, still toasted success, and still called `onUploaded()` for a dialog the operator had walked away from.

Photos already committed are on the order and cannot be recalled, so the dialog holds until the batch finishes.

- `requestOpenChange` swallows a close request while the upload mutation is pending; Escape, overlay click and the Close button all route through it
- Close button dims while the batch is filing, matching every other control in the dialog
- `onSuccess` keeps calling the `onOpenChange` prop directly — the mutation still reads as pending there, so routing it through the guard would leave the dialog stuck open
- `isUploading` is deliberately narrower than `isBusy`: closing mid-normalize stays allowed, since the session counter already voids that work

Not covered: `uploadFileToPresignedUrl` has no timeout, so a wedged connection holds the operator in the dialog until fetch gives up. Separate change to the upload path.

Type-check and lint pass.