### PR TITLE
fix: make paginated responses declare the meta they always send

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -63,18 +63,11 @@ export function toSearchParams<T extends Record<string, QueryValue>>(
 	) as SearchParamsOf<T>;
 }
 
-function toPaginated<T>(
-	response: { data: T[]; meta?: PaginationMeta },
-	query?: { limit?: number; offset?: number },
-): PaginatedData<T> {
-	return {
-		items: response.data,
-		meta: response.meta ?? {
-			limit: query?.limit ?? response.data.length,
-			offset: query?.offset ?? 0,
-			total: response.data.length,
-		},
-	};
+function toPaginated<T>(response: {
+	data: T[];
+	meta: PaginationMeta;
+}): PaginatedData<T> {
+	return { items: response.data, meta: response.meta };
 }
 
 type LoginSuccessResponse = InferResponseType<typeof rpc.api.auth.login.$post>;
@@ -515,7 +508,7 @@ export async function fetchCustomersPage(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 // Exact-phone lookup for the POS name-prefill. Returns the matching customer or
@@ -539,7 +532,7 @@ export async function fetchUsersPage(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 export type Me = InferResponseType<typeof rpc.api.admin.users.me.$get>["data"];
@@ -589,7 +582,7 @@ export async function fetchOrdersPage(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 export async function fetchCampaigns(query?: FetchCampaignsQuery) {
@@ -829,7 +822,7 @@ export async function fetchOrderServiceQueuePage(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 export async function updateOrderServiceStatus(
@@ -881,7 +874,7 @@ export async function fetchComplaintsPage(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 export function fetchComplaintDetail(id: number) {
@@ -1080,7 +1073,7 @@ export async function fetchShifts(
 		}),
 	);
 
-	return toPaginated(response, query);
+	return toPaginated(response);
 }
 
 export async function clockInShift(payload: { store_id: number }) {
@@ -1194,5 +1187,5 @@ export async function fetchAgingQueueReport(
 			}),
 		}),
 	);
-	return toPaginated(response, query);
+	return toPaginated(response);
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -728,6 +728,7 @@ export const orderServicesImagesTable = pgTable(
   },
   (table) => [
     index("order_services_images_deleted_at_idx").on(table.deleted_at),
+    index("order_services_images_service_idx").on(table.order_service_id),
   ]
 );
 

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -1,13 +1,8 @@
-interface Metadata {
-  limit?: number;
-  offset?: number;
-  total?: number;
-}
+import type { PaginationMeta } from "@/utils/pagination";
 
-interface SuccessResponse<T, M extends object = Metadata> {
+interface SuccessResponse<T> {
   data: T;
   message?: string;
-  meta?: M;
   success: true;
 }
 
@@ -17,11 +12,20 @@ interface ErrorResponse {
   success: false;
 }
 
-export function success<T, M extends object = Metadata>(
+// Two shapes, not one with an optional `meta`. A list endpoint always sends the
+// page it served, so declaring `meta?` made every client write a fallback for a
+// response the server cannot produce.
+export function success<T>(data: T, message?: string): SuccessResponse<T>;
+export function success<T>(
+  data: T,
+  message: string | undefined,
+  meta: PaginationMeta
+): SuccessResponse<T> & { meta: PaginationMeta };
+export function success<T>(
   data: T,
   message?: string,
-  meta?: M
-): SuccessResponse<T, M> {
+  meta?: PaginationMeta
+): SuccessResponse<T> & { meta?: PaginationMeta } {
   return {
     data,
     message,


### PR DESCRIPTION
## What

`success()` declared `meta` optional, so every list endpoint's RPC-inferred type said the page count *might* be absent. It never is — all seven paginated services pass `buildPaginationMeta()`. The web client paid for that with a fallback in `toPaginated` that synthesised `total` from `response.data.length`, i.e. from the size of the page it happened to receive. On any page but the last that number is wrong, and it fed the pagination footer.

Two overloads now:

```ts
success<T>(data, message?): SuccessResponse<T>
success<T>(data, message, meta: PaginationMeta): SuccessResponse<T> & { meta: PaginationMeta }
```

`meta` is the concrete `PaginationMeta`, not a free `M extends object` — there is exactly one meta shape in the codebase, and a route that wants a different one should have to change this signature to get it.

With `meta` required, `toPaginated`'s fallback is unreachable and deleted, along with the `query` argument that existed only to feed it. Seven call sites simplify to `toPaginated(response)`.

The guarantee is enforced, not nominal: if any list route stopped passing `meta`, the two-arg overload would resolve, the inferred response type would lose `meta`, and `toPaginated(response)` would fail to compile in `apps/web`.

## Index

Adds `order_services_images_service_idx` on `order_services_images(order_service_id)`. Two hot reads look photos up by service:

- `order-status-machine.ts:207` — the queued -> processing gate, on every "start work" transition
- `order.service.ts:387` — the order-detail photo join

Both scanned the table without it. **Already applied to dev and prod** via `CREATE INDEX IF NOT EXISTS`; this declares it in `schema.ts` so `push` stops seeing a delta.

## Not in this PR

- **Line-item price columns staying nullable.** `order_services.price` and friends have zero null rows on both databases, but you declined the `NOT NULL` — recorded here so the evidence isn't lost.
- **Four reports-module findings** (`perStoreForRange` round trips, a 15-statement -> 11 merge, a `storeScope` hoist, `listCampaignEffectivenessRows` `Promise.all`) — scoped out pending the reports overhaul.
- **`order_services_images_deleted_at_idx`** looked like dead weight on review, but `pg_stat_user_indexes` shows 614 scans on prod. Keeping it.

## Verification

- `bun run type-check` — 0 errors
- `bun test` — 505 pass, 0 fail
- `bun x ultracite check` — clean