### PR TITLE
fix(web): close the 2026-08-10 UI audit, phone-first

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -74,7 +74,7 @@ const workNavigation: NavItem[] = [
 		roles: ["admin", "cashier"],
 	},
 	{
-		to: "/worker",
+		to: "/queue",
 		label: "Queue",
 		icon: ScissorsIcon,
 		roles: ["admin", "cashier", "worker"],

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -46,6 +46,7 @@ import {
 	SidebarSeparator,
 	SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { meQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { getCurrentUser, useAuthStore } from "@/stores/auth-store";
@@ -232,6 +233,11 @@ export function AppShell({ title, children }: AppShellProps) {
 	const navigate = useNavigate();
 	const clearToken = useAuthStore((state) => state.clearToken);
 	const user = getCurrentUser();
+	// Tablet landscape (1024) is the width where DataTable switches to the real
+	// table but a 256px sidebar still eats a quarter of the viewport, clipping the
+	// Orders money column. Start on the icon rail below xl and hand those ~200px
+	// to the table; toggling still wins, so this is only the opening position.
+	const startsCollapsed = useIsMobile(1280);
 	// Nav visibility follows the DB-fresh role from /admin/users/me, not the
 	// stale JWT claim — role changes apply without re-login.
 	const meQuery = useQuery(meQueryOptions());
@@ -254,7 +260,7 @@ export function AppShell({ title, children }: AppShellProps) {
 		: [];
 
 	return (
-		<SidebarProvider>
+		<SidebarProvider defaultOpen={!startsCollapsed}>
 			<Sidebar collapsible="icon" variant="inset">
 				<SidebarHeader className="flex-row items-center justify-between group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-2">
 					<div className="flex items-center gap-2 px-2 text-sm font-semibold uppercase tracking-[0.18em] text-sidebar-foreground/80">

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -20,7 +20,12 @@ import {
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { type ComponentType, type PropsWithChildren, useEffect } from "react";
+import {
+	type ComponentType,
+	type PropsWithChildren,
+	useEffect,
+	useState,
+} from "react";
 import { useTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,7 +51,6 @@ import {
 	SidebarSeparator,
 	SidebarTrigger,
 } from "@/components/ui/sidebar";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { meQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { getCurrentUser, useAuthStore } from "@/stores/auth-store";
@@ -233,7 +237,11 @@ export function AppShell({ title, children }: AppShellProps) {
 	const navigate = useNavigate();
 	const clearToken = useAuthStore((state) => state.clearToken);
 	const user = getCurrentUser();
-	const startsCollapsed = useIsMobile(1280);
+	// Read once, deliberately not tracked: this only seeds the sidebar's
+	// defaultOpen, a state initializer nobody reads again. Following the
+	// breakpoint afterwards re-rendered the whole shell mid-drag to change
+	// nothing, and would fight a cashier who had collapsed the sidebar by hand.
+	const [startsCollapsed] = useState(() => window.innerWidth < 1280);
 	// Nav visibility follows the DB-fresh role from /admin/users/me, not the
 	// stale JWT claim — role changes apply without re-login.
 	const meQuery = useQuery(meQueryOptions());

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -233,10 +233,6 @@ export function AppShell({ title, children }: AppShellProps) {
 	const navigate = useNavigate();
 	const clearToken = useAuthStore((state) => state.clearToken);
 	const user = getCurrentUser();
-	// Tablet landscape (1024) is the width where DataTable switches to the real
-	// table but a 256px sidebar still eats a quarter of the viewport, clipping the
-	// Orders money column. Start on the icon rail below xl and hand those ~200px
-	// to the table; toggling still wins, so this is only the opening position.
 	const startsCollapsed = useIsMobile(1280);
 	// Nav visibility follows the DB-fresh role from /admin/users/me, not the
 	// stale JWT claim — role changes apply without re-login.

--- a/apps/web/src/components/chip-strip.tsx
+++ b/apps/web/src/components/chip-strip.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from "react";
+
+// A row of chips that outgrows its container — /queue's six statuses and the POS
+// catalog's ten categories both do. The mask fades the last chip out instead of
+// slicing it mid-word, which read as a broken layout rather than as "there is
+// more this way". Unconditional, not phone-only: whether the strip overflows
+// depends on the container — the expanded sidebar cuts it at 1024 too — and when
+// it does fit the fade lands on empty padding.
+export const ChipStripScroller = ({ children }: PropsWithChildren) => (
+	<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
+		{children}
+	</div>
+);
+
+// The row inside the scroller stays with each caller: /queue's chips are a
+// tablist, the catalog's are a fieldset of toggles, and flattening that into one
+// element would trade the screen reader's answer for a shared wrapper. Only the
+// measurements travel — pr-8 is what keeps the last chip clear of the fade.
+export const CHIP_STRIP_ROW = "flex min-w-max gap-2 px-1 pr-8";

--- a/apps/web/src/components/data-table-cards.tsx
+++ b/apps/web/src/components/data-table-cards.tsx
@@ -216,9 +216,6 @@ export const DataTableCards = <TData extends RowData>({
 										)}
 									</div>
 								) : null}
-								{/* Directly under the title, above the badges: a field people
-								    search by (the customer's name) cannot be the last thing
-								    on the card, boxed in with the low-frequency detail. */}
 								{subtitleCells.map((cell) => {
 									const mobileCard = cell.column.columnDef.meta?.mobileCard;
 									return (

--- a/apps/web/src/components/data-table-cards.tsx
+++ b/apps/web/src/components/data-table-cards.tsx
@@ -18,6 +18,7 @@ interface DataTableCardsProps<TData extends RowData> {
 
 interface CardCells<TData extends RowData> {
 	primaryCell?: Cell<TData, unknown>;
+	subtitleCells: Cell<TData, unknown>[];
 	eyebrowCells: Cell<TData, unknown>[];
 	badgeCells: Cell<TData, unknown>[];
 	footerCells: Cell<TData, unknown>[];
@@ -41,6 +42,7 @@ const bucketCardCells = <TData extends RowData>(
 	hiddenIds: Set<string>,
 ): CardCells<TData> => {
 	const buckets: CardCells<TData> = {
+		subtitleCells: [],
 		eyebrowCells: [],
 		badgeCells: [],
 		footerCells: [],
@@ -56,6 +58,10 @@ const bucketCardCells = <TData extends RowData>(
 			continue;
 		}
 		const slot = cell.column.columnDef.meta?.mobileCard?.slot;
+		if (slot === "subtitle") {
+			buckets.subtitleCells.push(cell);
+			continue;
+		}
 		if (slot === "eyebrow") {
 			buckets.eyebrowCells.push(cell);
 			continue;
@@ -124,6 +130,7 @@ export const DataTableCards = <TData extends RowData>({
 			{rows.map((row) => {
 				const {
 					primaryCell,
+					subtitleCells,
 					eyebrowCells,
 					badgeCells,
 					footerCells,
@@ -192,7 +199,9 @@ export const DataTableCards = <TData extends RowData>({
 							</div>
 						) : null}
 
-						{primaryCell || badgeCells.length > 0 ? (
+						{primaryCell ||
+						subtitleCells.length > 0 ||
+						badgeCells.length > 0 ? (
 							<div className="grid gap-2 px-3 py-2.5">
 								{primaryCell ? (
 									<div
@@ -207,6 +216,23 @@ export const DataTableCards = <TData extends RowData>({
 										)}
 									</div>
 								) : null}
+								{/* Directly under the title, above the badges: a field people
+								    search by (the customer's name) cannot be the last thing
+								    on the card, boxed in with the low-frequency detail. */}
+								{subtitleCells.map((cell) => {
+									const mobileCard = cell.column.columnDef.meta?.mobileCard;
+									return (
+										<div
+											className={cn("min-w-0 text-sm", mobileCard?.className)}
+											key={cell.id}
+										>
+											{flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext(),
+											)}
+										</div>
+									);
+								})}
 								{badgeCells.length > 0 ? (
 									<div className="flex flex-wrap items-center gap-1">
 										{badgeCells.map((cell) => {

--- a/apps/web/src/components/data-table-grid.tsx
+++ b/apps/web/src/components/data-table-grid.tsx
@@ -32,7 +32,11 @@ export const DataTableGrid = <TData extends RowData>({
 	emptyMessage,
 	sortable,
 }: DataTableGridProps<TData>) => (
-	<Table containerClassName="lg:max-h-[calc(100dvh-18rem)]">
+	// No height cap: capping the container made it the only scroller, so a 43-row
+	// services table showed 26% of its rows behind a 6px scrollbar while the page
+	// itself stayed put. The page scrolls now; the wrapper keeps overflow-x for
+	// tables wider than the viewport.
+	<Table>
 		<TableHeader>
 			{table.getHeaderGroups().map((headerGroup) => (
 				<TableRow key={headerGroup.id} className="border-border hover:bg-muted">

--- a/apps/web/src/components/data-table-grid.tsx
+++ b/apps/web/src/components/data-table-grid.tsx
@@ -32,10 +32,8 @@ export const DataTableGrid = <TData extends RowData>({
 	emptyMessage,
 	sortable,
 }: DataTableGridProps<TData>) => (
-	// No height cap: capping the container made it the only scroller, so a 43-row
-	// services table showed 26% of its rows behind a 6px scrollbar while the page
-	// itself stayed put. The page scrolls now; the wrapper keeps overflow-x for
-	// tables wider than the viewport.
+	// Never cap the height here: an inner scroller left 3 of 4 rows in a long
+	// table unreachable, because the page itself then had nothing to scroll.
 	<Table>
 		<TableHeader>
 			{table.getHeaderGroups().map((headerGroup) => (

--- a/apps/web/src/components/data-table-meta.ts
+++ b/apps/web/src/components/data-table-meta.ts
@@ -2,6 +2,7 @@ import type { RowData } from "@tanstack/react-table";
 
 type MobileCardSlot =
 	| "title"
+	| "subtitle"
 	| "eyebrow"
 	| "badges"
 	| "detail"

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -11,7 +11,7 @@ function Table({
 		<div
 			data-slot="table-container"
 			className={cn(
-				"relative w-full overflow-auto [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-muted/40",
+				"relative w-full overflow-x-auto [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-muted/40",
 				containerClassName,
 			)}
 		>

--- a/apps/web/src/features/orders/components/order-filter-pills.tsx
+++ b/apps/web/src/features/orders/components/order-filter-pills.tsx
@@ -37,10 +37,10 @@ interface OrderFilterPill {
 // Jakarta's date, never the device's: the server counts "today" with
 // jakartaNow(), and dayjs runs vanilla here, so a tablet left on UTC would send
 // a date_from the count never used. en-CA is the locale that prints YYYY-MM-DD.
-const jakartaToday = () =>
-	new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Jakarta" }).format(
-		new Date(),
-	);
+const jakartaDateFormat = new Intl.DateTimeFormat("en-CA", {
+	timeZone: "Asia/Jakarta",
+});
+const jakartaToday = () => jakartaDateFormat.format(new Date());
 
 const buildPills = (today: string): OrderFilterPill[] => [
 	{ key: "all", label: "All", patch: CLEARED },

--- a/apps/web/src/features/orders/components/order-filter-pills.tsx
+++ b/apps/web/src/features/orders/components/order-filter-pills.tsx
@@ -4,9 +4,8 @@ import type { OrderFilterValues } from "@/features/orders/components/order-filte
 import type { OrderListCounts } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-// Every pill owns the same five fields, so switching from Unpaid to Overdue
-// cannot leave the payment filter behind — the pill you can see is the whole
-// filter that is applied.
+// Every pill patches all five, so switching from Unpaid to Overdue cannot leave
+// the payment filter behind.
 const PILL_FIELDS = [
 	"status",
 	"paymentStatus",
@@ -29,8 +28,8 @@ const CLEARED: OrderFilterPillPatch = {
 };
 
 interface OrderFilterPill {
-	// Doubles as the counts key — a pill can't show a number that belongs to a
-	// different question than the one it filters by.
+	// Doubles as the counts key, so a pill cannot show a number for one question
+	// while filtering by another.
 	key: keyof OrderListCounts;
 	label: string;
 	patch: OrderFilterPillPatch;
@@ -65,10 +64,6 @@ interface OrderFilterPillsProps {
 	onChange: (patch: Partial<OrderFilterValues>) => void;
 }
 
-// The counts are the filters. Four controls that all read "All …" say nothing
-// until someone operates them, so the one fact worth acting on — three orders
-// nobody has collected — was invisible until you went looking. Now it is the
-// first thing on the page, and clicking it is the filter.
 export const OrderFilterPills = ({
 	values,
 	counts,
@@ -82,9 +77,6 @@ export const OrderFilterPills = ({
 			{pills.map((pill) => {
 				const isActive = isPillActive(pill.patch, values);
 				const count = counts?.[pill.key];
-				// Overdue earns its colour only when there is something to chase, and
-				// only while it isn't the filter — an active pill reads as selected,
-				// not as an alarm.
 				const isAlarm = pill.key === "overdue" && !isActive && !!count;
 
 				return (

--- a/apps/web/src/features/orders/components/order-filter-pills.tsx
+++ b/apps/web/src/features/orders/components/order-filter-pills.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { Button } from "@/components/ui/button";
 import type { OrderFilterValues } from "@/features/orders/components/order-filters";
 import type { OrderListCounts } from "@/lib/api";
@@ -34,6 +33,14 @@ interface OrderFilterPill {
 	label: string;
 	patch: OrderFilterPillPatch;
 }
+
+// Jakarta's date, never the device's: the server counts "today" with
+// jakartaNow(), and dayjs runs vanilla here, so a tablet left on UTC would send
+// a date_from the count never used. en-CA is the locale that prints YYYY-MM-DD.
+const jakartaToday = () =>
+	new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Jakarta" }).format(
+		new Date(),
+	);
 
 const buildPills = (today: string): OrderFilterPill[] => [
 	{ key: "all", label: "All", patch: CLEARED },
@@ -72,7 +79,7 @@ export const OrderFilterPills = ({
 	counts,
 	onChange,
 }: OrderFilterPillsProps) => {
-	const pills = buildPills(dayjs().format("YYYY-MM-DD"));
+	const pills = buildPills(jakartaToday());
 
 	return (
 		<fieldset className="mb-3 flex min-w-0 flex-wrap gap-1 border-0 p-0">

--- a/apps/web/src/features/orders/components/order-filter-pills.tsx
+++ b/apps/web/src/features/orders/components/order-filter-pills.tsx
@@ -1,0 +1,112 @@
+import dayjs from "dayjs";
+import { Button } from "@/components/ui/button";
+import type { OrderFilterValues } from "@/features/orders/components/order-filters";
+import type { OrderListCounts } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+// Every pill owns the same five fields, so switching from Unpaid to Overdue
+// cannot leave the payment filter behind — the pill you can see is the whole
+// filter that is applied.
+const PILL_FIELDS = [
+	"status",
+	"paymentStatus",
+	"overdue",
+	"dateFrom",
+	"dateTo",
+] as const;
+
+type OrderFilterPillPatch = Pick<
+	OrderFilterValues,
+	(typeof PILL_FIELDS)[number]
+>;
+
+const CLEARED: OrderFilterPillPatch = {
+	status: undefined,
+	paymentStatus: undefined,
+	overdue: undefined,
+	dateFrom: undefined,
+	dateTo: undefined,
+};
+
+interface OrderFilterPill {
+	// Doubles as the counts key — a pill can't show a number that belongs to a
+	// different question than the one it filters by.
+	key: keyof OrderListCounts;
+	label: string;
+	patch: OrderFilterPillPatch;
+}
+
+const buildPills = (today: string): OrderFilterPill[] => [
+	{ key: "all", label: "All", patch: CLEARED },
+	{
+		key: "today",
+		label: "Today",
+		patch: { ...CLEARED, dateFrom: today, dateTo: today },
+	},
+	{
+		key: "unpaid",
+		label: "Unpaid",
+		patch: { ...CLEARED, paymentStatus: "unpaid" },
+	},
+	{
+		key: "ready_for_pickup",
+		label: "Ready for pickup",
+		patch: { ...CLEARED, status: "ready_for_pickup" },
+	},
+	{ key: "overdue", label: "Overdue", patch: { ...CLEARED, overdue: true } },
+];
+
+const isPillActive = (patch: OrderFilterPillPatch, values: OrderFilterValues) =>
+	PILL_FIELDS.every((field) => patch[field] === values[field]);
+
+interface OrderFilterPillsProps {
+	values: OrderFilterValues;
+	counts?: OrderListCounts;
+	onChange: (patch: Partial<OrderFilterValues>) => void;
+}
+
+// The counts are the filters. Four controls that all read "All …" say nothing
+// until someone operates them, so the one fact worth acting on — three orders
+// nobody has collected — was invisible until you went looking. Now it is the
+// first thing on the page, and clicking it is the filter.
+export const OrderFilterPills = ({
+	values,
+	counts,
+	onChange,
+}: OrderFilterPillsProps) => {
+	const pills = buildPills(dayjs().format("YYYY-MM-DD"));
+
+	return (
+		<fieldset className="mb-3 flex min-w-0 flex-wrap gap-1 border-0 p-0">
+			<legend className="sr-only">Filter orders</legend>
+			{pills.map((pill) => {
+				const isActive = isPillActive(pill.patch, values);
+				const count = counts?.[pill.key];
+				// Overdue earns its colour only when there is something to chase, and
+				// only while it isn't the filter — an active pill reads as selected,
+				// not as an alarm.
+				const isAlarm = pill.key === "overdue" && !isActive && !!count;
+
+				return (
+					<Button
+						aria-pressed={isActive}
+						className={cn(
+							"gap-1.5 font-mono uppercase tracking-[0.14em]",
+							isAlarm && "border-destructive/50 text-destructive",
+						)}
+						key={pill.key}
+						onClick={() => onChange(pill.patch)}
+						size="sm"
+						type="button"
+						variant={isActive ? "default" : "outline"}
+					>
+						{pill.label}
+						{count === undefined ? null : (
+							<span className="font-semibold tabular-nums">{count}</span>
+						)}
+					</Button>
+				);
+			})}
+		</fieldset>
+	);
+};

--- a/apps/web/src/features/orders/components/order-filter-pills.tsx
+++ b/apps/web/src/features/orders/components/order-filter-pills.tsx
@@ -47,9 +47,12 @@ const buildPills = (today: string): OrderFilterPill[] => [
 		label: "Unpaid",
 		patch: { ...CLEARED, paymentStatus: "unpaid" },
 	},
+	// "Ready for pickup" set in tracked uppercase is 17 characters and wraps the
+	// row onto a second line on a phone. The pill sits next to Overdue, which is
+	// the same shelf — "Ready" is not ambiguous here.
 	{
 		key: "ready_for_pickup",
-		label: "Ready for pickup",
+		label: "Ready",
 		patch: { ...CLEARED, status: "ready_for_pickup" },
 	},
 	{ key: "overdue", label: "Overdue", patch: { ...CLEARED, overdue: true } },

--- a/apps/web/src/features/orders/components/order-filters.tsx
+++ b/apps/web/src/features/orders/components/order-filters.tsx
@@ -1,6 +1,7 @@
 import { FunnelIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { DebouncedSearchInput } from "@/components/debounced-search-input";
+import { SelectField } from "@/components/form/select-field";
 import { Button } from "@/components/ui/button";
 import { DateRangePicker } from "@/components/ui/date-picker";
 import {
@@ -11,6 +12,7 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
+import { formatOrderStatus, formatPaymentStatus } from "@/lib/status";
 
 export const ORDER_STATUS_VALUES = [
 	"created",
@@ -42,6 +44,22 @@ interface OrderFiltersProps {
 	onChange: (patch: Partial<OrderFilterValues>) => void;
 }
 
+// "" is the all-stores/statuses sentinel — selecting it maps back to undefined.
+const STATUS_ITEMS: Record<string, string> = {
+	"": "All statuses",
+	created: formatOrderStatus("created"),
+	processing: formatOrderStatus("processing"),
+	ready_for_pickup: formatOrderStatus("ready_for_pickup"),
+	completed: formatOrderStatus("completed"),
+	cancelled: formatOrderStatus("cancelled"),
+};
+
+const PAYMENT_ITEMS: Record<string, string> = {
+	"": "All payments",
+	paid: formatPaymentStatus("paid"),
+	unpaid: formatPaymentStatus("unpaid"),
+};
+
 interface FilterControlsProps extends OrderFiltersProps {
 	idPrefix: string;
 }
@@ -66,6 +84,42 @@ const FilterControls = ({
 			placeholder="Filter by store"
 			triggerClassName="h-10 w-full lg:w-max lg:min-w-40"
 		/>
+		{/* The pills above cover the two statuses the counter reaches for hourly.
+		    These carry the rest — cancelled, completed, paid — which reconciliation
+		    needs and no pill offers, and they double as the readout for a status
+		    arrived at by shared link or back button. */}
+		<SelectField
+			id={`${idPrefix}-status`}
+			aria-label="Filter by order status"
+			items={STATUS_ITEMS}
+			value={values.status ?? ""}
+			onValueChange={(value) => {
+				const status = (value || undefined) as OrderStatusFilter | undefined;
+				onChange({
+					status,
+					// Overdue is the ready-for-pickup shelf aged past its window, so
+					// naming any other status contradicts it. Dropping it here is what
+					// keeps the Overdue pill and this select from asking together for
+					// orders that cannot exist, which the server refuses outright.
+					...(status && status !== "ready_for_pickup"
+						? { overdue: undefined }
+						: {}),
+				});
+			}}
+			placeholder="All statuses"
+			className="w-full lg:w-max lg:min-w-40"
+		/>
+		<SelectField
+			id={`${idPrefix}-payment`}
+			aria-label="Filter by payment status"
+			items={PAYMENT_ITEMS}
+			value={values.paymentStatus ?? ""}
+			onValueChange={(value) =>
+				onChange({ paymentStatus: (value || undefined) as PaymentStatusFilter })
+			}
+			placeholder="All payments"
+			className="w-full lg:w-max lg:min-w-40"
+		/>
 		<DateRangePicker
 			id={`${idPrefix}-date`}
 			resetOnSelect
@@ -88,14 +142,23 @@ export const OrderFilters = ({
 	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
 	const isAdmin = role === "admin";
 
-	// Status and payment belong to the pills, so this dialog neither counts nor
-	// clears them: Clear all must not undo the pill selected above it.
+	// Every field that narrows the list is counted here and cleared by Clear all,
+	// including the ones a pill can set. A filter the badge does not count is a
+	// filter the cashier cannot see, and one Clear all skips is a filter they
+	// cannot undo — which is how a shared /orders?status=completed link used to
+	// leave someone staring at a short list with nothing on screen explaining it.
 	const activeCount =
+		(values.status ? 1 : 0) +
+		(values.paymentStatus ? 1 : 0) +
+		(values.overdue ? 1 : 0) +
 		(values.dateFrom || values.dateTo ? 1 : 0) +
 		(isAdmin && values.storeId ? 1 : 0);
 
 	const handleClearAll = () => {
 		onChange({
+			status: undefined,
+			paymentStatus: undefined,
+			overdue: undefined,
 			dateFrom: undefined,
 			dateTo: undefined,
 			...(isAdmin ? { storeId: undefined } : {}),

--- a/apps/web/src/features/orders/components/order-filters.tsx
+++ b/apps/web/src/features/orders/components/order-filters.tsx
@@ -88,9 +88,8 @@ export const OrderFilters = ({
 	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
 	const isAdmin = role === "admin";
 
-	// Status and payment live in the pills now, so they are not counted here and
-	// Clear all leaves them alone — clearing the dialog must not silently undo
-	// the pill the user can see selected above it.
+	// Status and payment belong to the pills, so this dialog neither counts nor
+	// clears them: Clear all must not undo the pill selected above it.
 	const activeCount =
 		(values.dateFrom || values.dateTo ? 1 : 0) +
 		(isAdmin && values.storeId ? 1 : 0);

--- a/apps/web/src/features/orders/components/order-filters.tsx
+++ b/apps/web/src/features/orders/components/order-filters.tsx
@@ -1,7 +1,6 @@
 import { FunnelIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { DebouncedSearchInput } from "@/components/debounced-search-input";
-import { SelectField } from "@/components/form/select-field";
 import { Button } from "@/components/ui/button";
 import { DateRangePicker } from "@/components/ui/date-picker";
 import {
@@ -12,7 +11,6 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
-import { formatOrderStatus, formatPaymentStatus } from "@/lib/status";
 
 export const ORDER_STATUS_VALUES = [
 	"created",
@@ -32,6 +30,7 @@ export interface OrderFilterValues {
 	storeId?: number;
 	status?: OrderStatusFilter;
 	paymentStatus?: PaymentStatusFilter;
+	overdue?: boolean;
 	dateFrom?: string;
 	dateTo?: string;
 }
@@ -42,22 +41,6 @@ interface OrderFiltersProps {
 	userStoreIds: number[];
 	onChange: (patch: Partial<OrderFilterValues>) => void;
 }
-
-// "" is the all-stores/statuses sentinel — selecting it maps back to undefined.
-const STATUS_ITEMS: Record<string, string> = {
-	"": "All statuses",
-	created: formatOrderStatus("created"),
-	processing: formatOrderStatus("processing"),
-	ready_for_pickup: formatOrderStatus("ready_for_pickup"),
-	completed: formatOrderStatus("completed"),
-	cancelled: formatOrderStatus("cancelled"),
-};
-
-const PAYMENT_ITEMS: Record<string, string> = {
-	"": "All payments",
-	paid: formatPaymentStatus("paid"),
-	unpaid: formatPaymentStatus("unpaid"),
-};
 
 interface FilterControlsProps extends OrderFiltersProps {
 	idPrefix: string;
@@ -83,28 +66,6 @@ const FilterControls = ({
 			placeholder="Filter by store"
 			triggerClassName="h-10 w-full lg:w-max lg:min-w-40"
 		/>
-		<SelectField
-			id={`${idPrefix}-status`}
-			aria-label="Filter by order status"
-			items={STATUS_ITEMS}
-			value={values.status ?? ""}
-			onValueChange={(value) =>
-				onChange({ status: (value || undefined) as OrderStatusFilter })
-			}
-			placeholder="All statuses"
-			className="w-full lg:w-max lg:min-w-40"
-		/>
-		<SelectField
-			id={`${idPrefix}-payment`}
-			aria-label="Filter by payment status"
-			items={PAYMENT_ITEMS}
-			value={values.paymentStatus ?? ""}
-			onValueChange={(value) =>
-				onChange({ paymentStatus: (value || undefined) as PaymentStatusFilter })
-			}
-			placeholder="All payments"
-			className="w-full lg:w-max lg:min-w-40"
-		/>
 		<DateRangePicker
 			id={`${idPrefix}-date`}
 			resetOnSelect
@@ -127,16 +88,15 @@ export const OrderFilters = ({
 	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
 	const isAdmin = role === "admin";
 
+	// Status and payment live in the pills now, so they are not counted here and
+	// Clear all leaves them alone — clearing the dialog must not silently undo
+	// the pill the user can see selected above it.
 	const activeCount =
-		(values.status ? 1 : 0) +
-		(values.paymentStatus ? 1 : 0) +
 		(values.dateFrom || values.dateTo ? 1 : 0) +
 		(isAdmin && values.storeId ? 1 : 0);
 
 	const handleClearAll = () => {
 		onChange({
-			status: undefined,
-			paymentStatus: undefined,
 			dateFrom: undefined,
 			dateTo: undefined,
 			...(isAdmin ? { storeId: undefined } : {}),

--- a/apps/web/src/features/orders/components/order-identity-strip.tsx
+++ b/apps/web/src/features/orders/components/order-identity-strip.tsx
@@ -18,19 +18,12 @@ import {
 import { OpenComplaintForm } from "@/features/complaints/components/open-complaint-form";
 import { useOpenComplaintMutation } from "@/features/complaints/hooks/useComplaintMutations";
 import { OrderCourierForm } from "@/features/orders/components/order-courier-form";
-import {
-	CancelOrderForm,
-	RefundOrderForm,
-} from "@/features/orders/components/order-line-reversal-form";
+import { CancelOrderForm } from "@/features/orders/components/order-line-reversal-form";
 import { OrderPickupEventDialog } from "@/features/orders/components/order-pickup-event-dialog";
 import { PaymentStatusBadge } from "@/features/orders/components/payment-status-badge";
-import {
-	useCancelOrderMutation,
-	useRefundOrderMutation,
-} from "@/features/orders/hooks/useOrderMutations";
+import { useCancelOrderMutation } from "@/features/orders/hooks/useOrderMutations";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
 import type { OrderActionGates } from "@/features/orders/lib/order-action-gates";
-import { buildRefundCaps } from "@/features/orders/lib/refund-preview";
 import { buildTrackingUrl } from "@/features/orders/lib/tracking-link";
 import { usePrintReceiptMutation } from "@/features/printing/hooks/usePrintReceipt";
 import type { OrderDetail } from "@/lib/api";
@@ -57,7 +50,6 @@ export const OrderIdentityStrip = ({
 	const openDialog = useDialog((s) => s.openDialog);
 	const closeDialog = useDialog((s) => s.closeDialog);
 	const cancelOrderMutation = useCancelOrderMutation(orderId);
-	const refundMutation = useRefundOrderMutation(orderId);
 	const openComplaintMutation = useOpenComplaintMutation(orderId);
 	const printReceiptMutation = usePrintReceiptMutation(orderId);
 
@@ -145,31 +137,6 @@ export const OrderIdentityStrip = ({
 		});
 	};
 
-	const openRefundOrderDialog = () => {
-		openDialog({
-			title: "Refund order",
-			description: "Select items to refund and provide reasons.",
-			contentClassName: "sm:max-w-xl",
-			content: () => (
-				<RefundOrderForm
-					capsByLineKey={buildRefundCaps(detail)}
-					closeDialog={closeDialog}
-					orderId={orderId}
-					refundableProducts={gates.refundableProducts.map((item) => ({
-						id: item.id,
-						name: item.product?.name ?? `Product #${item.product_id}`,
-						qty: item.qty,
-					}))}
-					refundableServices={gates.refundableServices.map((service) => ({
-						id: service.id,
-						item_code: service.item_code ?? null,
-					}))}
-					refundMutation={refundMutation}
-				/>
-			),
-		});
-	};
-
 	const openComplaintDialog = () => {
 		openDialog({
 			title: "Open complaint",
@@ -190,13 +157,14 @@ export const OrderIdentityStrip = ({
 		});
 	};
 
+	// Refund order now lives beside the money it reverses, in the payment column.
+	// It was the only irreversible entry in this menu, one item below a routine
+	// reprint with nothing between them.
 	const hasMenu =
 		Boolean(trackingUrl) ||
 		gates.canManageCourier ||
 		gates.canCancelOrder ||
-		gates.canRefundWholeOrder ||
 		gates.canOpenComplaint;
-	const showActions = readyCount > 0 || hasMenu;
 	const meta = [
 		detail.customer?.name,
 		detail.customer?.phone_number,
@@ -246,68 +214,63 @@ export const OrderIdentityStrip = ({
 						<p className="text-muted-foreground text-sm">{meta}</p>
 					</div>
 
-					{showActions ? (
-						<div className="flex shrink-0 items-center gap-2">
-							{renderPickupButton("hidden sm:inline-flex")}
-							{hasMenu ? (
-								<DropdownMenu>
-									<DropdownMenuTrigger
-										render={
-											<Button
-												aria-label="More actions"
-												icon={<DotsThreeVerticalIcon className="size-4" />}
-												size="icon"
-												variant="outline"
-											/>
-										}
-									/>
-									<DropdownMenuContent align="end" className="w-40">
-										<DropdownMenuItem
-											disabled={printReceiptMutation.isPending}
-											onClick={() => printReceiptMutation.mutate()}
-										>
-											<PrinterIcon className="size-4" />
-											Print receipt
+					<div className="flex shrink-0 items-center gap-2">
+						{renderPickupButton("hidden sm:inline-flex")}
+						{/* Reprinting a receipt is what the counter does most often at this
+						    desk — it belongs on the surface, not two taps down an
+						    unlabelled menu it shared with the refund. */}
+						<Button
+							icon={<PrinterIcon className="size-4" />}
+							loading={printReceiptMutation.isPending}
+							onClick={() => printReceiptMutation.mutate()}
+							type="button"
+							variant="outline"
+						>
+							Print
+						</Button>
+						{hasMenu ? (
+							<DropdownMenu>
+								<DropdownMenuTrigger
+									render={
+										<Button
+											aria-label="More actions"
+											icon={<DotsThreeVerticalIcon className="size-4" />}
+											size="icon"
+											variant="outline"
+										/>
+									}
+								/>
+								<DropdownMenuContent align="end" className="w-40">
+									{trackingUrl ? (
+										<DropdownMenuItem onClick={handleCopyTrackingLink}>
+											<LinkSimpleIcon className="size-4" />
+											Copy tracking link
 										</DropdownMenuItem>
-										{trackingUrl ? (
-											<DropdownMenuItem onClick={handleCopyTrackingLink}>
-												<LinkSimpleIcon className="size-4" />
-												Copy tracking link
-											</DropdownMenuItem>
-										) : null}
-										{gates.canManageCourier ? (
-											<DropdownMenuItem onClick={openCourierDialog}>
-												<TruckIcon className="size-4" />
-												Set courier
-											</DropdownMenuItem>
-										) : null}
-										{gates.canOpenComplaint ? (
-											<DropdownMenuItem onClick={openComplaintDialog}>
-												<WarningCircleIcon className="size-4" />
-												Open complaint
-											</DropdownMenuItem>
-										) : null}
-										{gates.canCancelOrder ? (
-											<DropdownMenuItem
-												onClick={openCancelOrderDialog}
-												variant="destructive"
-											>
-												Cancel order
-											</DropdownMenuItem>
-										) : null}
-										{gates.canRefundWholeOrder ? (
-											<DropdownMenuItem
-												onClick={openRefundOrderDialog}
-												variant="destructive"
-											>
-												Refund order
-											</DropdownMenuItem>
-										) : null}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							) : null}
-						</div>
-					) : null}
+									) : null}
+									{gates.canManageCourier ? (
+										<DropdownMenuItem onClick={openCourierDialog}>
+											<TruckIcon className="size-4" />
+											Set courier
+										</DropdownMenuItem>
+									) : null}
+									{gates.canOpenComplaint ? (
+										<DropdownMenuItem onClick={openComplaintDialog}>
+											<WarningCircleIcon className="size-4" />
+											Open complaint
+										</DropdownMenuItem>
+									) : null}
+									{gates.canCancelOrder ? (
+										<DropdownMenuItem
+											onClick={openCancelOrderDialog}
+											variant="destructive"
+										>
+											Cancel order
+										</DropdownMenuItem>
+									) : null}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						) : null}
+					</div>
 				</div>
 
 				{renderPickupButton("w-full sm:hidden")}

--- a/apps/web/src/features/orders/components/order-identity-strip.tsx
+++ b/apps/web/src/features/orders/components/order-identity-strip.tsx
@@ -157,9 +157,6 @@ export const OrderIdentityStrip = ({
 		});
 	};
 
-	// Refund order now lives beside the money it reverses, in the payment column.
-	// It was the only irreversible entry in this menu, one item below a routine
-	// reprint with nothing between them.
 	const hasMenu =
 		Boolean(trackingUrl) ||
 		gates.canManageCourier ||
@@ -216,9 +213,6 @@ export const OrderIdentityStrip = ({
 
 					<div className="flex shrink-0 items-center gap-2">
 						{renderPickupButton("hidden sm:inline-flex")}
-						{/* Reprinting a receipt is what the counter does most often at this
-						    desk — it belongs on the surface, not two taps down an
-						    unlabelled menu it shared with the refund. */}
 						<Button
 							icon={<PrinterIcon className="size-4" />}
 							loading={printReceiptMutation.isPending}

--- a/apps/web/src/features/orders/components/order-payment-section.tsx
+++ b/apps/web/src/features/orders/components/order-payment-section.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/field";
 import { Separator } from "@/components/ui/separator";
 import { OrderMoneySummary } from "@/features/orders/components/order-money-summary";
+import { OrderRefundAction } from "@/features/orders/components/order-refund-action";
 import { OrderSectionHeader } from "@/features/orders/components/order-section-header";
 import { useOrderPaymentMutation } from "@/features/orders/hooks/useOrderMutations";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
@@ -52,6 +53,7 @@ export const OrderPaymentSection = ({
 			<OrderMoneySummary detail={detail} />
 		</div>
 		<PaymentDetails detail={detail} gates={gates} orderId={orderId} />
+		<OrderRefundAction detail={detail} gates={gates} orderId={orderId} />
 	</Card>
 );
 

--- a/apps/web/src/features/orders/components/order-pickup-event-dialog.tsx
+++ b/apps/web/src/features/orders/components/order-pickup-event-dialog.tsx
@@ -18,12 +18,12 @@ import {
 	InputOTPSlot,
 } from "@/components/ui/input-otp";
 import { SinglePhotoCaptureDialog } from "@/features/orders/components/photo-upload-dialog";
+import { invalidateOrderQueries } from "@/features/orders/lib/invalidate-order-queries";
 import { isAcceptedImage } from "@/features/orders/utils/photo-upload";
 import {
 	createOrderPickupEvent,
 	type OrderDetail,
 	presignOrderPickupEvent,
-	queryKeys,
 	uploadFileToPresignedUrl,
 } from "@/lib/api";
 import { formatOrderServiceItemDetails } from "@/lib/order-service-item-details";
@@ -159,10 +159,10 @@ export const OrderPickupEventDialog = ({
 		},
 		onSuccess: async () => {
 			toast.success("Pickup recorded");
-			await queryClient.invalidateQueries({
-				queryKey: queryKeys.orderDetail(orderId),
-			});
-			await queryClient.invalidateQueries({ queryKey: ["orders"] });
+			// A collected Item leaves the workshop queue and the ready-for-pickup
+			// shelf both — the /queue chips and the /orders pills each hold a number
+			// this hand-off just changed.
+			await invalidateOrderQueries(queryClient, orderId);
 			closeDialog();
 		},
 		onError: (error: Error) => {

--- a/apps/web/src/features/orders/components/order-refund-action.tsx
+++ b/apps/web/src/features/orders/components/order-refund-action.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { RefundOrderForm } from "@/features/orders/components/order-line-reversal-form";
+import { useRefundOrderMutation } from "@/features/orders/hooks/useOrderMutations";
+import type { OrderActionGates } from "@/features/orders/lib/order-action-gates";
+import { buildRefundCaps } from "@/features/orders/lib/refund-preview";
+import type { OrderDetail } from "@/lib/api";
+import { useDialog } from "@/stores/dialog-store";
+
+interface OrderRefundActionProps {
+	orderId: number;
+	detail: OrderDetail;
+	gates: OrderActionGates;
+}
+
+// Refunding is the one thing at this desk that moves money back out, and it
+// reads the same numbers the payment card shows — so it sits under them,
+// bordered and destructive, rather than one line below "Print receipt" in a
+// menu where a mis-tap costs a reversal.
+export const OrderRefundAction = ({
+	orderId,
+	detail,
+	gates,
+}: OrderRefundActionProps) => {
+	const openDialog = useDialog((s) => s.openDialog);
+	const closeDialog = useDialog((s) => s.closeDialog);
+	const refundMutation = useRefundOrderMutation(orderId);
+
+	if (!gates.canRefundWholeOrder) {
+		return null;
+	}
+
+	const openRefundOrderDialog = () => {
+		openDialog({
+			title: "Refund order",
+			description: "Select items to refund and provide reasons.",
+			contentClassName: "sm:max-w-xl",
+			content: () => (
+				<RefundOrderForm
+					capsByLineKey={buildRefundCaps(detail)}
+					closeDialog={closeDialog}
+					orderId={orderId}
+					refundableProducts={gates.refundableProducts.map((item) => ({
+						id: item.id,
+						name: item.product?.name ?? `Product #${item.product_id}`,
+						qty: item.qty,
+					}))}
+					refundableServices={gates.refundableServices.map((service) => ({
+						id: service.id,
+						item_code: service.item_code ?? null,
+					}))}
+					refundMutation={refundMutation}
+				/>
+			),
+		});
+	};
+
+	return (
+		<div className="border-t px-4 py-3">
+			<Button
+				className="border-destructive/40"
+				onClick={openRefundOrderDialog}
+				type="button"
+				variant="destructive"
+			>
+				Refund order
+			</Button>
+		</div>
+	);
+};

--- a/apps/web/src/features/orders/components/order-refund-action.tsx
+++ b/apps/web/src/features/orders/components/order-refund-action.tsx
@@ -12,10 +12,6 @@ interface OrderRefundActionProps {
 	gates: OrderActionGates;
 }
 
-// Refunding is the one thing at this desk that moves money back out, and it
-// reads the same numbers the payment card shows — so it sits under them,
-// bordered and destructive, rather than one line below "Print receipt" in a
-// menu where a mis-tap costs a reversal.
 export const OrderRefundAction = ({
 	orderId,
 	detail,

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -115,8 +115,6 @@ export function QueueServiceDetail({
 				queryKey: queryKeys.orderServiceQueue({ store_id: storeId }),
 			});
 		}
-		// Moving an item between statuses moves it between chips, so the numbers
-		// on the strip the worker just came from are already wrong.
 		await queryClient.invalidateQueries({
 			queryKey: ["order-service-queue-counts"],
 		});

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -118,6 +118,9 @@ export function QueueServiceDetail({
 		await queryClient.invalidateQueries({
 			queryKey: ["order-service-queue-counts"],
 		});
+		// The Orders list and its pills read the same fulfillment this just moved.
+		await queryClient.invalidateQueries({ queryKey: ["orders"] });
+		await queryClient.invalidateQueries({ queryKey: ["order-counts"] });
 	};
 
 	const startWorkMutation = useMutation({

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -115,6 +115,11 @@ export function QueueServiceDetail({
 				queryKey: queryKeys.orderServiceQueue({ store_id: storeId }),
 			});
 		}
+		// Moving an item between statuses moves it between chips, so the numbers
+		// on the strip the worker just came from are already wrong.
+		await queryClient.invalidateQueries({
+			queryKey: ["order-service-queue-counts"],
+		});
 	};
 
 	const startWorkMutation = useMutation({
@@ -202,7 +207,7 @@ export function QueueServiceDetail({
 		<>
 			<div className="mb-5 flex items-start gap-3">
 				<Link
-					to="/worker"
+					to="/queue"
 					search={{ storeId: detail.store?.id }}
 					className="flex size-9 shrink-0 items-center justify-center border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 				>

--- a/apps/web/src/features/orders/components/queue-service-detail.tsx
+++ b/apps/web/src/features/orders/components/queue-service-detail.tsx
@@ -21,9 +21,9 @@ import { OrderPhotoGallery } from "@/features/orders/components/order-photo-gall
 import { PhotoUploadDialog } from "@/features/orders/components/photo-upload-dialog";
 import { StatusTimeline } from "@/features/orders/components/status-timeline";
 import { formatOrderDateTime } from "@/features/orders/lib/format";
+import { invalidateOrderQueries } from "@/features/orders/lib/invalidate-order-queries";
 import { orderServicePhotoUploader } from "@/features/orders/utils/photo-upload";
 import {
-	queryKeys,
 	type UpdateOrderServiceStatusPayload,
 	updateOrderServiceStatus,
 } from "@/lib/api";
@@ -106,29 +106,14 @@ export function QueueServiceDetail({
 		(service) => service.id === serviceId,
 	);
 
-	const refreshData = async (storeId?: number) => {
-		await queryClient.invalidateQueries({
-			queryKey: queryKeys.orderDetail(orderId),
-		});
-		if (storeId !== undefined) {
-			await queryClient.invalidateQueries({
-				queryKey: queryKeys.orderServiceQueue({ store_id: storeId }),
-			});
-		}
-		await queryClient.invalidateQueries({
-			queryKey: ["order-service-queue-counts"],
-		});
-		// The Orders list and its pills read the same fulfillment this just moved.
-		await queryClient.invalidateQueries({ queryKey: ["orders"] });
-		await queryClient.invalidateQueries({ queryKey: ["order-counts"] });
-	};
+	const refreshData = () => invalidateOrderQueries(queryClient, orderId);
 
 	const startWorkMutation = useMutation({
 		mutationFn: () =>
 			updateOrderServiceStatus(orderId, serviceId, { status: "processing" }),
 		onSuccess: async () => {
 			toast.success("Work started");
-			await refreshData(detail?.store?.id);
+			await refreshData();
 		},
 		onError: (error: Error) => {
 			toast.error(readServerErrorMessage(error, "Failed to start work"));
@@ -141,7 +126,7 @@ export function QueueServiceDetail({
 		onSuccess: async () => {
 			toast.success("Status updated");
 			setStatusNote("");
-			await refreshData(detail?.store?.id);
+			await refreshData();
 		},
 		onError: (error: Error) => {
 			toast.error(readServerErrorMessage(error, "Failed to update status"));
@@ -382,7 +367,7 @@ export function QueueServiceDetail({
 					badgeLabel={selectedService.item_code ?? undefined}
 					uploader={orderServicePhotoUploader(orderId, serviceId)}
 					onUploaded={async () => {
-						await refreshData(detail.store?.id);
+						await refreshData();
 					}}
 				/>
 

--- a/apps/web/src/features/orders/components/queue-status-tabs.tsx
+++ b/apps/web/src/features/orders/components/queue-status-tabs.tsx
@@ -27,10 +27,13 @@ export const QueueStatusTabs = ({
 	counts,
 	onValueChange,
 }: QueueStatusTabsProps) => (
-	<div className="-mx-1 overflow-x-auto pb-1">
+	// Six statuses never fit a phone, so the strip scrolls. The mask fades the
+	// last chip out instead of slicing it mid-word, which read as a broken
+	// layout rather than as "there is more this way".
+	<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] sm:[mask-image:none]">
 		<div
 			aria-label="Queue status"
-			className="flex min-w-max gap-2 px-1"
+			className="flex min-w-max gap-2 px-1 pr-8 sm:pr-1"
 			role="tablist"
 		>
 			{STATUS_TAB_ITEMS.map((status) => {

--- a/apps/web/src/features/orders/components/queue-status-tabs.tsx
+++ b/apps/web/src/features/orders/components/queue-status-tabs.tsx
@@ -27,13 +27,15 @@ export const QueueStatusTabs = ({
 	counts,
 	onValueChange,
 }: QueueStatusTabsProps) => (
-	// Six statuses never fit a phone, so the strip scrolls. The mask fades the
-	// last chip out instead of slicing it mid-word, which read as a broken
-	// layout rather than as "there is more this way".
-	<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] sm:[mask-image:none]">
+	// Six statuses rarely fit, so the strip scrolls. The mask fades the last chip
+	// out instead of slicing it mid-word, which read as a broken layout rather
+	// than as "there is more this way". Unconditional, not phone-only: whether
+	// the strip overflows depends on the container — the expanded sidebar cuts it
+	// at 1024 too — and when it does fit the fade lands on empty padding.
+	<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
 		<div
 			aria-label="Queue status"
-			className="flex min-w-max gap-2 px-1 pr-8 sm:pr-1"
+			className="flex min-w-max gap-2 px-1 pr-8"
 			role="tablist"
 		>
 			{STATUS_TAB_ITEMS.map((status) => {

--- a/apps/web/src/features/orders/components/queue-status-tabs.tsx
+++ b/apps/web/src/features/orders/components/queue-status-tabs.tsx
@@ -4,7 +4,6 @@ import {
 	ACTIVE_ORDER_SERVICE_STATUSES,
 	formatOrderServiceStatus,
 } from "@/lib/status";
-import { cn } from "@/lib/utils";
 
 const STATUS_TAB_ITEMS: {
 	value: "all" | (typeof ACTIVE_ORDER_SERVICE_STATUSES)[number];
@@ -21,16 +20,14 @@ interface QueueStatusTabsProps {
 	value: string;
 	counts?: OrderServiceQueueCounts;
 	onValueChange: (value: string) => void;
-	className?: string;
 }
 
 export const QueueStatusTabs = ({
 	value,
 	counts,
 	onValueChange,
-	className,
 }: QueueStatusTabsProps) => (
-	<div className={cn("-mx-1 overflow-x-auto pb-1", className)}>
+	<div className="-mx-1 overflow-x-auto pb-1">
 		<div
 			aria-label="Queue status"
 			className="flex min-w-max gap-2 px-1"

--- a/apps/web/src/features/orders/components/queue-status-tabs.tsx
+++ b/apps/web/src/features/orders/components/queue-status-tabs.tsx
@@ -1,12 +1,16 @@
 import { Button } from "@/components/ui/button";
+import type { OrderServiceQueueCounts } from "@/lib/api";
 import {
 	ACTIVE_ORDER_SERVICE_STATUSES,
 	formatOrderServiceStatus,
 } from "@/lib/status";
 import { cn } from "@/lib/utils";
 
-const STATUS_TAB_ITEMS = [
-	{ value: "all", label: "All active statuses" },
+const STATUS_TAB_ITEMS: {
+	value: "all" | (typeof ACTIVE_ORDER_SERVICE_STATUSES)[number];
+	label: string;
+}[] = [
+	{ value: "all", label: "All" },
 	...ACTIVE_ORDER_SERVICE_STATUSES.map((status) => ({
 		value: status,
 		label: formatOrderServiceStatus(status),
@@ -15,49 +19,46 @@ const STATUS_TAB_ITEMS = [
 
 interface QueueStatusTabsProps {
 	value: string;
+	counts?: OrderServiceQueueCounts;
 	onValueChange: (value: string) => void;
 	className?: string;
 }
 
 export const QueueStatusTabs = ({
 	value,
+	counts,
 	onValueChange,
 	className,
 }: QueueStatusTabsProps) => (
-	<div className={cn("grid gap-2", className)}>
-		<p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-			Status
-		</p>
-		<div className="-mx-1 overflow-x-auto pb-1">
-			<div
-				role="tablist"
-				aria-label="Queue status"
-				className="flex min-w-max gap-2 px-1"
-			>
-				{STATUS_TAB_ITEMS.map((status) => {
-					const isActive = value === status.value;
+	<div className={cn("-mx-1 overflow-x-auto pb-1", className)}>
+		<div
+			aria-label="Queue status"
+			className="flex min-w-max gap-2 px-1"
+			role="tablist"
+		>
+			{STATUS_TAB_ITEMS.map((status) => {
+				const isActive = value === status.value;
+				const count = counts?.[status.value];
 
-					return (
-						<Button
-							key={status.value}
-							type="button"
-							variant={isActive ? "default" : "outline"}
-							size="lg"
-							role="tab"
-							aria-selected={isActive}
-							className={cn(
-								"h-11 px-4 text-sm",
-								isActive
-									? "border-primary bg-primary text-primary-foreground shadow-sm"
-									: "border-border/80 bg-background text-foreground/70 hover:border-foreground/20 hover:bg-muted/70 hover:text-foreground",
-							)}
-							onClick={() => onValueChange(status.value)}
-						>
-							{status.label}
-						</Button>
-					);
-				})}
-			</div>
+				return (
+					<Button
+						aria-selected={isActive}
+						className="h-11 gap-1.5 px-3 text-sm"
+						key={status.value}
+						onClick={() => onValueChange(status.value)}
+						role="tab"
+						type="button"
+						variant={isActive ? "default" : "outline"}
+					>
+						{status.label}
+						{count === undefined ? null : (
+							<span className="font-mono font-semibold tabular-nums">
+								{count}
+							</span>
+						)}
+					</Button>
+				);
+			})}
 		</div>
 	</div>
 );

--- a/apps/web/src/features/orders/components/queue-status-tabs.tsx
+++ b/apps/web/src/features/orders/components/queue-status-tabs.tsx
@@ -1,3 +1,4 @@
+import { CHIP_STRIP_ROW, ChipStripScroller } from "@/components/chip-strip";
 import { Button } from "@/components/ui/button";
 import type { OrderServiceQueueCounts } from "@/lib/api";
 import {
@@ -27,17 +28,8 @@ export const QueueStatusTabs = ({
 	counts,
 	onValueChange,
 }: QueueStatusTabsProps) => (
-	// Six statuses rarely fit, so the strip scrolls. The mask fades the last chip
-	// out instead of slicing it mid-word, which read as a broken layout rather
-	// than as "there is more this way". Unconditional, not phone-only: whether
-	// the strip overflows depends on the container — the expanded sidebar cuts it
-	// at 1024 too — and when it does fit the fade lands on empty padding.
-	<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
-		<div
-			aria-label="Queue status"
-			className="flex min-w-max gap-2 px-1 pr-8"
-			role="tablist"
-		>
+	<ChipStripScroller>
+		<div aria-label="Queue status" className={CHIP_STRIP_ROW} role="tablist">
 			{STATUS_TAB_ITEMS.map((status) => {
 				const isActive = value === status.value;
 				const count = counts?.[status.value];
@@ -62,5 +54,5 @@ export const QueueStatusTabs = ({
 				);
 			})}
 		</div>
-	</div>
+	</ChipStripScroller>
 );

--- a/apps/web/src/features/orders/hooks/useOrderMutations.ts
+++ b/apps/web/src/features/orders/hooks/useOrderMutations.ts
@@ -23,6 +23,13 @@ export const useRefreshOrder = (orderId: number) => {
 			}),
 			queryClient.invalidateQueries({ queryKey: ["orders"] }),
 			queryClient.invalidateQueries({ queryKey: ["order-counts"] }),
+			// A service status moved from the order detail is the same move the
+			// workshop makes from /queue, so both chip strips have to be dropped —
+			// otherwise whichever screen you did not use keeps yesterday's number.
+			queryClient.invalidateQueries({ queryKey: ["order-service-queue"] }),
+			queryClient.invalidateQueries({
+				queryKey: ["order-service-queue-counts"],
+			}),
 		]);
 	}, [orderId, queryClient]);
 };

--- a/apps/web/src/features/orders/hooks/useOrderMutations.ts
+++ b/apps/web/src/features/orders/hooks/useOrderMutations.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { invalidateOrderQueries } from "@/features/orders/lib/invalidate-order-queries";
 import {
 	cancelOrder,
 	createOrderRefund,
-	queryKeys,
 	type SetOrderServicePricePayload,
 	setOrderServicePrice,
 	type UpdateOrderPaymentPayload,
@@ -17,20 +17,7 @@ export const useRefreshOrder = (orderId: number) => {
 	const queryClient = useQueryClient();
 
 	return useCallback(async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.orderDetail(orderId),
-			}),
-			queryClient.invalidateQueries({ queryKey: ["orders"] }),
-			queryClient.invalidateQueries({ queryKey: ["order-counts"] }),
-			// A service status moved from the order detail is the same move the
-			// workshop makes from /queue, so both chip strips have to be dropped —
-			// otherwise whichever screen you did not use keeps yesterday's number.
-			queryClient.invalidateQueries({ queryKey: ["order-service-queue"] }),
-			queryClient.invalidateQueries({
-				queryKey: ["order-service-queue-counts"],
-			}),
-		]);
+		await invalidateOrderQueries(queryClient, orderId);
 	}, [orderId, queryClient]);
 };
 

--- a/apps/web/src/features/orders/hooks/useOrderMutations.ts
+++ b/apps/web/src/features/orders/hooks/useOrderMutations.ts
@@ -22,6 +22,7 @@ export const useRefreshOrder = (orderId: number) => {
 				queryKey: queryKeys.orderDetail(orderId),
 			}),
 			queryClient.invalidateQueries({ queryKey: ["orders"] }),
+			queryClient.invalidateQueries({ queryKey: ["order-counts"] }),
 		]);
 	}, [orderId, queryClient]);
 };

--- a/apps/web/src/features/orders/lib/create-order-workflow.ts
+++ b/apps/web/src/features/orders/lib/create-order-workflow.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { invalidateOrderQueries } from "@/features/orders/lib/invalidate-order-queries";
 
 type HandleCreatedOrderSuccessOptions = {
 	created: unknown;
@@ -32,7 +33,10 @@ export async function handleCreatedOrderSuccess({
 	const orderId = getCreatedOrderId(created);
 
 	await Promise.all([
-		queryClient.invalidateQueries({ queryKey: ["orders"] }),
+		// A new order is an item on the workshop floor and a row in every count
+		// the /orders pills show, so All and Today are wrong the moment this
+		// returns unless the whole set is dropped.
+		invalidateOrderQueries(queryClient),
 		// A redeemed voucher / bumped listed-campaign redeemed_count changes what's
 		// eligible at the next checkout — refresh campaigns so a capped promo that
 		// just hit its limit stops showing as selectable and the voucher-codes

--- a/apps/web/src/features/orders/lib/invalidate-order-queries.ts
+++ b/apps/web/src/features/orders/lib/invalidate-order-queries.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/api";
+
+// One list for every write that moves an Order or one of its Items, because the
+// same move lands on four screens: the order itself, the /orders list and its
+// pills, and the /queue strip and its chips. A counter recording a pickup and a
+// worker finishing a shoe each leave the other screen's number wrong, so the
+// site that forgets a key is the bug — there must only be one site.
+export const invalidateOrderQueries = (
+	queryClient: QueryClient,
+	orderId?: number,
+) =>
+	Promise.all([
+		orderId === undefined
+			? undefined
+			: queryClient.invalidateQueries({
+					queryKey: queryKeys.orderDetail(orderId),
+				}),
+		queryClient.invalidateQueries({ queryKey: ["orders"] }),
+		queryClient.invalidateQueries({ queryKey: ["order-counts"] }),
+		queryClient.invalidateQueries({ queryKey: ["order-service-queue"] }),
+		queryClient.invalidateQueries({
+			queryKey: ["order-service-queue-counts"],
+		}),
+	]);

--- a/apps/web/src/features/transactions/components/cart-lines.tsx
+++ b/apps/web/src/features/transactions/components/cart-lines.tsx
@@ -1,16 +1,9 @@
 import { XIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
-import {
-	getServiceLinePrice,
-	type ServiceCartDisplayLine,
-} from "@/features/transactions/cart/cart";
+import { getServiceLinePrice } from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
+import { getOrderServiceItemDescriptors } from "@/lib/order-service-item-details";
 import { formatMoney, parseMoney } from "@/shared/money";
-
-const getServiceDescriptors = (line: ServiceCartDisplayLine): string[] =>
-	[line.brand, line.color, line.model, line.size]
-		.map((value) => value.trim())
-		.filter(Boolean);
 
 // Shared by the standing rail and the phone mini bar. Reads the cart itself
 // rather than taking rows as props, so the two surfaces cannot show different
@@ -47,7 +40,7 @@ export const CartLines = () => {
 			))}
 
 			{serviceRows.map((line, index) => {
-				const descriptors = getServiceDescriptors(line);
+				const descriptors = getOrderServiceItemDescriptors(line);
 				const isUnpriced =
 					line.service.price === null && getServiceLinePrice(line) <= 0;
 
@@ -67,10 +60,10 @@ export const CartLines = () => {
 							</span>
 							<span className="flex flex-wrap gap-1">
 								{descriptors.length > 0 ? (
-									descriptors.map((value) => (
+									descriptors.map((value, valueIndex) => (
 										<span
 											className="border border-border/70 bg-background px-1.5 font-mono text-[10px] text-muted-foreground"
-											key={value}
+											key={`${valueIndex}-${value}`}
 										>
 											{value}
 										</span>

--- a/apps/web/src/features/transactions/components/cart-lines.tsx
+++ b/apps/web/src/features/transactions/components/cart-lines.tsx
@@ -1,0 +1,104 @@
+import { XIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import {
+	getServiceLinePrice,
+	type ServiceCartDisplayLine,
+} from "@/features/transactions/cart/cart";
+import { useCart } from "@/features/transactions/cart/useCart";
+import { formatMoney, parseMoney } from "@/shared/money";
+
+const getServiceDescriptors = (line: ServiceCartDisplayLine): string[] =>
+	[line.brand, line.color, line.model, line.size]
+		.map((value) => value.trim())
+		.filter(Boolean);
+
+// Shared by the standing rail and the phone mini bar. Reads the cart itself
+// rather than taking rows as props, so the two surfaces cannot show different
+// lines or remove them differently. Callers gate on count and own the empty
+// state — this renders nothing useful for an empty cart.
+export const CartLines = () => {
+	const { productRows, serviceRows, removeProduct, removeService } = useCart();
+
+	return (
+		<ul className="grid gap-2">
+			{productRows.map((line) => (
+				<li
+					className="flex items-center gap-2 border-border/70 border-b border-dashed pb-2 last:border-b-0"
+					key={`product-${line.id}`}
+				>
+					<span className="flex min-w-0 flex-1 items-baseline justify-between gap-2">
+						<span className="min-w-0 truncate font-medium text-xs">
+							{line.qty} × {line.product.name}
+						</span>
+						<span className="shrink-0 font-mono text-[11px] tabular-nums">
+							{formatMoney(parseMoney(line.product.price) * line.qty)}
+						</span>
+					</span>
+					<Button
+						aria-label={`Remove ${line.product.name}`}
+						className="size-11 shrink-0"
+						icon={<XIcon className="size-4" />}
+						onClick={() => removeProduct(line.id)}
+						size="icon-xs"
+						type="button"
+						variant="outline"
+					/>
+				</li>
+			))}
+
+			{serviceRows.map((line, index) => {
+				const descriptors = getServiceDescriptors(line);
+				const isUnpriced =
+					line.service.price === null && getServiceLinePrice(line) <= 0;
+
+				return (
+					<li
+						className="flex items-center gap-2 border-border/70 border-b border-dashed pb-2 last:border-b-0"
+						key={line.line_id}
+					>
+						<span className="grid min-w-0 flex-1 gap-1">
+							<span className="flex items-baseline justify-between gap-2">
+								<span className="min-w-0 truncate font-medium text-xs">
+									{index + 1} · {line.service.name}
+								</span>
+								<span className="shrink-0 font-mono text-[11px] tabular-nums">
+									{formatMoney(getServiceLinePrice(line))}
+								</span>
+							</span>
+							<span className="flex flex-wrap gap-1">
+								{descriptors.length > 0 ? (
+									descriptors.map((value) => (
+										<span
+											className="border border-border/70 bg-background px-1.5 font-mono text-[10px] text-muted-foreground"
+											key={value}
+										>
+											{value}
+										</span>
+									))
+								) : (
+									<span className="font-mono text-[10px] text-muted-foreground">
+										No detail yet
+									</span>
+								)}
+								{isUnpriced ? (
+									<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
+										No price yet
+									</span>
+								) : null}
+							</span>
+						</span>
+						<Button
+							aria-label={`Remove ${line.service.name}`}
+							className="size-11 shrink-0"
+							icon={<XIcon className="size-4" />}
+							onClick={() => removeService(line.line_id)}
+							size="icon-xs"
+							type="button"
+							variant="outline"
+						/>
+					</li>
+				);
+			})}
+		</ul>
+	);
+};

--- a/apps/web/src/features/transactions/components/cart-mini-bar.tsx
+++ b/apps/web/src/features/transactions/components/cart-mini-bar.tsx
@@ -6,7 +6,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useCart } from "@/features/transactions/cart/useCart";
 import { CartLines } from "@/features/transactions/components/cart-lines";
-import { formatIDRCurrency } from "@/shared/utils";
+import { formatMoney } from "@/shared/money";
 
 interface CartMiniBarProps {
 	hasStore: boolean;
@@ -64,9 +64,7 @@ export const CartMiniBar = ({ hasStore, onOpen }: CartMiniBarProps) => {
 					</span>
 				</span>
 				<span className="flex items-center gap-2">
-					<span className="font-semibold">
-						{formatIDRCurrency(String(subtotal))}
-					</span>
+					<span className="font-semibold">{formatMoney(subtotal)}</span>
 					<CaretUpIcon className="size-4" />
 				</span>
 			</Button>

--- a/apps/web/src/features/transactions/components/cart-mini-bar.tsx
+++ b/apps/web/src/features/transactions/components/cart-mini-bar.tsx
@@ -19,7 +19,7 @@ export const CartMiniBar = ({ hasStore, onOpen }: CartMiniBarProps) => {
 	// transparent hint let service cards show through the one sentence that
 	// explains a blocked checkout.
 	return (
-		<div className="sticky bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-40 grid gap-1 border-border/70 border-t bg-background px-1 pt-2 pb-1">
+		<div className="sticky bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-40 grid gap-1 border-border/70 border-t bg-background px-1 pt-2 pb-1 xl:hidden">
 			{/* Says up front why the bar won't open, so the block isn't a dead-end
 			    tap — this hint is the only in-place explanation the cashier gets. */}
 			{hasStore ? null : (

--- a/apps/web/src/features/transactions/components/cart-mini-bar.tsx
+++ b/apps/web/src/features/transactions/components/cart-mini-bar.tsx
@@ -15,8 +15,11 @@ export const CartMiniBar = ({ hasStore, onOpen }: CartMiniBarProps) => {
 		return null;
 	}
 
+	// Opaque surface, not a bare stack: the catalog scrolls underneath, and a
+	// transparent hint let service cards show through the one sentence that
+	// explains a blocked checkout.
 	return (
-		<div className="sticky bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-40 grid gap-1 py-1">
+		<div className="sticky bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-40 grid gap-1 border-border/70 border-t bg-background px-1 pt-2 pb-1">
 			{/* Says up front why the bar won't open, so the block isn't a dead-end
 			    tap — this hint is the only in-place explanation the cashier gets. */}
 			{hasStore ? null : (

--- a/apps/web/src/features/transactions/components/cart-mini-bar.tsx
+++ b/apps/web/src/features/transactions/components/cart-mini-bar.tsx
@@ -15,9 +15,8 @@ export const CartMiniBar = ({ hasStore, onOpen }: CartMiniBarProps) => {
 		return null;
 	}
 
-	// Opaque surface, not a bare stack: the catalog scrolls underneath, and a
-	// transparent hint let service cards show through the one sentence that
-	// explains a blocked checkout.
+	// Keep the surface opaque: the catalog scrolls underneath, and a transparent
+	// bar let service cards show through the hint text.
 	return (
 		<div className="sticky bottom-[calc(env(safe-area-inset-bottom)+0.5rem)] z-40 grid gap-1 border-border/70 border-t bg-background px-1 pt-2 pb-1 xl:hidden">
 			{/* Says up front why the bar won't open, so the block isn't a dead-end

--- a/apps/web/src/features/transactions/components/cart-mini-bar.tsx
+++ b/apps/web/src/features/transactions/components/cart-mini-bar.tsx
@@ -1,6 +1,11 @@
-import { CaretUpIcon, ShoppingCartIcon } from "@phosphor-icons/react";
+import {
+	CaretDownIcon,
+	CaretUpIcon,
+	ShoppingCartIcon,
+} from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { useCart } from "@/features/transactions/cart/useCart";
+import { CartLines } from "@/features/transactions/components/cart-lines";
 import { formatIDRCurrency } from "@/shared/utils";
 
 interface CartMiniBarProps {
@@ -26,11 +31,31 @@ export const CartMiniBar = ({ hasStore, onOpen }: CartMiniBarProps) => {
 					Select a store to check out.
 				</p>
 			)}
+
+			{/* Closed by default. Without it, dropping a mis-tapped line means keying
+			    a customer name and phone first, because the lines only exist on step
+			    two of the checkout. Capped height so an open cart cannot bury the
+			    catalog the cashier is still tapping. */}
+			<details className="group border border-border/70 bg-background">
+				<summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 hover:bg-muted/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
+					<span className="font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]">
+						Cart
+					</span>
+					<CaretDownIcon
+						aria-hidden="true"
+						className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+					/>
+				</summary>
+				<div className="max-h-[40dvh] overflow-y-auto border-border/70 border-t px-3 py-2">
+					<CartLines />
+				</div>
+			</details>
+
 			<Button
-				type="button"
-				size="lg"
 				className="h-14 w-full justify-between gap-3"
 				onClick={onOpen}
+				size="lg"
+				type="button"
 			>
 				<span className="flex items-center gap-2">
 					<ShoppingCartIcon className="size-5" />

--- a/apps/web/src/features/transactions/components/cart-rail.tsx
+++ b/apps/web/src/features/transactions/components/cart-rail.tsx
@@ -7,7 +7,6 @@ import {
 import { useCart } from "@/features/transactions/cart/useCart";
 import { formatMoney, parseMoney } from "@/shared/money";
 
-// The descriptors the cashier keyed, in the order they read them off the item.
 const getServiceDescriptors = (line: ServiceCartDisplayLine): string[] =>
 	[line.brand, line.color, line.model, line.size]
 		.map((value) => value.trim())
@@ -18,10 +17,6 @@ interface CartRailProps {
 	onCheckout: () => void;
 }
 
-// Standing cart, laptop only. Below xl the bottom sheet is the right pattern and
-// stays; at 1280+ the catalog and the cart could never be on screen together, so
-// adding a forgotten item meant closing the sheet and losing your place in a
-// 40-card grid. The running total and the thing being sold belong in one glance.
 export const CartRail = ({ hasStore, onCheckout }: CartRailProps) => {
 	const { productRows, serviceRows, subtotal, count } = useCart();
 
@@ -109,9 +104,8 @@ export const CartRail = ({ hasStore, onCheckout }: CartRailProps) => {
 			</div>
 
 			<div className="grid gap-2 border-border/70 border-t px-3 py-2.5">
-				{/* Subtotal, not Total: campaigns, vouchers and any manual discount are
-				    chosen in the checkout, so the number here is pre-discount and the
-				    footer's Total is the one the customer pays. */}
+				{/* Subtotal, never Total: discounts are chosen in the checkout, so this
+				    number is pre-discount and is not what the customer pays. */}
 				<div className="flex items-baseline justify-between gap-2">
 					<span className="font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]">
 						Subtotal

--- a/apps/web/src/features/transactions/components/cart-rail.tsx
+++ b/apps/web/src/features/transactions/components/cart-rail.tsx
@@ -1,16 +1,8 @@
 import { ShoppingCartIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
-import {
-	getServiceLinePrice,
-	type ServiceCartDisplayLine,
-} from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
-import { formatMoney, parseMoney } from "@/shared/money";
-
-const getServiceDescriptors = (line: ServiceCartDisplayLine): string[] =>
-	[line.brand, line.color, line.model, line.size]
-		.map((value) => value.trim())
-		.filter(Boolean);
+import { CartLines } from "@/features/transactions/components/cart-lines";
+import { formatMoney } from "@/shared/money";
 
 interface CartRailProps {
 	hasStore: boolean;
@@ -18,7 +10,7 @@ interface CartRailProps {
 }
 
 export const CartRail = ({ hasStore, onCheckout }: CartRailProps) => {
-	const { productRows, serviceRows, subtotal, count } = useCart();
+	const { subtotal, count } = useCart();
 
 	return (
 		<aside
@@ -40,66 +32,9 @@ export const CartRail = ({ hasStore, onCheckout }: CartRailProps) => {
 						Tap a service to start an order.
 					</p>
 				) : (
-					<ul className="grid gap-2 p-3">
-						{productRows.map((line) => (
-							<li
-								className="grid gap-0.5 border-border/70 border-b border-dashed pb-2 last:border-b-0"
-								key={`product-${line.id}`}
-							>
-								<div className="flex items-baseline justify-between gap-2">
-									<span className="min-w-0 truncate font-medium text-xs">
-										{line.qty} × {line.product.name}
-									</span>
-									<span className="shrink-0 font-mono text-[11px] tabular-nums">
-										{formatMoney(parseMoney(line.product.price) * line.qty)}
-									</span>
-								</div>
-							</li>
-						))}
-
-						{serviceRows.map((line, index) => {
-							const descriptors = getServiceDescriptors(line);
-							const isUnpriced =
-								line.service.price === null && getServiceLinePrice(line) <= 0;
-
-							return (
-								<li
-									className="grid gap-1 border-border/70 border-b border-dashed pb-2 last:border-b-0"
-									key={line.line_id}
-								>
-									<div className="flex items-baseline justify-between gap-2">
-										<span className="min-w-0 truncate font-medium text-xs">
-											{index + 1} · {line.service.name}
-										</span>
-										<span className="shrink-0 font-mono text-[11px] tabular-nums">
-											{formatMoney(getServiceLinePrice(line))}
-										</span>
-									</div>
-									<div className="flex flex-wrap gap-1">
-										{descriptors.length > 0 ? (
-											descriptors.map((value) => (
-												<span
-													className="border border-border/70 bg-background px-1.5 font-mono text-[10px] text-muted-foreground"
-													key={value}
-												>
-													{value}
-												</span>
-											))
-										) : (
-											<span className="font-mono text-[10px] text-muted-foreground">
-												No detail yet
-											</span>
-										)}
-										{isUnpriced ? (
-											<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
-												No price yet
-											</span>
-										) : null}
-									</div>
-								</li>
-							);
-						})}
-					</ul>
+					<div className="p-3">
+						<CartLines />
+					</div>
 				)}
 			</div>
 

--- a/apps/web/src/features/transactions/components/cart-rail.tsx
+++ b/apps/web/src/features/transactions/components/cart-rail.tsx
@@ -1,0 +1,140 @@
+import { ShoppingCartIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import {
+	getServiceLinePrice,
+	type ServiceCartDisplayLine,
+} from "@/features/transactions/cart/cart";
+import { useCart } from "@/features/transactions/cart/useCart";
+import { formatMoney, parseMoney } from "@/shared/money";
+
+// The descriptors the cashier keyed, in the order they read them off the item.
+const getServiceDescriptors = (line: ServiceCartDisplayLine): string[] =>
+	[line.brand, line.color, line.model, line.size]
+		.map((value) => value.trim())
+		.filter(Boolean);
+
+interface CartRailProps {
+	hasStore: boolean;
+	onCheckout: () => void;
+}
+
+// Standing cart, laptop only. Below xl the bottom sheet is the right pattern and
+// stays; at 1280+ the catalog and the cart could never be on screen together, so
+// adding a forgotten item meant closing the sheet and losing your place in a
+// 40-card grid. The running total and the thing being sold belong in one glance.
+export const CartRail = ({ hasStore, onCheckout }: CartRailProps) => {
+	const { productRows, serviceRows, subtotal, count } = useCart();
+
+	return (
+		<aside
+			aria-label="Cart"
+			className="sticky top-0 hidden max-h-dvh grid-rows-[auto_1fr_auto] border border-border/70 bg-muted/20 xl:grid"
+		>
+			<div className="flex items-baseline justify-between gap-2 border-border/70 border-b px-3 py-2">
+				<span className="font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]">
+					Cart
+				</span>
+				<span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+					{count} {count === 1 ? "item" : "items"}
+				</span>
+			</div>
+
+			<div className="min-h-0 overflow-y-auto">
+				{count === 0 ? (
+					<p className="px-3 py-8 text-center text-muted-foreground text-xs">
+						Tap a service to start an order.
+					</p>
+				) : (
+					<ul className="grid gap-2 p-3">
+						{productRows.map((line) => (
+							<li
+								className="grid gap-0.5 border-border/70 border-b border-dashed pb-2 last:border-b-0"
+								key={`product-${line.id}`}
+							>
+								<div className="flex items-baseline justify-between gap-2">
+									<span className="min-w-0 truncate font-medium text-xs">
+										{line.qty} × {line.product.name}
+									</span>
+									<span className="shrink-0 font-mono text-[11px] tabular-nums">
+										{formatMoney(parseMoney(line.product.price) * line.qty)}
+									</span>
+								</div>
+							</li>
+						))}
+
+						{serviceRows.map((line, index) => {
+							const descriptors = getServiceDescriptors(line);
+							const isUnpriced =
+								line.service.price === null && getServiceLinePrice(line) <= 0;
+
+							return (
+								<li
+									className="grid gap-1 border-border/70 border-b border-dashed pb-2 last:border-b-0"
+									key={line.line_id}
+								>
+									<div className="flex items-baseline justify-between gap-2">
+										<span className="min-w-0 truncate font-medium text-xs">
+											{index + 1} · {line.service.name}
+										</span>
+										<span className="shrink-0 font-mono text-[11px] tabular-nums">
+											{formatMoney(getServiceLinePrice(line))}
+										</span>
+									</div>
+									<div className="flex flex-wrap gap-1">
+										{descriptors.length > 0 ? (
+											descriptors.map((value) => (
+												<span
+													className="border border-border/70 bg-background px-1.5 font-mono text-[10px] text-muted-foreground"
+													key={value}
+												>
+													{value}
+												</span>
+											))
+										) : (
+											<span className="font-mono text-[10px] text-muted-foreground">
+												No detail yet
+											</span>
+										)}
+										{isUnpriced ? (
+											<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
+												No price yet
+											</span>
+										) : null}
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
+
+			<div className="grid gap-2 border-border/70 border-t px-3 py-2.5">
+				{/* Subtotal, not Total: campaigns, vouchers and any manual discount are
+				    chosen in the checkout, so the number here is pre-discount and the
+				    footer's Total is the one the customer pays. */}
+				<div className="flex items-baseline justify-between gap-2">
+					<span className="font-mono text-[10px] text-muted-foreground uppercase tracking-[0.18em]">
+						Subtotal
+					</span>
+					<span className="font-mono font-semibold text-sm tabular-nums">
+						{formatMoney(subtotal)}
+					</span>
+				</div>
+				{hasStore ? null : (
+					<p className="text-muted-foreground text-xs">
+						Select a store to check out.
+					</p>
+				)}
+				<Button
+					className="h-11 w-full"
+					disabled={count === 0}
+					icon={<ShoppingCartIcon className="size-4" />}
+					onClick={onCheckout}
+					type="button"
+				>
+					Check out
+				</Button>
+			</div>
+		</aside>
+	);
+};

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -157,7 +157,6 @@ export const CheckoutItemsStep = () => {
 
 				{serviceRows.map((line, index) => (
 					<CheckoutServiceLineRow
-						categoryName={getEntityCategoryName(line.service, categoryMap)}
 						itemNumber={index + 1}
 						key={line.line_id}
 						line={line}
@@ -190,7 +189,6 @@ export const CheckoutItemsStep = () => {
 interface CheckoutServiceLineRowProps {
 	line: ServiceCartDisplayLine;
 	itemNumber: number;
-	categoryName: string;
 	onRemove: (lineId: string) => void;
 	onFieldChange: (
 		lineId: string,
@@ -202,7 +200,6 @@ interface CheckoutServiceLineRowProps {
 const CheckoutServiceLineRow = ({
 	line,
 	itemNumber,
-	categoryName,
 	onRemove,
 	onFieldChange,
 }: CheckoutServiceLineRowProps) => {
@@ -219,13 +216,11 @@ const CheckoutServiceLineRow = ({
 					{itemNumber}
 				</span>
 				<span className="grid min-w-0 flex-1 gap-1">
-					<span className="flex min-w-0 items-baseline gap-1.5">
-						<span className="truncate text-sm font-medium">
-							{line.service.name}
-						</span>
-						<span className="shrink-0 text-muted-foreground text-xs">
-							{categoryName}
-						</span>
+					{/* Wraps rather than truncates: service names run to 30+ characters
+					    and the price column leaves this one ~130px on a phone, so
+					    truncating cut every line down to "Deep Clea…". */}
+					<span className="line-clamp-2 text-sm font-medium">
+						{line.service.name}
 					</span>
 					<span className="flex flex-wrap gap-1">
 						{descriptors.length > 0 ? (

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
 import { getEntityCategoryName } from "@/features/transactions/lib/transactions";
+import { getOrderServiceItemDescriptors } from "@/lib/order-service-item-details";
 import { categoriesQueryOptions } from "@/lib/query-options";
 import { cn } from "@/lib/utils";
 import { formatMoney, parseMoney } from "@/shared/money";
@@ -203,58 +204,101 @@ const CheckoutServiceLineRow = ({
 	onRemove,
 	onFieldChange,
 }: CheckoutServiceLineRowProps) => {
-	const descriptors = [line.brand, line.color, line.model, line.size]
-		.map((value) => value.trim())
-		.filter(Boolean);
+	const descriptors = getOrderServiceItemDescriptors(line);
 	const isUnpriced =
 		line.service.price === null && getServiceLinePrice(line) <= 0;
 
 	return (
-		<details className="group relative border border-border/70">
-			<summary className="flex cursor-pointer list-none items-start gap-3 p-3 hover:bg-muted/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
-				<span className="mt-0.5 shrink-0 font-mono text-[11px] text-muted-foreground tabular-nums">
-					{itemNumber}
-				</span>
-				<span className="grid min-w-0 flex-1 gap-1">
-					{/* Wraps rather than truncates: service names run to 30+ characters
-					    and the price column leaves this one ~130px on a phone, so
-					    truncating cut every line down to "Deep Clea…". */}
-					<span className="line-clamp-2 text-sm font-medium">
-						{line.service.name}
+		// Remove sits outside <details>, not merely outside <summary>: a closed
+		// disclosure hides every non-summary child, so a button parked there is
+		// unreachable until the row is expanded — and rows start collapsed.
+		<div className="relative">
+			<details className="group border border-border/70">
+				<summary className="flex cursor-pointer list-none items-start gap-3 p-3 hover:bg-muted/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
+					<span className="mt-0.5 shrink-0 font-mono text-[11px] text-muted-foreground tabular-nums">
+						{itemNumber}
 					</span>
-					<span className="flex flex-wrap gap-1">
-						{descriptors.length > 0 ? (
-							descriptors.map((value) => (
-								<span
-									className="border border-border/70 px-1.5 font-mono text-[10px] text-muted-foreground"
-									key={value}
-								>
-									{value}
+					<span className="grid min-w-0 flex-1 gap-1">
+						{/* Wraps rather than truncates: service names run to 30+ characters
+						    and the price column leaves this one ~130px on a phone, so
+						    truncating cut every line down to "Deep Clea…". */}
+						<span className="line-clamp-2 text-sm font-medium">
+							{line.service.name}
+						</span>
+						<span className="flex flex-wrap gap-1">
+							{descriptors.length > 0 ? (
+								descriptors.map((value, valueIndex) => (
+									<span
+										className="border border-border/70 px-1.5 font-mono text-[10px] text-muted-foreground"
+										key={`${valueIndex}-${value}`}
+									>
+										{value}
+									</span>
+								))
+							) : (
+								<span className="font-mono text-[10px] text-muted-foreground">
+									Add detail
 								</span>
-							))
-						) : (
-							<span className="font-mono text-[10px] text-muted-foreground">
-								Add detail
-							</span>
-						)}
-						{isUnpriced ? (
-							<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
-								No price yet
-							</span>
-						) : null}
+							)}
+							{isUnpriced ? (
+								<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
+									No price yet
+								</span>
+							) : null}
+						</span>
 					</span>
-				</span>
-				<span className="mt-0.5 shrink-0 pr-11 font-mono text-sm font-semibold tabular-nums">
-					{formatMoney(getServiceLinePrice(line))}
-				</span>
-				<CaretDownIcon
-					aria-hidden="true"
-					className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
-				/>
-			</summary>
+					<span className="mt-0.5 shrink-0 pr-11 font-mono text-sm font-semibold tabular-nums">
+						{formatMoney(getServiceLinePrice(line))}
+					</span>
+					<CaretDownIcon
+						aria-hidden="true"
+						className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+					/>
+				</summary>
 
-			{/* Outside <summary> so the row keeps one activation target — a button
-			    nested in a summary toggles the disclosure on its way through. */}
+				<div className="grid gap-3 border-border/70 border-t p-3">
+					<div className="grid gap-3 sm:grid-cols-2">
+						{SERVICE_FIELDS.map((field) => (
+							<Field className={field.className} key={field.key}>
+								<FieldLabel htmlFor={`service-${field.key}-${line.line_id}`}>
+									{field.label}
+								</FieldLabel>
+								<Input
+									className="h-11"
+									id={`service-${field.key}-${line.line_id}`}
+									onChange={(event) =>
+										onFieldChange(line.line_id, field.key, event.target.value)
+									}
+									placeholder={field.placeholder}
+									value={line[field.key]}
+								/>
+							</Field>
+						))}
+					</div>
+					{line.service.price === null ? (
+						// Blank is a valid answer here, not a missing one: a Repair is priced
+						// after inspection (ADR-0018).
+						<Field>
+							<FieldLabel htmlFor={`service-price-${line.line_id}`}>
+								Price
+							</FieldLabel>
+							<CurrencyInput
+								id={`service-price-${line.line_id}`}
+								onValueChange={(value) =>
+									onFieldChange(line.line_id, "price", value)
+								}
+								value={line.price}
+							/>
+							<FieldDescription>
+								{line.price.trim() === ""
+									? "No price yet — payment waits until this line is priced after inspection."
+									: "Agreed price. Can be corrected until the order is paid."}
+							</FieldDescription>
+						</Field>
+					) : null}
+				</div>
+			</details>
+
 			<Button
 				aria-label={`Remove ${line.service.name}`}
 				className="absolute top-2 right-8 size-11"
@@ -264,49 +308,7 @@ const CheckoutServiceLineRow = ({
 				type="button"
 				variant="outline"
 			/>
-
-			<div className="grid gap-3 border-border/70 border-t p-3">
-				<div className="grid gap-3 sm:grid-cols-2">
-					{SERVICE_FIELDS.map((field) => (
-						<Field className={field.className} key={field.key}>
-							<FieldLabel htmlFor={`service-${field.key}-${line.line_id}`}>
-								{field.label}
-							</FieldLabel>
-							<Input
-								className="h-11"
-								id={`service-${field.key}-${line.line_id}`}
-								onChange={(event) =>
-									onFieldChange(line.line_id, field.key, event.target.value)
-								}
-								placeholder={field.placeholder}
-								value={line[field.key]}
-							/>
-						</Field>
-					))}
-				</div>
-				{line.service.price === null ? (
-					// Blank is a valid answer here, not a missing one: a Repair is priced
-					// after inspection (ADR-0018).
-					<Field>
-						<FieldLabel htmlFor={`service-price-${line.line_id}`}>
-							Price
-						</FieldLabel>
-						<CurrencyInput
-							id={`service-price-${line.line_id}`}
-							onValueChange={(value) =>
-								onFieldChange(line.line_id, "price", value)
-							}
-							value={line.price}
-						/>
-						<FieldDescription>
-							{line.price.trim() === ""
-								? "No price yet — payment waits until this line is priced after inspection."
-								: "Agreed price. Can be corrected until the order is paid."}
-						</FieldDescription>
-					</Field>
-				) : null}
-			</div>
-		</details>
+		</div>
 	);
 };
 

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -1,5 +1,6 @@
 import {
 	CameraIcon,
+	CaretDownIcon,
 	CheckCircleIcon,
 	EyeIcon,
 	WarningIcon,
@@ -22,6 +23,7 @@ import { PhotoLightbox } from "@/features/orders/components/photo-lightbox";
 import { SinglePhotoCaptureDialog } from "@/features/orders/components/photo-upload-dialog";
 import {
 	getServiceLinePrice,
+	type ServiceCartDisplayLine,
 	type TransactionDraftValues,
 } from "@/features/transactions/cart/cart";
 import { useCart } from "@/features/transactions/cart/useCart";
@@ -76,6 +78,11 @@ export const CheckoutItemsStep = () => {
 
 	return (
 		<div className="grid gap-5">
+			{/* Above the items, not below them: this is the control that satisfies
+			    Continue's "Add a drop-off photo" gate, and with three items expanded it
+			    used to sit ~1000px further down with nothing pointing at it. */}
+			<CheckoutDropoffPhotoField />
+
 			<div className="grid gap-3">
 				{productRows.length === 0 && serviceRows.length === 0 ? (
 					<div className="border border-dashed border-border p-4 text-sm text-muted-foreground">
@@ -151,78 +158,15 @@ export const CheckoutItemsStep = () => {
 					</div>
 				))}
 
-				{serviceRows.map((line) => (
-					<div
-						className="grid gap-3 border border-border/70 p-3"
+				{serviceRows.map((line, index) => (
+					<CheckoutServiceLineRow
+						categoryName={getEntityCategoryName(line.service, categoryMap)}
+						itemNumber={index + 1}
 						key={line.line_id}
-					>
-						<div className="flex items-start justify-between gap-3">
-							<div>
-								<p className="text-sm font-medium">{line.service.name}</p>
-								<p className="text-xs text-muted-foreground">
-									Service | {getEntityCategoryName(line.service, categoryMap)}
-								</p>
-							</div>
-							<Button
-								aria-label={`Remove ${line.service.name}`}
-								className="size-11"
-								icon={<XIcon className="size-4" />}
-								onClick={() => removeService(line.line_id)}
-								size="icon-xs"
-								type="button"
-								variant="outline"
-							/>
-						</div>
-						<div className="grid gap-3 sm:grid-cols-2">
-							{SERVICE_FIELDS.map((field) => (
-								<Field className={field.className} key={field.key}>
-									<FieldLabel htmlFor={`service-${field.key}-${line.line_id}`}>
-										{field.label}
-									</FieldLabel>
-									<Input
-										className="h-11"
-										id={`service-${field.key}-${line.line_id}`}
-										onChange={(event) =>
-											updateServiceField(
-												line.line_id,
-												field.key,
-												event.target.value,
-											)
-										}
-										placeholder={field.placeholder}
-										value={line[field.key]}
-									/>
-								</Field>
-							))}
-						</div>
-						{line.service.price === null ? (
-							// No-list-price Service (Repair, ADR-0018): the price is keyed
-							// here when the customer already agreed to a number, and left
-							// blank when the workshop still has to inspect the item.
-							<Field>
-								<FieldLabel htmlFor={`service-price-${line.line_id}`}>
-									Price
-								</FieldLabel>
-								<CurrencyInput
-									id={`service-price-${line.line_id}`}
-									onValueChange={(value) =>
-										updateServiceField(line.line_id, "price", value)
-									}
-									value={line.price}
-								/>
-								<FieldDescription>
-									{line.price.trim() === ""
-										? "No price yet — payment waits until this line is priced after inspection."
-										: "Agreed price. Can be corrected until the order is paid."}
-								</FieldDescription>
-							</Field>
-						) : null}
-						<div className="flex items-center justify-end gap-3">
-							<p className="text-sm font-semibold">
-								{formatMoney(getServiceLinePrice(line))}
-							</p>
-						</div>
-					</div>
+						line={line}
+						onFieldChange={updateServiceField}
+						onRemove={removeService}
+					/>
 				))}
 			</div>
 
@@ -242,9 +186,144 @@ export const CheckoutItemsStep = () => {
 					</Field>
 				)}
 			/>
-
-			<CheckoutDropoffPhotoField />
 		</div>
+	);
+};
+
+interface CheckoutServiceLineRowProps {
+	line: ServiceCartDisplayLine;
+	itemNumber: number;
+	categoryName: string;
+	onRemove: (lineId: string) => void;
+	onFieldChange: (
+		lineId: string,
+		field: ServiceFieldSpec["key"] | "price",
+		value: string,
+	) => void;
+}
+
+// One Item, collapsed to a row. Every descriptor here is optional, so five
+// expanded fields per item turned a realistic five-pair intake into 25 empty
+// inputs and pushed the photo control off screen. The summary carries what the
+// cashier reads back to the customer — the number that tells two identical
+// services apart, the descriptors already keyed, and whether the line is still
+// unpriced — and the fields open on demand.
+const CheckoutServiceLineRow = ({
+	line,
+	itemNumber,
+	categoryName,
+	onRemove,
+	onFieldChange,
+}: CheckoutServiceLineRowProps) => {
+	const descriptors = [line.brand, line.color, line.model, line.size]
+		.map((value) => value.trim())
+		.filter(Boolean);
+	// A no-list-price line left blank is normal (ADR-0018), but collapsing the
+	// price field would hide that state — so it becomes a chip.
+	const isUnpriced =
+		line.service.price === null && getServiceLinePrice(line) <= 0;
+
+	return (
+		<details className="group relative border border-border/70">
+			<summary className="flex cursor-pointer list-none items-start gap-3 p-3 hover:bg-muted/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
+				<span className="mt-0.5 shrink-0 font-mono text-[11px] text-muted-foreground tabular-nums">
+					{itemNumber}
+				</span>
+				<span className="grid min-w-0 flex-1 gap-1">
+					<span className="flex min-w-0 items-baseline gap-1.5">
+						<span className="truncate text-sm font-medium">
+							{line.service.name}
+						</span>
+						<span className="shrink-0 text-muted-foreground text-xs">
+							{categoryName}
+						</span>
+					</span>
+					<span className="flex flex-wrap gap-1">
+						{descriptors.length > 0 ? (
+							descriptors.map((value) => (
+								<span
+									className="border border-border/70 px-1.5 font-mono text-[10px] text-muted-foreground"
+									key={value}
+								>
+									{value}
+								</span>
+							))
+						) : (
+							<span className="font-mono text-[10px] text-muted-foreground">
+								Add detail
+							</span>
+						)}
+						{isUnpriced ? (
+							<span className="border border-warning/50 bg-warning/10 px-1.5 font-mono text-[10px] text-warning">
+								No price yet
+							</span>
+						) : null}
+					</span>
+				</span>
+				<span className="mt-0.5 shrink-0 pr-11 font-mono text-sm font-semibold tabular-nums">
+					{formatMoney(getServiceLinePrice(line))}
+				</span>
+				<CaretDownIcon
+					aria-hidden="true"
+					className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+				/>
+			</summary>
+
+			{/* Outside <summary> so the row keeps one activation target — a button
+			    nested in a summary toggles the disclosure on its way through. */}
+			<Button
+				aria-label={`Remove ${line.service.name}`}
+				className="absolute top-2 right-8 size-11"
+				icon={<XIcon className="size-4" />}
+				onClick={() => onRemove(line.line_id)}
+				size="icon-xs"
+				type="button"
+				variant="outline"
+			/>
+
+			<div className="grid gap-3 border-border/70 border-t p-3">
+				<div className="grid gap-3 sm:grid-cols-2">
+					{SERVICE_FIELDS.map((field) => (
+						<Field className={field.className} key={field.key}>
+							<FieldLabel htmlFor={`service-${field.key}-${line.line_id}`}>
+								{field.label}
+							</FieldLabel>
+							<Input
+								className="h-11"
+								id={`service-${field.key}-${line.line_id}`}
+								onChange={(event) =>
+									onFieldChange(line.line_id, field.key, event.target.value)
+								}
+								placeholder={field.placeholder}
+								value={line[field.key]}
+							/>
+						</Field>
+					))}
+				</div>
+				{line.service.price === null ? (
+					// No-list-price Service (Repair, ADR-0018): the price is keyed here
+					// when the customer already agreed to a number, and left blank when
+					// the workshop still has to inspect the item.
+					<Field>
+						<FieldLabel htmlFor={`service-price-${line.line_id}`}>
+							Price
+						</FieldLabel>
+						<CurrencyInput
+							id={`service-price-${line.line_id}`}
+							onValueChange={(value) =>
+								onFieldChange(line.line_id, "price", value)
+							}
+							value={line.price}
+						/>
+						<FieldDescription>
+							{line.price.trim() === ""
+								? "No price yet — payment waits until this line is priced after inspection."
+								: "Agreed price. Can be corrected until the order is paid."}
+						</FieldDescription>
+					</Field>
+				) : null}
+			</div>
+		</details>
 	);
 };
 

--- a/apps/web/src/features/transactions/components/checkout-items-step.tsx
+++ b/apps/web/src/features/transactions/components/checkout-items-step.tsx
@@ -78,9 +78,6 @@ export const CheckoutItemsStep = () => {
 
 	return (
 		<div className="grid gap-5">
-			{/* Above the items, not below them: this is the control that satisfies
-			    Continue's "Add a drop-off photo" gate, and with three items expanded it
-			    used to sit ~1000px further down with nothing pointing at it. */}
 			<CheckoutDropoffPhotoField />
 
 			<div className="grid gap-3">
@@ -202,12 +199,6 @@ interface CheckoutServiceLineRowProps {
 	) => void;
 }
 
-// One Item, collapsed to a row. Every descriptor here is optional, so five
-// expanded fields per item turned a realistic five-pair intake into 25 empty
-// inputs and pushed the photo control off screen. The summary carries what the
-// cashier reads back to the customer — the number that tells two identical
-// services apart, the descriptors already keyed, and whether the line is still
-// unpriced — and the fields open on demand.
 const CheckoutServiceLineRow = ({
 	line,
 	itemNumber,
@@ -218,8 +209,6 @@ const CheckoutServiceLineRow = ({
 	const descriptors = [line.brand, line.color, line.model, line.size]
 		.map((value) => value.trim())
 		.filter(Boolean);
-	// A no-list-price line left blank is normal (ADR-0018), but collapsing the
-	// price field would hide that state — so it becomes a chip.
 	const isUnpriced =
 		line.service.price === null && getServiceLinePrice(line) <= 0;
 
@@ -301,9 +290,8 @@ const CheckoutServiceLineRow = ({
 					))}
 				</div>
 				{line.service.price === null ? (
-					// No-list-price Service (Repair, ADR-0018): the price is keyed here
-					// when the customer already agreed to a number, and left blank when
-					// the workshop still has to inspect the item.
+					// Blank is a valid answer here, not a missing one: a Repair is priced
+					// after inspection (ADR-0018).
 					<Field>
 						<FieldLabel htmlFor={`service-price-${line.line_id}`}>
 							Price

--- a/apps/web/src/features/transactions/components/checkout-stepper.tsx
+++ b/apps/web/src/features/transactions/components/checkout-stepper.tsx
@@ -39,10 +39,8 @@ export const CheckoutStepper = ({
 			{CHECKOUT_STEPS.map((step, index) => {
 				const isCurrent = step.key === current;
 				const isComplete = index < currentIndex;
-				// aria-disabled, not disabled: a `disabled` button drops out of the tab
-				// order, so the one control that could carry "why is this locked" became
-				// unreachable to a keyboard or screen reader. Locked steps stay
-				// focusable and point at the hint; the click is guarded instead.
+				// aria-disabled, never disabled: a `disabled` button leaves the tab order,
+				// taking the hint that explains the lock out of reach. Guard the click.
 				const isLocked = !isStepEnabled(step.key);
 
 				return (

--- a/apps/web/src/features/transactions/components/checkout-stepper.tsx
+++ b/apps/web/src/features/transactions/components/checkout-stepper.tsx
@@ -15,6 +15,7 @@ interface CheckoutStepperProps {
 	current: CheckoutStep;
 	onSelect: (step: CheckoutStep) => void;
 	isStepEnabled: (step: CheckoutStep) => boolean;
+	lockHintId?: string;
 }
 
 // Labeled progress header. New cashiers follow Continue; the labels say what's
@@ -25,27 +26,42 @@ export const CheckoutStepper = ({
 	current,
 	onSelect,
 	isStepEnabled,
+	lockHintId,
 }: CheckoutStepperProps) => {
 	const currentIndex = CHECKOUT_STEPS.findIndex((step) => step.key === current);
 
 	return (
-		<nav aria-label="Checkout steps" className="flex items-stretch gap-1">
+		<nav
+			aria-describedby={lockHintId}
+			aria-label="Checkout steps"
+			className="flex items-stretch gap-1"
+		>
 			{CHECKOUT_STEPS.map((step, index) => {
 				const isCurrent = step.key === current;
 				const isComplete = index < currentIndex;
+				// aria-disabled, not disabled: a `disabled` button drops out of the tab
+				// order, so the one control that could carry "why is this locked" became
+				// unreachable to a keyboard or screen reader. Locked steps stay
+				// focusable and point at the hint; the click is guarded instead.
+				const isLocked = !isStepEnabled(step.key);
 
 				return (
 					<button
 						aria-current={isCurrent ? "step" : undefined}
+						aria-disabled={isLocked || undefined}
 						className={cn(
-							"flex min-h-11 flex-1 items-center justify-center gap-2 border px-2 text-xs font-medium outline-none transition focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40",
+							"flex min-h-11 flex-1 items-center justify-center gap-2 border px-2 text-xs font-medium outline-none transition focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
 							isCurrent
 								? "border-foreground bg-foreground text-background"
 								: "border-border/70 text-foreground/60 hover:bg-muted/40",
+							isLocked && "cursor-not-allowed opacity-40 hover:bg-transparent",
 						)}
-						disabled={!isStepEnabled(step.key)}
 						key={step.key}
-						onClick={() => onSelect(step.key)}
+						onClick={() => {
+							if (!isLocked) {
+								onSelect(step.key);
+							}
+						}}
 						type="button"
 					>
 						<span

--- a/apps/web/src/features/transactions/components/checkout-stepper.tsx
+++ b/apps/web/src/features/transactions/components/checkout-stepper.tsx
@@ -31,11 +31,7 @@ export const CheckoutStepper = ({
 	const currentIndex = CHECKOUT_STEPS.findIndex((step) => step.key === current);
 
 	return (
-		<nav
-			aria-describedby={lockHintId}
-			aria-label="Checkout steps"
-			className="flex items-stretch gap-1"
-		>
+		<nav aria-label="Checkout steps" className="flex items-stretch gap-1">
 			{CHECKOUT_STEPS.map((step, index) => {
 				const isCurrent = step.key === current;
 				const isComplete = index < currentIndex;
@@ -46,6 +42,10 @@ export const CheckoutStepper = ({
 				return (
 					<button
 						aria-current={isCurrent ? "step" : undefined}
+						// On the locked button itself, not on the <nav>: a description
+						// hung off a landmark is not read out when focus lands on a child,
+						// which would leave the lock unexplained again.
+						aria-describedby={isLocked ? lockHintId : undefined}
 						aria-disabled={isLocked || undefined}
 						className={cn(
 							"flex min-h-11 flex-1 items-center justify-center gap-2 border px-2 text-xs font-medium outline-none transition focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -24,6 +24,39 @@ import { cn } from "@/lib/utils";
 import { formatIDRCurrency } from "@/shared/utils";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
+interface CategoryPillProps {
+	label: string;
+	isActive: boolean;
+	onSelect: () => void;
+	count?: number;
+}
+
+const CategoryPill = ({
+	label,
+	isActive,
+	onSelect,
+	count,
+}: CategoryPillProps) => (
+	<button
+		aria-pressed={isActive}
+		className={cn(
+			"flex min-h-8 items-baseline gap-1.5 border px-2 py-1 text-xs outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
+			isActive
+				? "border-foreground bg-foreground text-background"
+				: "border-border/70 text-foreground/70 hover:bg-muted/40",
+		)}
+		onClick={onSelect}
+		type="button"
+	>
+		{label}
+		{count === undefined ? null : (
+			<span className="font-mono font-semibold text-[10px] tabular-nums">
+				{count}
+			</span>
+		)}
+	</button>
+);
+
 export function TransactionsCatalog() {
 	const { isAdmin, visibleStores, handleStoreChange } =
 		useTransactionsPageContext();
@@ -39,6 +72,12 @@ export function TransactionsCatalog() {
 	);
 	const activeServiceCategory = useTransactionsPageStore(
 		(state) => state.activeServiceCategory,
+	);
+	const setActiveProductCategory = useTransactionsPageStore(
+		(state) => state.setActiveProductCategory,
+	);
+	const setActiveServiceCategory = useTransactionsPageStore(
+		(state) => state.setActiveServiceCategory,
 	);
 
 	const categoriesQuery = useQuery(categoriesQueryOptions());
@@ -59,6 +98,7 @@ export function TransactionsCatalog() {
 	const selectedStoreId = useWatch({ control, name: "selectedStoreId" }) ?? "";
 	const storeError = formState.errors.selectedStoreId;
 	const productCart = useWatch({ control, name: "productCart" }) ?? [];
+	const serviceCart = useWatch({ control, name: "serviceCart" }) ?? [];
 
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),
@@ -91,55 +131,72 @@ export function TransactionsCatalog() {
 		return () => window.removeEventListener("keydown", handleKeydown);
 	}, []);
 
-	const filteredProducts = useMemo(
+	const modeItems: (Product | Service)[] =
+		mode === "products" ? products : services;
+	const activeCategory =
+		mode === "products" ? activeProductCategory : activeServiceCategory;
+	const setActiveCategory =
+		mode === "products" ? setActiveProductCategory : setActiveServiceCategory;
+
+	// Counts come from the whole catalog, not the search-narrowed list: a pill set
+	// that shrinks as you type can drop the pill you filtered by, leaving no way
+	// back to All.
+	const categoryOptions = useMemo(() => {
+		const byId = new Map<number, { id: number; name: string; count: number }>();
+		for (const item of modeItems) {
+			const seen = byId.get(item.category_id);
+			if (seen) {
+				seen.count += 1;
+				continue;
+			}
+			byId.set(item.category_id, {
+				id: item.category_id,
+				name: getEntityCategoryName(item, categoryMap),
+				count: 1,
+			});
+		}
+		return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+	}, [categoryMap, modeItems]);
+
+	const activeItems = useMemo(
 		() =>
-			products.filter((product) => {
+			modeItems.filter((item) => {
+				if (activeCategory !== "all" && item.category_id !== activeCategory) {
+					return false;
+				}
+				if (searchValue.length === 0) {
+					return true;
+				}
 				const categoryName = getEntityCategoryName(
-					product,
+					item,
 					categoryMap,
 				).toLowerCase();
-				const matchesCategory =
-					activeProductCategory === "all" ||
-					product.category_id === activeProductCategory;
-				const matchesSearch =
-					searchValue.length === 0 ||
-					product.name.toLowerCase().includes(searchValue) ||
-					(product.description ?? "").toLowerCase().includes(searchValue) ||
-					categoryName.includes(searchValue);
-
-				return matchesCategory && matchesSearch;
+				return (
+					item.name.toLowerCase().includes(searchValue) ||
+					(item.description ?? "").toLowerCase().includes(searchValue) ||
+					categoryName.includes(searchValue)
+				);
 			}),
-		[activeProductCategory, categoryMap, products, searchValue],
-	);
-	const filteredServices = useMemo(
-		() =>
-			services.filter((service) => {
-				const categoryName = getEntityCategoryName(
-					service,
-					categoryMap,
-				).toLowerCase();
-				const matchesCategory =
-					activeServiceCategory === "all" ||
-					service.category_id === activeServiceCategory;
-				const matchesSearch =
-					searchValue.length === 0 ||
-					service.name.toLowerCase().includes(searchValue) ||
-					(service.description ?? "").toLowerCase().includes(searchValue) ||
-					categoryName.includes(searchValue);
-
-				return matchesCategory && matchesSearch;
-			}),
-		[activeServiceCategory, categoryMap, searchValue, services],
+		[activeCategory, categoryMap, modeItems, searchValue],
 	);
 
-	const activeItems = mode === "products" ? filteredProducts : filteredServices;
 	const productCartQtyById = useMemo(
 		() => new Map(productCart.map((line) => [line.id, line.qty])),
 		[productCart],
 	);
 
+	// Each service add creates its own cart line (one line = one Item), so the
+	// card's badge counts lines, not a qty field.
+	const serviceCartCountById = useMemo(() => {
+		const counts = new Map<number, number>();
+		for (const line of serviceCart) {
+			counts.set(line.id, (counts.get(line.id) ?? 0) + 1);
+		}
+		return counts;
+	}, [serviceCart]);
+
 	return (
-		<div className="grid gap-5 self-start xl:sticky xl:top-0">
+		<div className="grid gap-5 self-start">
 			<Card className="border-border/70">
 				<CardContent className="grid gap-4 p-4 sm:p-5">
 					<div className="grid gap-3">
@@ -210,17 +267,44 @@ export function TransactionsCatalog() {
 								</kbd>
 							</div>
 						</Field>
+
+						{/* One strip instead of the same category eyebrow repeated on all 43
+						    cards. A single category isn't a filter, so the strip only earns
+						    its row when there are at least two. */}
+						{categoryOptions.length > 1 ? (
+							<fieldset className="flex min-w-0 flex-wrap gap-1 border-0 p-0">
+								<legend className="sr-only">Filter by category</legend>
+								<CategoryPill
+									isActive={activeCategory === "all"}
+									label="All"
+									onSelect={() => setActiveCategory("all")}
+								/>
+								{categoryOptions.map((category) => (
+									<CategoryPill
+										count={category.count}
+										isActive={activeCategory === category.id}
+										key={category.id}
+										label={category.name}
+										onSelect={() => setActiveCategory(category.id)}
+									/>
+								))}
+							</fieldset>
+						) : null}
 					</div>
 				</CardContent>
 			</Card>
 
-			<div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+			{/* Two-up from the smallest width: one card per row put 43 services over
+			    6323px — about 7.5 phone screens to reach the last one. */}
+			<div className="grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
 				{activeItems.map((item) => {
 					const isProduct = mode === "products";
 					const productCount = productCartQtyById.get(item.id) ?? 0;
 					const isOutOfStock =
 						isProduct && Number((item as Product).stock ?? 0) <= productCount;
-					const categoryName = getEntityCategoryName(item, categoryMap);
+					const inCartCount = isProduct
+						? productCount
+						: (serviceCartCountById.get(item.id) ?? 0);
 
 					return (
 						<Card
@@ -236,7 +320,7 @@ export function TransactionsCatalog() {
 								<button
 									type="button"
 									className={cn(
-										"flex h-full min-h-22 w-full flex-col gap-2 p-3 text-left outline-none transition active:scale-[0.97] focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
+										"relative flex h-full min-h-16 w-full flex-col gap-1 p-2.5 text-left outline-none transition active:scale-[0.97] focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
 										isProduct
 											? "hover:bg-muted/30 active:bg-muted/60"
 											: "hover:bg-background/80 active:bg-background/60",
@@ -250,15 +334,23 @@ export function TransactionsCatalog() {
 									disabled={isOutOfStock}
 									aria-label={`Add ${item.name}`}
 								>
-									{categoryName ? (
-										<span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-											{categoryName}
+									{/* Adding an item otherwise leaves no mark on the card it came
+									    from, so a cashier mid-intake can't tell what they have
+									    already put in the cart without opening it. */}
+									{inCartCount > 0 ? (
+										<span className="absolute top-0 right-0 grid size-5 place-items-center bg-foreground font-mono font-bold text-[10px] text-background tabular-nums">
+											{inCartCount}
 										</span>
 									) : null}
-									<p className="line-clamp-2 text-sm font-semibold leading-snug">
+									<p
+										className={cn(
+											"line-clamp-2 text-sm font-semibold leading-snug",
+											inCartCount > 0 && "pr-5",
+										)}
+									>
 										{item.name}
 									</p>
-									<p className="mt-auto font-mono text-sm font-semibold tabular-nums">
+									<p className="mt-auto font-mono text-xs font-semibold tabular-nums">
 										{/* No list price (ADR-0018): the cashier keys the number
 										    on the cart line if agreed, or leaves it blank until
 										    the workshop inspects the item. */}

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -24,39 +24,6 @@ import { cn } from "@/lib/utils";
 import { formatIDRCurrency } from "@/shared/utils";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
-interface CategoryPillProps {
-	label: string;
-	isActive: boolean;
-	onSelect: () => void;
-	count?: number;
-}
-
-const CategoryPill = ({
-	label,
-	isActive,
-	onSelect,
-	count,
-}: CategoryPillProps) => (
-	<button
-		aria-pressed={isActive}
-		className={cn(
-			"flex min-h-8 items-baseline gap-1.5 border px-2 py-1 text-xs outline-none transition-colors focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
-			isActive
-				? "border-foreground bg-foreground text-background"
-				: "border-border/70 text-foreground/70 hover:bg-muted/40",
-		)}
-		onClick={onSelect}
-		type="button"
-	>
-		{label}
-		{count === undefined ? null : (
-			<span className="font-mono font-semibold text-[10px] tabular-nums">
-				{count}
-			</span>
-		)}
-	</button>
-);
-
 export function TransactionsCatalog() {
 	const { isAdmin, visibleStores, handleStoreChange } =
 		useTransactionsPageContext();
@@ -72,12 +39,6 @@ export function TransactionsCatalog() {
 	);
 	const activeServiceCategory = useTransactionsPageStore(
 		(state) => state.activeServiceCategory,
-	);
-	const setActiveProductCategory = useTransactionsPageStore(
-		(state) => state.setActiveProductCategory,
-	);
-	const setActiveServiceCategory = useTransactionsPageStore(
-		(state) => state.setActiveServiceCategory,
 	);
 
 	const categoriesQuery = useQuery(categoriesQueryOptions());
@@ -98,7 +59,6 @@ export function TransactionsCatalog() {
 	const selectedStoreId = useWatch({ control, name: "selectedStoreId" }) ?? "";
 	const storeError = formState.errors.selectedStoreId;
 	const productCart = useWatch({ control, name: "productCart" }) ?? [];
-	const serviceCart = useWatch({ control, name: "serviceCart" }) ?? [];
 
 	const categoryMap = useMemo(
 		() => new Map(categories.map((category) => [category.id, category])),
@@ -131,70 +91,55 @@ export function TransactionsCatalog() {
 		return () => window.removeEventListener("keydown", handleKeydown);
 	}, []);
 
-	const modeItems: (Product | Service)[] =
-		mode === "products" ? products : services;
-	const activeCategory =
-		mode === "products" ? activeProductCategory : activeServiceCategory;
-	const setActiveCategory =
-		mode === "products" ? setActiveProductCategory : setActiveServiceCategory;
-
-	// Built from the whole catalog, never the search-narrowed list: a pill set that
-	// shrinks as you type can drop the pill you are filtering by.
-	const categoryOptions = useMemo(() => {
-		const byId = new Map<number, { id: number; name: string; count: number }>();
-		for (const item of modeItems) {
-			const seen = byId.get(item.category_id);
-			if (seen) {
-				seen.count += 1;
-				continue;
-			}
-			byId.set(item.category_id, {
-				id: item.category_id,
-				name: getEntityCategoryName(item, categoryMap),
-				count: 1,
-			});
-		}
-		return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
-	}, [categoryMap, modeItems]);
-
-	const activeItems = useMemo(
+	const filteredProducts = useMemo(
 		() =>
-			modeItems.filter((item) => {
-				if (activeCategory !== "all" && item.category_id !== activeCategory) {
-					return false;
-				}
-				if (searchValue.length === 0) {
-					return true;
-				}
+			products.filter((product) => {
 				const categoryName = getEntityCategoryName(
-					item,
+					product,
 					categoryMap,
 				).toLowerCase();
-				return (
-					item.name.toLowerCase().includes(searchValue) ||
-					(item.description ?? "").toLowerCase().includes(searchValue) ||
-					categoryName.includes(searchValue)
-				);
+				const matchesCategory =
+					activeProductCategory === "all" ||
+					product.category_id === activeProductCategory;
+				const matchesSearch =
+					searchValue.length === 0 ||
+					product.name.toLowerCase().includes(searchValue) ||
+					(product.description ?? "").toLowerCase().includes(searchValue) ||
+					categoryName.includes(searchValue);
+
+				return matchesCategory && matchesSearch;
 			}),
-		[activeCategory, categoryMap, modeItems, searchValue],
+		[activeProductCategory, categoryMap, products, searchValue],
+	);
+	const filteredServices = useMemo(
+		() =>
+			services.filter((service) => {
+				const categoryName = getEntityCategoryName(
+					service,
+					categoryMap,
+				).toLowerCase();
+				const matchesCategory =
+					activeServiceCategory === "all" ||
+					service.category_id === activeServiceCategory;
+				const matchesSearch =
+					searchValue.length === 0 ||
+					service.name.toLowerCase().includes(searchValue) ||
+					(service.description ?? "").toLowerCase().includes(searchValue) ||
+					categoryName.includes(searchValue);
+
+				return matchesCategory && matchesSearch;
+			}),
+		[activeServiceCategory, categoryMap, searchValue, services],
 	);
 
+	const activeItems = mode === "products" ? filteredProducts : filteredServices;
 	const productCartQtyById = useMemo(
 		() => new Map(productCart.map((line) => [line.id, line.qty])),
 		[productCart],
 	);
 
-	// One cart line per Item, so this counts lines — services have no qty field.
-	const serviceCartCountById = useMemo(() => {
-		const counts = new Map<number, number>();
-		for (const line of serviceCart) {
-			counts.set(line.id, (counts.get(line.id) ?? 0) + 1);
-		}
-		return counts;
-	}, [serviceCart]);
-
 	return (
-		<div className="grid gap-5 self-start">
+		<div className="grid gap-5 self-start xl:sticky xl:top-0">
 			<Card className="border-border/70">
 				<CardContent className="grid gap-4 p-4 sm:p-5">
 					<div className="grid gap-3">
@@ -249,7 +194,9 @@ export function TransactionsCatalog() {
 						</div>
 
 						<Field>
-							<FieldLabel htmlFor="transaction-search">Search</FieldLabel>
+							<FieldLabel className="sr-only" htmlFor="transaction-search">
+								Search
+							</FieldLabel>
 							<div className="relative">
 								<MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
 								<Input
@@ -265,39 +212,17 @@ export function TransactionsCatalog() {
 								</kbd>
 							</div>
 						</Field>
-
-						{categoryOptions.length > 1 ? (
-							<fieldset className="flex min-w-0 flex-wrap gap-1 border-0 p-0">
-								<legend className="sr-only">Filter by category</legend>
-								<CategoryPill
-									isActive={activeCategory === "all"}
-									label="All"
-									onSelect={() => setActiveCategory("all")}
-								/>
-								{categoryOptions.map((category) => (
-									<CategoryPill
-										count={category.count}
-										isActive={activeCategory === category.id}
-										key={category.id}
-										label={category.name}
-										onSelect={() => setActiveCategory(category.id)}
-									/>
-								))}
-							</fieldset>
-						) : null}
 					</div>
 				</CardContent>
 			</Card>
 
-			<div className="grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+			<div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
 				{activeItems.map((item) => {
 					const isProduct = mode === "products";
 					const productCount = productCartQtyById.get(item.id) ?? 0;
 					const isOutOfStock =
 						isProduct && Number((item as Product).stock ?? 0) <= productCount;
-					const inCartCount = isProduct
-						? productCount
-						: (serviceCartCountById.get(item.id) ?? 0);
+					const categoryName = getEntityCategoryName(item, categoryMap);
 
 					return (
 						<Card
@@ -313,7 +238,7 @@ export function TransactionsCatalog() {
 								<button
 									type="button"
 									className={cn(
-										"relative flex h-full min-h-16 w-full flex-col gap-1 p-2.5 text-left outline-none transition active:scale-[0.97] focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
+										"flex h-full min-h-22 w-full flex-col gap-2 p-3 text-left outline-none transition active:scale-[0.97] focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
 										isProduct
 											? "hover:bg-muted/30 active:bg-muted/60"
 											: "hover:bg-background/80 active:bg-background/60",
@@ -327,20 +252,15 @@ export function TransactionsCatalog() {
 									disabled={isOutOfStock}
 									aria-label={`Add ${item.name}`}
 								>
-									{inCartCount > 0 ? (
-										<span className="absolute top-0 right-0 grid size-5 place-items-center bg-foreground font-mono font-bold text-[10px] text-background tabular-nums">
-											{inCartCount}
+									{categoryName ? (
+										<span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+											{categoryName}
 										</span>
 									) : null}
-									<p
-										className={cn(
-											"line-clamp-2 text-sm font-semibold leading-snug",
-											inCartCount > 0 && "pr-5",
-										)}
-									>
+									<p className="line-clamp-2 text-sm font-semibold leading-snug">
 										{item.name}
 									</p>
-									<p className="mt-auto font-mono text-xs font-semibold tabular-nums">
+									<p className="mt-auto font-mono text-sm font-semibold tabular-nums">
 										{/* No list price (ADR-0018): the cashier keys the number
 										    on the cart line if agreed, or leaves it blank until
 										    the workshop inspects the item. */}

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -138,9 +138,8 @@ export function TransactionsCatalog() {
 	const setActiveCategory =
 		mode === "products" ? setActiveProductCategory : setActiveServiceCategory;
 
-	// Counts come from the whole catalog, not the search-narrowed list: a pill set
-	// that shrinks as you type can drop the pill you filtered by, leaving no way
-	// back to All.
+	// Built from the whole catalog, never the search-narrowed list: a pill set that
+	// shrinks as you type can drop the pill you are filtering by.
 	const categoryOptions = useMemo(() => {
 		const byId = new Map<number, { id: number; name: string; count: number }>();
 		for (const item of modeItems) {
@@ -185,8 +184,7 @@ export function TransactionsCatalog() {
 		[productCart],
 	);
 
-	// Each service add creates its own cart line (one line = one Item), so the
-	// card's badge counts lines, not a qty field.
+	// One cart line per Item, so this counts lines — services have no qty field.
 	const serviceCartCountById = useMemo(() => {
 		const counts = new Map<number, number>();
 		for (const line of serviceCart) {
@@ -268,9 +266,6 @@ export function TransactionsCatalog() {
 							</div>
 						</Field>
 
-						{/* One strip instead of the same category eyebrow repeated on all 43
-						    cards. A single category isn't a filter, so the strip only earns
-						    its row when there are at least two. */}
 						{categoryOptions.length > 1 ? (
 							<fieldset className="flex min-w-0 flex-wrap gap-1 border-0 p-0">
 								<legend className="sr-only">Filter by category</legend>
@@ -294,8 +289,6 @@ export function TransactionsCatalog() {
 				</CardContent>
 			</Card>
 
-			{/* Two-up from the smallest width: one card per row put 43 services over
-			    6323px — about 7.5 phone screens to reach the last one. */}
 			<div className="grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
 				{activeItems.map((item) => {
 					const isProduct = mode === "products";
@@ -334,9 +327,6 @@ export function TransactionsCatalog() {
 									disabled={isOutOfStock}
 									aria-label={`Add ${item.name}`}
 								>
-									{/* Adding an item otherwise leaves no mark on the card it came
-									    from, so a cashier mid-intake can't tell what they have
-									    already put in the cart without opening it. */}
 									{inCartCount > 0 ? (
 										<span className="absolute top-0 right-0 grid size-5 place-items-center bg-foreground font-mono font-bold text-[10px] text-background tabular-nums">
 											{inCartCount}

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -6,6 +6,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useEffect, useMemo, useRef } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -39,6 +40,12 @@ export function TransactionsCatalog() {
 	);
 	const activeServiceCategory = useTransactionsPageStore(
 		(state) => state.activeServiceCategory,
+	);
+	const setActiveProductCategory = useTransactionsPageStore(
+		(state) => state.setActiveProductCategory,
+	);
+	const setActiveServiceCategory = useTransactionsPageStore(
+		(state) => state.setActiveServiceCategory,
 	);
 
 	const categoriesQuery = useQuery(categoriesQueryOptions());
@@ -133,6 +140,32 @@ export function TransactionsCatalog() {
 	);
 
 	const activeItems = mode === "products" ? filteredProducts : filteredServices;
+
+	const modeItems = mode === "products" ? products : services;
+	const activeCategory =
+		mode === "products" ? activeProductCategory : activeServiceCategory;
+	const setActiveCategory =
+		mode === "products" ? setActiveProductCategory : setActiveServiceCategory;
+
+	// Counted off the whole catalog, never the search-narrowed list: a pill set
+	// that shrinks as you type can drop the pill you are filtering by.
+	const categoryOptions = useMemo(() => {
+		const byId = new Map<number, { id: number; name: string; count: number }>();
+		for (const item of modeItems) {
+			const seen = byId.get(item.category_id);
+			if (seen) {
+				seen.count += 1;
+				continue;
+			}
+			byId.set(item.category_id, {
+				id: item.category_id,
+				name: getEntityCategoryName(item, categoryMap),
+				count: 1,
+			});
+		}
+		return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+	}, [categoryMap, modeItems]);
+
 	const productCartQtyById = useMemo(
 		() => new Map(productCart.map((line) => [line.id, line.qty])),
 		[productCart],
@@ -212,6 +245,49 @@ export function TransactionsCatalog() {
 								</kbd>
 							</div>
 						</Field>
+
+						{/* Ten categories over 43 services never fit a phone row, so the
+						    strip scrolls and fades at the edge — same treatment as the
+						    /queue status chips. Hidden when the catalog has one category,
+						    because then the strip only ever says "All". */}
+						{categoryOptions.length > 1 ? (
+							<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
+								<fieldset className="flex min-w-max gap-2 border-0 p-0 px-1 pr-8">
+									<legend className="sr-only">Filter by category</legend>
+									<Button
+										aria-pressed={activeCategory === "all"}
+										className="h-11 gap-1.5 px-3 text-sm"
+										onClick={() => setActiveCategory("all")}
+										type="button"
+										variant={activeCategory === "all" ? "default" : "outline"}
+									>
+										All
+										<span className="font-mono font-semibold tabular-nums">
+											{modeItems.length}
+										</span>
+									</Button>
+									{categoryOptions.map((category) => {
+										const isActive = activeCategory === category.id;
+
+										return (
+											<Button
+												aria-pressed={isActive}
+												className="h-11 gap-1.5 px-3 text-sm"
+												key={category.id}
+												onClick={() => setActiveCategory(category.id)}
+												type="button"
+												variant={isActive ? "default" : "outline"}
+											>
+												{category.name}
+												<span className="font-mono font-semibold tabular-nums">
+													{category.count}
+												</span>
+											</Button>
+										);
+									})}
+								</fieldset>
+							</div>
+						) : null}
 					</div>
 				</CardContent>
 			</Card>

--- a/apps/web/src/features/transactions/components/transactions-catalog.tsx
+++ b/apps/web/src/features/transactions/components/transactions-catalog.tsx
@@ -6,6 +6,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useEffect, useMemo, useRef } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
+import { CHIP_STRIP_ROW, ChipStripScroller } from "@/components/chip-strip";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
@@ -246,13 +247,11 @@ export function TransactionsCatalog() {
 							</div>
 						</Field>
 
-						{/* Ten categories over 43 services never fit a phone row, so the
-						    strip scrolls and fades at the edge — same treatment as the
-						    /queue status chips. Hidden when the catalog has one category,
-						    because then the strip only ever says "All". */}
+						{/* Hidden when the catalog has one category, because then the strip
+						    only ever says "All". */}
 						{categoryOptions.length > 1 ? (
-							<div className="-mx-1 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
-								<fieldset className="flex min-w-max gap-2 border-0 p-0 px-1 pr-8">
+							<ChipStripScroller>
+								<fieldset className={cn(CHIP_STRIP_ROW, "border-0 p-0")}>
 									<legend className="sr-only">Filter by category</legend>
 									<Button
 										aria-pressed={activeCategory === "all"}
@@ -286,7 +285,7 @@ export function TransactionsCatalog() {
 										);
 									})}
 								</fieldset>
-							</div>
+							</ChipStripScroller>
 						) : null}
 					</div>
 				</CardContent>

--- a/apps/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/apps/web/src/features/transactions/components/transactions-checkout.tsx
@@ -24,6 +24,10 @@ import {
 import { cn } from "@/lib/utils";
 import { useTransactionsPageStore } from "@/stores/transactions-store";
 
+// Shared between the hint element and the stepper's aria-describedby so the two
+// can't drift apart.
+const LOCKED_STEP_HINT_ID = "checkout-locked-step-hint";
+
 // Three-step POS checkout: Customer → Items → Payment. Body scrolls; the total +
 // primary action live in a pinned footer so they stay reachable on the iPad
 // sheet. Step is local state and resets to "customer" each time the sheet
@@ -63,6 +67,31 @@ export const TransactionsCheckout = () => {
 		return customerReady;
 	};
 
+	// Dimming a locked step says "not yet" but never says what to do about it.
+	// Name the locked steps and the field that clears the gate, in fix order —
+	// the same information the footer's Continue hint gives for the step the
+	// cashier is already on.
+	const lockedStepHint = (() => {
+		const locked = CHECKOUT_STEPS.filter(
+			(entry, index) => index > stepIndex && !isStepEnabled(entry.key),
+		);
+		if (locked.length === 0) {
+			return "";
+		}
+		const steps = locked.map((entry) => entry.label).join(" and ");
+		const verb = locked.length > 1 ? "unlock" : "unlocks";
+		if (!customerReady) {
+			return `${steps} ${verb} once you enter the customer name and phone.`;
+		}
+		const missing = [
+			count > 0 ? null : "an item",
+			dropoffPhoto ? null : "a drop-off photo",
+		]
+			.filter(Boolean)
+			.join(" and ");
+		return `${steps} ${verb} once you add ${missing}.`;
+	})();
+
 	const headingRef = useRef<HTMLHeadingElement>(null);
 
 	// Direction is a consequence of the navigation action — set alongside the
@@ -96,41 +125,49 @@ export const TransactionsCheckout = () => {
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col">
-			<SheetHeader className="flex-row items-center gap-3 border-b border-border/70">
+			<SheetHeader className="gap-2 border-b border-border/70">
 				<SheetTitle className="sr-only">Checkout</SheetTitle>
 				<SheetDescription className="sr-only">
 					Complete customer, items, and payment to create the order.
 				</SheetDescription>
-				<div className="min-w-0 flex-1">
-					<CheckoutStepper
-						current={step}
-						isStepEnabled={isStepEnabled}
-						onSelect={goToStep}
-					/>
+				<div className="flex flex-row items-center gap-3">
+					<div className="min-w-0 flex-1">
+						<CheckoutStepper
+							current={step}
+							isStepEnabled={isStepEnabled}
+							lockHintId={lockedStepHint ? LOCKED_STEP_HINT_ID : undefined}
+							onSelect={goToStep}
+						/>
+					</div>
+					<Button
+						className="h-11 shrink-0"
+						disabled={
+							count === 0 &&
+							!customerName &&
+							!customerPhone &&
+							selectedCampaignIds.length === 0 &&
+							!dropoffPhoto
+						}
+						icon={<TrashIcon className="size-4" />}
+						onClick={() => {
+							resetCart();
+							// Start over means start at step one — otherwise Reset on the
+							// Payment step strands the cashier there with everything cleared
+							// and a disabled Create Order.
+							goToStep("customer");
+						}}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						Reset
+					</Button>
 				</div>
-				<Button
-					className="h-11 shrink-0"
-					disabled={
-						count === 0 &&
-						!customerName &&
-						!customerPhone &&
-						selectedCampaignIds.length === 0 &&
-						!dropoffPhoto
-					}
-					icon={<TrashIcon className="size-4" />}
-					onClick={() => {
-						resetCart();
-						// Start over means start at step one — otherwise Reset on the
-						// Payment step strands the cashier there with everything cleared
-						// and a disabled Create Order.
-						goToStep("customer");
-					}}
-					size="sm"
-					type="button"
-					variant="outline"
-				>
-					Reset
-				</Button>
+				{lockedStepHint ? (
+					<p className="text-muted-foreground text-xs" id={LOCKED_STEP_HINT_ID}>
+						{lockedStepHint}
+					</p>
+				) : null}
 			</SheetHeader>
 
 			<div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/web/src/features/transactions/components/transactions-checkout.tsx
+++ b/apps/web/src/features/transactions/components/transactions-checkout.tsx
@@ -67,10 +67,6 @@ export const TransactionsCheckout = () => {
 		return customerReady;
 	};
 
-	// Dimming a locked step says "not yet" but never says what to do about it.
-	// Name the locked steps and the field that clears the gate, in fix order —
-	// the same information the footer's Continue hint gives for the step the
-	// cashier is already on.
 	const lockedStepHint = (() => {
 		const locked = CHECKOUT_STEPS.filter(
 			(entry, index) => index > stepIndex && !isStepEnabled(entry.key),
@@ -151,9 +147,8 @@ export const TransactionsCheckout = () => {
 						icon={<TrashIcon className="size-4" />}
 						onClick={() => {
 							resetCart();
-							// Start over means start at step one — otherwise Reset on the
-							// Payment step strands the cashier there with everything cleared
-							// and a disabled Create Order.
+							// Reset on the Payment step otherwise strands the cashier there
+							// with an empty cart and a disabled Create Order.
 							goToStep("customer");
 						}}
 						size="sm"

--- a/apps/web/src/features/transactions/components/transactions-workspace.tsx
+++ b/apps/web/src/features/transactions/components/transactions-workspace.tsx
@@ -6,16 +6,12 @@ import { CartMiniBar } from "@/features/transactions/components/cart-mini-bar";
 import { CartRail } from "@/features/transactions/components/cart-rail";
 import { TransactionsCatalog } from "@/features/transactions/components/transactions-catalog";
 import { TransactionsCheckout } from "@/features/transactions/components/transactions-checkout";
-import { useIsMobile } from "@/hooks/use-mobile";
 
 export function TransactionsWorkspace() {
 	const [cartSheetOpen, setCartSheetOpen] = useState(false);
 	const form = useFormContext<TransactionDraftValues>();
 	const selectedStoreId =
 		useWatch({ control: form.control, name: "selectedStoreId" }) ?? "";
-	// Must stay the same breakpoint as CartRail's xl, or the rail and the bottom
-	// sheet both show at once.
-	const isNarrow = useIsMobile(1280);
 
 	// The store scopes everything the checkout reads — campaigns, vouchers, the
 	// order itself — so a storeless checkout can only end in a rejected submit.
@@ -39,10 +35,13 @@ export function TransactionsWorkspace() {
 				<CartRail hasStore={!!selectedStoreId} onCheckout={handleOpenCart} />
 			</div>
 			<Sheet onOpenChange={setCartSheetOpen} open={cartSheetOpen}>
+				{/* Bottom at every width, never a right drawer: the item rows lay their
+				    descriptor fields out in two columns and the stepper needs the room,
+				    and a right sheet caps at max-w-sm. */}
 				<SheetContent
 					className="data-[side=bottom]:h-[92dvh]"
 					showCloseButton={false}
-					side={isNarrow ? "bottom" : "right"}
+					side="bottom"
 				>
 					<TransactionsCheckout />
 				</SheetContent>

--- a/apps/web/src/features/transactions/components/transactions-workspace.tsx
+++ b/apps/web/src/features/transactions/components/transactions-workspace.tsx
@@ -3,14 +3,20 @@ import { useFormContext, useWatch } from "react-hook-form";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import type { TransactionDraftValues } from "@/features/transactions/cart/cart";
 import { CartMiniBar } from "@/features/transactions/components/cart-mini-bar";
+import { CartRail } from "@/features/transactions/components/cart-rail";
 import { TransactionsCatalog } from "@/features/transactions/components/transactions-catalog";
 import { TransactionsCheckout } from "@/features/transactions/components/transactions-checkout";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export function TransactionsWorkspace() {
 	const [cartSheetOpen, setCartSheetOpen] = useState(false);
 	const form = useFormContext<TransactionDraftValues>();
 	const selectedStoreId =
 		useWatch({ control: form.control, name: "selectedStoreId" }) ?? "";
+	// Same 1280 boundary the cart rail uses: where the rail is standing, the
+	// checkout comes in from the side so the catalog it used to bury stays on
+	// screen. Below that the bottom sheet is the right pattern and keeps it.
+	const isNarrow = useIsMobile(1280);
 
 	// The store scopes everything the checkout reads — campaigns, vouchers, the
 	// order itself — so a storeless checkout can only end in a rejected submit.
@@ -26,15 +32,18 @@ export function TransactionsWorkspace() {
 
 	return (
 		<>
-			<div className="grid gap-6">
-				<TransactionsCatalog />
-				<CartMiniBar hasStore={!!selectedStoreId} onOpen={handleOpenCart} />
+			<div className="grid items-start gap-6 xl:grid-cols-[minmax(0,1fr)_20rem]">
+				<div className="grid min-w-0 gap-6">
+					<TransactionsCatalog />
+					<CartMiniBar hasStore={!!selectedStoreId} onOpen={handleOpenCart} />
+				</div>
+				<CartRail hasStore={!!selectedStoreId} onCheckout={handleOpenCart} />
 			</div>
-			<Sheet open={cartSheetOpen} onOpenChange={setCartSheetOpen}>
+			<Sheet onOpenChange={setCartSheetOpen} open={cartSheetOpen}>
 				<SheetContent
-					side="bottom"
 					className="data-[side=bottom]:h-[92dvh]"
 					showCloseButton={false}
+					side={isNarrow ? "bottom" : "right"}
 				>
 					<TransactionsCheckout />
 				</SheetContent>

--- a/apps/web/src/features/transactions/components/transactions-workspace.tsx
+++ b/apps/web/src/features/transactions/components/transactions-workspace.tsx
@@ -13,9 +13,8 @@ export function TransactionsWorkspace() {
 	const form = useFormContext<TransactionDraftValues>();
 	const selectedStoreId =
 		useWatch({ control: form.control, name: "selectedStoreId" }) ?? "";
-	// Same 1280 boundary the cart rail uses: where the rail is standing, the
-	// checkout comes in from the side so the catalog it used to bury stays on
-	// screen. Below that the bottom sheet is the right pattern and keeps it.
+	// Must stay the same breakpoint as CartRail's xl, or the rail and the bottom
+	// sheet both show at once.
 	const isNarrow = useIsMobile(1280);
 
 	// The store scopes everything the checkout reads — campaigns, vouchers, the

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -281,10 +281,6 @@ export type FetchOrdersQuery = {
 	date_to?: string;
 };
 
-export type FetchOrderCountsQuery = {
-	store_id?: number;
-};
-
 export type FetchOrderServiceQueueQuery = {
 	limit?: number;
 	offset?: number;
@@ -613,10 +609,10 @@ export async function fetchOrdersPage(
 	return toPaginated(response);
 }
 
-export async function fetchOrderCounts(query?: FetchOrderCountsQuery) {
+export async function fetchOrderCounts(storeId?: number) {
 	const response = await parseResponse(
 		rpcWithAuth().api.admin.orders.counts.$get({
-			query: query ? toSearchParams(query) : undefined,
+			query: toSearchParams({ store_id: storeId }),
 		}),
 	);
 
@@ -866,7 +862,7 @@ export async function fetchOrderServiceQueuePage(
 export async function fetchOrderServiceQueueCounts(storeId?: number) {
 	const response = await parseResponse(
 		rpcWithAuth().api.admin.orders.services.queue.counts.$get({
-			query: storeId === undefined ? {} : { store_id: String(storeId) },
+			query: toSearchParams({ store_id: storeId }),
 		}),
 	);
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -104,6 +104,9 @@ export type Order = InferResponseType<
 export type OrderListCounts = InferResponseType<
 	typeof rpc.api.admin.orders.counts.$get
 >["data"];
+export type OrderServiceQueueCounts = InferResponseType<
+	typeof rpc.api.admin.orders.services.queue.counts.$get
+>["data"];
 export type OrderDetail = InferResponseType<
 	(typeof rpc.api.admin.orders)[":id"]["$get"]
 >["data"];
@@ -484,6 +487,8 @@ export const queryKeys = {
 			"store_id" | "search" | "status" | "date_from" | "date_to"
 		>,
 	) => ["order-service-queue", query ?? {}] as const,
+	orderServiceQueueCounts: (storeId?: number) =>
+		["order-service-queue-counts", storeId ?? null] as const,
 	shifts: (query?: FetchShiftsQuery) => ["shifts", query ?? {}] as const,
 	shiftCurrent: ["shift-current"] as const,
 	reportOverview: (query: FetchReportOverviewQuery) =>
@@ -856,6 +861,16 @@ export async function fetchOrderServiceQueuePage(
 	);
 
 	return toPaginated(response);
+}
+
+export async function fetchOrderServiceQueueCounts(storeId?: number) {
+	const response = await parseResponse(
+		rpcWithAuth().api.admin.orders.services.queue.counts.$get({
+			query: storeId === undefined ? {} : { store_id: String(storeId) },
+		}),
+	);
+
+	return response.data;
 }
 
 export async function updateOrderServiceStatus(

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -101,6 +101,9 @@ export type PaymentMethod = InferResponseType<
 export type Order = InferResponseType<
 	typeof rpc.api.admin.orders.$get
 >["data"][number];
+export type OrderListCounts = InferResponseType<
+	typeof rpc.api.admin.orders.counts.$get
+>["data"];
 export type OrderDetail = InferResponseType<
 	(typeof rpc.api.admin.orders)[":id"]["$get"]
 >["data"];
@@ -270,8 +273,13 @@ export type FetchOrdersQuery = {
 		| "completed"
 		| "cancelled";
 	payment_status?: "paid" | "unpaid";
+	overdue?: boolean;
 	date_from?: string;
 	date_to?: string;
+};
+
+export type FetchOrderCountsQuery = {
+	store_id?: number;
 };
 
 export type FetchOrderServiceQueueQuery = {
@@ -460,6 +468,7 @@ export const queryKeys = {
 	products: ["products"] as const,
 	paymentMethods: ["payment-methods"] as const,
 	orders: (query?: FetchOrdersQuery) => ["orders", query ?? {}] as const,
+	orderCounts: (storeId?: number) => ["order-counts", storeId ?? null] as const,
 	orderDetail: (id: number) => ["order-detail", id] as const,
 	campaigns: (query?: FetchCampaignsQuery) =>
 		["campaigns", query ?? {}] as const,
@@ -597,6 +606,16 @@ export async function fetchOrdersPage(
 	);
 
 	return toPaginated(response);
+}
+
+export async function fetchOrderCounts(query?: FetchOrderCountsQuery) {
+	const response = await parseResponse(
+		rpcWithAuth().api.admin.orders.counts.$get({
+			query: query ? toSearchParams(query) : undefined,
+		}),
+	);
+
+	return response.data;
 }
 
 export async function fetchCampaigns(query?: FetchCampaignsQuery) {

--- a/apps/web/src/lib/order-service-item-details.ts
+++ b/apps/web/src/lib/order-service-item-details.ts
@@ -5,18 +5,25 @@ type ServiceItemDetails = {
 	size?: string | null;
 };
 
-export function getOrderServiceItemDetails({
+// One field order for every surface that names an Item — the cart line, the
+// checkout row, the queue row. Two screens listing the same shoe as
+// "Nike · Black · Yeezy" and "Nike · Yeezy · Black" read as two different items.
+export function getOrderServiceItemDescriptors({
 	brand,
 	model,
 	color,
 	size,
-}: ServiceItemDetails): string | null {
-	const parts = [brand, model, color, size].flatMap((value) => {
+}: ServiceItemDetails): string[] {
+	return [brand, model, color, size].flatMap((value) => {
 		const trimmed = value?.trim();
 		return trimmed ? [trimmed] : [];
 	});
+}
 
-	return parts.join(" · ") || null;
+export function getOrderServiceItemDetails(
+	details: ServiceItemDetails,
+): string | null {
+	return getOrderServiceItemDescriptors(details).join(" · ") || null;
 }
 
 export function formatOrderServiceItemDetails(details: ServiceItemDetails) {

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -109,10 +109,7 @@ export const orderServiceQueueCountsQueryOptions = (storeId?: number) =>
 export const orderCountsQueryOptions = (storeId?: number) =>
 	queryOptions({
 		queryKey: queryKeys.orderCounts(storeId),
-		queryFn: () =>
-			fetchOrderCounts(
-				storeId === undefined ? undefined : { store_id: storeId },
-			),
+		queryFn: () => fetchOrderCounts(storeId),
 	});
 
 export const orderDetailQueryOptions = (id: number) =>

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -21,6 +21,7 @@ import {
 	fetchCustomersPage,
 	fetchFinancialReport,
 	fetchMe,
+	fetchOrderCounts,
 	fetchOrderDetail,
 	fetchOrdersFlowReport,
 	fetchOrdersPage,
@@ -96,6 +97,15 @@ export const ordersPageQueryOptions = (query?: FetchOrdersQuery) =>
 	queryOptions({
 		queryKey: queryKeys.orders(query),
 		queryFn: () => fetchOrdersPage(query),
+	});
+
+export const orderCountsQueryOptions = (storeId?: number) =>
+	queryOptions({
+		queryKey: queryKeys.orderCounts(storeId),
+		queryFn: () =>
+			fetchOrderCounts(
+				storeId === undefined ? undefined : { store_id: storeId },
+			),
 	});
 
 export const orderDetailQueryOptions = (id: number) =>

--- a/apps/web/src/lib/query-options.ts
+++ b/apps/web/src/lib/query-options.ts
@@ -23,6 +23,7 @@ import {
 	fetchMe,
 	fetchOrderCounts,
 	fetchOrderDetail,
+	fetchOrderServiceQueueCounts,
 	fetchOrdersFlowReport,
 	fetchOrdersPage,
 	fetchPaymentMethods,
@@ -97,6 +98,12 @@ export const ordersPageQueryOptions = (query?: FetchOrdersQuery) =>
 	queryOptions({
 		queryKey: queryKeys.orders(query),
 		queryFn: () => fetchOrdersPage(query),
+	});
+
+export const orderServiceQueueCountsQueryOptions = (storeId?: number) =>
+	queryOptions({
+		queryKey: queryKeys.orderServiceQueueCounts(storeId),
+		queryFn: () => fetchOrderServiceQueueCounts(storeId),
 	});
 
 export const orderCountsQueryOptions = (storeId?: number) =>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -30,8 +30,8 @@ import { Route as AdminComplaintsIndexRouteImport } from "./routes/_admin/compla
 import { Route as AdminComplaintsComplaintIdRouteImport } from "./routes/_admin/complaints.$complaintId";
 import { Route as AdminOrdersIndexRouteImport } from "./routes/_admin/orders.index";
 import { Route as AdminOrdersOrderIdRouteImport } from "./routes/_admin/orders.$orderId";
-import { Route as AdminWorkerIndexRouteImport } from "./routes/_admin/worker.index";
-import { Route as AdminWorkerOrderIdServiceIdRouteImport } from "./routes/_admin/worker.$orderId.$serviceId";
+import { Route as AdminQueueIndexRouteImport } from "./routes/_admin/queue.index";
+import { Route as AdminQueueOrderIdServiceIdRouteImport } from "./routes/_admin/queue.$orderId.$serviceId";
 
 const AdminRouteRoute = AdminRouteRouteImport.update({
   id: "/_admin",
@@ -138,15 +138,15 @@ const AdminOrdersOrderIdRoute = AdminOrdersOrderIdRouteImport.update({
   path: "/orders/$orderId",
   getParentRoute: () => AdminRouteRoute,
 } as any);
-const AdminWorkerIndexRoute = AdminWorkerIndexRouteImport.update({
-  id: "/worker/",
-  path: "/worker/",
+const AdminQueueIndexRoute = AdminQueueIndexRouteImport.update({
+  id: "/queue/",
+  path: "/queue/",
   getParentRoute: () => AdminRouteRoute,
 } as any);
-const AdminWorkerOrderIdServiceIdRoute =
-  AdminWorkerOrderIdServiceIdRouteImport.update({
-    id: "/worker/$orderId/$serviceId",
-    path: "/worker/$orderId/$serviceId",
+const AdminQueueOrderIdServiceIdRoute =
+  AdminQueueOrderIdServiceIdRouteImport.update({
+    id: "/queue/$orderId/$serviceId",
+    path: "/queue/$orderId/$serviceId",
     getParentRoute: () => AdminRouteRoute,
   } as any);
 
@@ -171,8 +171,8 @@ export interface FileRoutesByFullPath {
   "/orders/$orderId": typeof AdminOrdersOrderIdRoute;
   "/complaints/": typeof AdminComplaintsIndexRoute;
   "/orders/": typeof AdminOrdersIndexRoute;
-  "/worker/": typeof AdminWorkerIndexRoute;
-  "/worker/$orderId/$serviceId": typeof AdminWorkerOrderIdServiceIdRoute;
+  "/queue/": typeof AdminQueueIndexRoute;
+  "/queue/$orderId/$serviceId": typeof AdminQueueOrderIdServiceIdRoute;
 }
 export interface FileRoutesByTo {
   "/login": typeof LoginRoute;
@@ -195,8 +195,8 @@ export interface FileRoutesByTo {
   "/orders/$orderId": typeof AdminOrdersOrderIdRoute;
   "/complaints": typeof AdminComplaintsIndexRoute;
   "/orders": typeof AdminOrdersIndexRoute;
-  "/worker": typeof AdminWorkerIndexRoute;
-  "/worker/$orderId/$serviceId": typeof AdminWorkerOrderIdServiceIdRoute;
+  "/queue": typeof AdminQueueIndexRoute;
+  "/queue/$orderId/$serviceId": typeof AdminQueueOrderIdServiceIdRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
@@ -221,8 +221,8 @@ export interface FileRoutesById {
   "/_admin/orders/$orderId": typeof AdminOrdersOrderIdRoute;
   "/_admin/complaints/": typeof AdminComplaintsIndexRoute;
   "/_admin/orders/": typeof AdminOrdersIndexRoute;
-  "/_admin/worker/": typeof AdminWorkerIndexRoute;
-  "/_admin/worker/$orderId/$serviceId": typeof AdminWorkerOrderIdServiceIdRoute;
+  "/_admin/queue/": typeof AdminQueueIndexRoute;
+  "/_admin/queue/$orderId/$serviceId": typeof AdminQueueOrderIdServiceIdRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
@@ -247,8 +247,8 @@ export interface FileRouteTypes {
     | "/orders/$orderId"
     | "/complaints/"
     | "/orders/"
-    | "/worker/"
-    | "/worker/$orderId/$serviceId";
+    | "/queue/"
+    | "/queue/$orderId/$serviceId";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/login"
@@ -271,8 +271,8 @@ export interface FileRouteTypes {
     | "/orders/$orderId"
     | "/complaints"
     | "/orders"
-    | "/worker"
-    | "/worker/$orderId/$serviceId";
+    | "/queue"
+    | "/queue/$orderId/$serviceId";
   id:
     | "__root__"
     | "/_admin"
@@ -296,8 +296,8 @@ export interface FileRouteTypes {
     | "/_admin/orders/$orderId"
     | "/_admin/complaints/"
     | "/_admin/orders/"
-    | "/_admin/worker/"
-    | "/_admin/worker/$orderId/$serviceId";
+    | "/_admin/queue/"
+    | "/_admin/queue/$orderId/$serviceId";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -456,18 +456,18 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AdminOrdersOrderIdRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
-    "/_admin/worker/": {
-      id: "/_admin/worker/";
-      path: "/worker";
-      fullPath: "/worker/";
-      preLoaderRoute: typeof AdminWorkerIndexRouteImport;
+    "/_admin/queue/": {
+      id: "/_admin/queue/";
+      path: "/queue";
+      fullPath: "/queue/";
+      preLoaderRoute: typeof AdminQueueIndexRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
-    "/_admin/worker/$orderId/$serviceId": {
-      id: "/_admin/worker/$orderId/$serviceId";
-      path: "/worker/$orderId/$serviceId";
-      fullPath: "/worker/$orderId/$serviceId";
-      preLoaderRoute: typeof AdminWorkerOrderIdServiceIdRouteImport;
+    "/_admin/queue/$orderId/$serviceId": {
+      id: "/_admin/queue/$orderId/$serviceId";
+      path: "/queue/$orderId/$serviceId";
+      fullPath: "/queue/$orderId/$serviceId";
+      preLoaderRoute: typeof AdminQueueOrderIdServiceIdRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
   }
@@ -491,8 +491,8 @@ interface AdminRouteRouteChildren {
   AdminOrdersOrderIdRoute: typeof AdminOrdersOrderIdRoute;
   AdminComplaintsIndexRoute: typeof AdminComplaintsIndexRoute;
   AdminOrdersIndexRoute: typeof AdminOrdersIndexRoute;
-  AdminWorkerIndexRoute: typeof AdminWorkerIndexRoute;
-  AdminWorkerOrderIdServiceIdRoute: typeof AdminWorkerOrderIdServiceIdRoute;
+  AdminQueueIndexRoute: typeof AdminQueueIndexRoute;
+  AdminQueueOrderIdServiceIdRoute: typeof AdminQueueOrderIdServiceIdRoute;
 }
 
 const AdminRouteRouteChildren: AdminRouteRouteChildren = {
@@ -513,8 +513,8 @@ const AdminRouteRouteChildren: AdminRouteRouteChildren = {
   AdminOrdersOrderIdRoute: AdminOrdersOrderIdRoute,
   AdminComplaintsIndexRoute: AdminComplaintsIndexRoute,
   AdminOrdersIndexRoute: AdminOrdersIndexRoute,
-  AdminWorkerIndexRoute: AdminWorkerIndexRoute,
-  AdminWorkerOrderIdServiceIdRoute: AdminWorkerOrderIdServiceIdRoute,
+  AdminQueueIndexRoute: AdminQueueIndexRoute,
+  AdminQueueOrderIdServiceIdRoute: AdminQueueOrderIdServiceIdRoute,
 };
 
 const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -123,21 +123,27 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		<>
 			<OrderIdentityStrip detail={detail} gates={gates} orderId={id} />
 
-			<div className="grid gap-3 sm:gap-4">
+			{/* Two columns at xl: on a 1440 laptop the single stack put Payment
+			    below a 20-item Services list, so the one number the counter is
+			    asked for was a scroll away. Services keeps the wide track; money
+			    and photos ride alongside it. */}
+			<div className="grid items-start gap-3 sm:gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
 				<OrderLineItemsCard
 					detail={detail}
 					isAdmin={gates.isAdmin}
 					orderId={id}
 				/>
 
-				<OrderPaymentSection detail={detail} gates={gates} orderId={id} />
+				<div className="grid gap-3 sm:gap-4">
+					<OrderPaymentSection detail={detail} gates={gates} orderId={id} />
 
-				<OrderAttachmentsCard
-					canManageDropoff={gates.canManageDropoffPhoto}
-					onUploaded={refreshOrder}
-					order={detail}
-					pickupEvents={pickupEvents}
-				/>
+					<OrderAttachmentsCard
+						canManageDropoff={gates.canManageDropoffPhoto}
+						onUploaded={refreshOrder}
+						order={detail}
+						pickupEvents={pickupEvents}
+					/>
+				</div>
 			</div>
 		</>
 	);

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -123,23 +123,21 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		<>
 			<OrderIdentityStrip detail={detail} gates={gates} orderId={id} />
 
-			<div className="grid items-start gap-3 sm:gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
+			<div className="grid gap-3 sm:gap-4">
 				<OrderLineItemsCard
 					detail={detail}
 					isAdmin={gates.isAdmin}
 					orderId={id}
 				/>
 
-				<div className="grid gap-3 sm:gap-4">
-					<OrderPaymentSection detail={detail} gates={gates} orderId={id} />
+				<OrderPaymentSection detail={detail} gates={gates} orderId={id} />
 
-					<OrderAttachmentsCard
-						canManageDropoff={gates.canManageDropoffPhoto}
-						onUploaded={refreshOrder}
-						order={detail}
-						pickupEvents={pickupEvents}
-					/>
-				</div>
+				<OrderAttachmentsCard
+					canManageDropoff={gates.canManageDropoffPhoto}
+					onUploaded={refreshOrder}
+					order={detail}
+					pickupEvents={pickupEvents}
+				/>
 			</div>
 		</>
 	);

--- a/apps/web/src/routes/_admin/orders.$orderId.tsx
+++ b/apps/web/src/routes/_admin/orders.$orderId.tsx
@@ -123,10 +123,6 @@ function AdminOrderDetailPage({ orderId: id }: { orderId: number }) {
 		<>
 			<OrderIdentityStrip detail={detail} gates={gates} orderId={id} />
 
-			{/* Two columns at xl: on a 1440 laptop the single stack put Payment
-			    below a 20-item Services list, so the one number the counter is
-			    asked for was a scroll away. Services keeps the wide track; money
-			    and photos ride alongside it. */}
 			<div className="grid items-start gap-3 sm:gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
 				<OrderLineItemsCard
 					detail={detail}

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -11,6 +11,7 @@ import { TablePagination } from "@/components/table-pagination";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { OrderFilterPills } from "@/features/orders/components/order-filter-pills";
 import {
 	ORDER_STATUS_VALUES,
 	OrderFilters,
@@ -22,6 +23,7 @@ import { PickupRadar } from "@/features/orders/components/pickup-radar";
 import type { FetchOrdersQuery, Order } from "@/lib/api";
 import {
 	meQueryOptions,
+	orderCountsQueryOptions,
 	ordersPageQueryOptions,
 	storesQueryOptions,
 } from "@/lib/query-options";
@@ -41,6 +43,7 @@ const ordersSearchSchema = z.object({
 	storeId: z.coerce.number().int().positive().optional().catch(undefined),
 	status: z.enum(ORDER_STATUS_VALUES).optional().catch(undefined),
 	paymentStatus: z.enum(PAYMENT_STATUS_VALUES).optional().catch(undefined),
+	overdue: z.boolean().optional().catch(undefined),
 	dateFrom: z
 		.string()
 		.regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -66,6 +69,7 @@ function buildOrdersListParams(
 		...(storeId !== undefined ? { store_id: storeId } : {}),
 		...(filters.status ? { status: filters.status } : {}),
 		...(filters.paymentStatus ? { payment_status: filters.paymentStatus } : {}),
+		...(filters.overdue ? { overdue: true } : {}),
 		...(filters.dateFrom ? { date_from: filters.dateFrom } : {}),
 		...(filters.dateTo ? { date_to: filters.dateTo } : {}),
 	};
@@ -160,6 +164,13 @@ function OrdersPage() {
 		enabled: role === "admin" ? true : parsedStoreId !== undefined,
 	});
 
+	// Same gate as the list: pills that counted branches the list refuses to show
+	// would be a triage row for someone else's orders.
+	const orderCountsQuery = useQuery({
+		...orderCountsQueryOptions(parsedStoreId),
+		enabled: role === "admin" ? true : parsedStoreId !== undefined,
+	});
+
 	const hasNoStoreAssignment =
 		role !== "admin" && meQuery.isSuccess && userStoreIds.length === 0;
 
@@ -216,12 +227,34 @@ function OrdersPage() {
 				accessorKey: "customer_name",
 				header: "Customer",
 				meta: {
+					// Subtitle, not a detail cell: the name is what people search by, and
+					// it used to be the last thing on a phone card, boxed in below the
+					// badges with the fields nobody scans for.
 					mobileCard: {
-						label: "Customer",
-						className: "col-span-2",
-						valueClassName: "truncate",
+						slot: "subtitle",
 					},
 				},
+				cell: ({ row }) => (
+					<div className="grid min-w-0 gap-1">
+						<span className="truncate font-medium">
+							{row.original.customer_name}
+						</span>
+						{/* What the customer says at the counter — "the black Nikes" — is
+						    the only way to tell two Repair orders apart. */}
+						{row.original.item_descriptors.length > 0 ? (
+							<span className="flex min-w-0 flex-wrap gap-1">
+								{row.original.item_descriptors.map((descriptor) => (
+									<span
+										className="border border-border/70 bg-muted/40 px-1.5 font-mono text-[10px] text-muted-foreground"
+										key={descriptor}
+									>
+										{descriptor}
+									</span>
+								))}
+							</span>
+						) : null}
+					</div>
+				),
 			},
 			{
 				accessorKey: "status",
@@ -295,6 +328,11 @@ function OrdersPage() {
 			<div className="grid gap-4">
 				<Card>
 					<CardContent>
+						<OrderFilterPills
+							counts={orderCountsQuery.data}
+							onChange={handleFilterChange}
+							values={search}
+						/>
 						<OrderFilters
 							values={search}
 							role={role}

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -238,10 +238,10 @@ function OrdersPage() {
 						</span>
 						{row.original.item_descriptors.length > 0 ? (
 							<span className="flex min-w-0 flex-wrap gap-1">
-								{row.original.item_descriptors.map((descriptor) => (
+								{row.original.item_descriptors.map((descriptor, index) => (
 									<span
 										className="border border-border/70 bg-muted/40 px-1.5 font-mono text-[10px] text-muted-foreground"
-										key={descriptor}
+										key={`${index}-${descriptor}`}
 									>
 										{descriptor}
 									</span>

--- a/apps/web/src/routes/_admin/orders.index.tsx
+++ b/apps/web/src/routes/_admin/orders.index.tsx
@@ -164,8 +164,8 @@ function OrdersPage() {
 		enabled: role === "admin" ? true : parsedStoreId !== undefined,
 	});
 
-	// Same gate as the list: pills that counted branches the list refuses to show
-	// would be a triage row for someone else's orders.
+	// Must stay the same gate as the list, or the pills count branches the list
+	// below them refuses to show.
 	const orderCountsQuery = useQuery({
 		...orderCountsQueryOptions(parsedStoreId),
 		enabled: role === "admin" ? true : parsedStoreId !== undefined,
@@ -227,9 +227,6 @@ function OrdersPage() {
 				accessorKey: "customer_name",
 				header: "Customer",
 				meta: {
-					// Subtitle, not a detail cell: the name is what people search by, and
-					// it used to be the last thing on a phone card, boxed in below the
-					// badges with the fields nobody scans for.
 					mobileCard: {
 						slot: "subtitle",
 					},
@@ -239,8 +236,6 @@ function OrdersPage() {
 						<span className="truncate font-medium">
 							{row.original.customer_name}
 						</span>
-						{/* What the customer says at the counter — "the black Nikes" — is
-						    the only way to tell two Repair orders apart. */}
 						{row.original.item_descriptors.length > 0 ? (
 							<span className="flex min-w-0 flex-wrap gap-1">
 								{row.original.item_descriptors.map((descriptor) => (

--- a/apps/web/src/routes/_admin/queue.$orderId.$serviceId.tsx
+++ b/apps/web/src/routes/_admin/queue.$orderId.$serviceId.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { QueueServiceDetail } from "@/features/orders/components/queue-service-detail";
 import { orderDetailQueryOptions } from "@/lib/query-options";
 
-export const Route = createFileRoute("/_admin/worker/$orderId/$serviceId")({
+export const Route = createFileRoute("/_admin/queue/$orderId/$serviceId")({
 	loader: async ({ context, params }) => {
 		const orderId = Number(params.orderId);
 
@@ -12,10 +12,10 @@ export const Route = createFileRoute("/_admin/worker/$orderId/$serviceId")({
 
 		await context.queryClient.ensureQueryData(orderDetailQueryOptions(orderId));
 	},
-	component: WorkerQueueDetailPage,
+	component: QueueDetailPage,
 });
 
-function WorkerQueueDetailPage() {
+function QueueDetailPage() {
 	const { orderId, serviceId } = Route.useParams();
 	const parsedOrderId = Number(orderId);
 	const parsedServiceId = Number(serviceId);

--- a/apps/web/src/routes/_admin/queue.index.tsx
+++ b/apps/web/src/routes/_admin/queue.index.tsx
@@ -447,9 +447,6 @@ function QueuePage() {
 			/>
 
 			<div className="grid gap-3">
-				{/* One line, so the first queue row is above the fold on a phone. The
-				    old panel stacked a label, an input and two full-width buttons and
-				    pushed every item off screen. */}
 				<div className="flex items-center gap-2">
 					<Input
 						aria-label="Find by item code, order ID, or line ID"
@@ -533,10 +530,8 @@ function QueuePage() {
 						/>
 					))}
 
-					{/* isLoading, not isPending: with no store picked the query is
-					    disabled, and a disabled query stays pending forever — gating on
-					    isPending stacks four skeletons under "Select a store." that never
-					    resolve. */}
+					{/* isLoading, never isPending: with no store picked this query is
+					    disabled, and a disabled query stays pending forever. */}
 					{queueQuery.isLoading ? (
 						<div className="grid gap-2">
 							{Array.from({ length: 6 }, (_, index) => (
@@ -585,8 +580,6 @@ interface QueueRowProps {
 }
 
 const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
-	// One clock for the row, ticking a minute at a time: age is the whole point
-	// of the row, so a stale number is worse than the re-render.
 	const [now, setNow] = useState(() => Date.now());
 	useEffect(() => {
 		const interval = setInterval(() => setNow(Date.now()), 60_000);
@@ -618,8 +611,6 @@ const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
 			onClick={() => onOpen(item)}
 			type="button"
 		>
-			{/* The stripe is the triage signal — colour at the edge of every row
-			    reads down a list without stopping to parse a badge. */}
 			<span
 				aria-hidden="true"
 				className={cn("w-1 shrink-0", AGE_STRIPE_CLASS[tone])}

--- a/apps/web/src/routes/_admin/queue.index.tsx
+++ b/apps/web/src/routes/_admin/queue.index.tsx
@@ -1,6 +1,6 @@
 import {
 	CaretRightIcon,
-	HourglassIcon,
+	FunnelIcon,
 	MagnifyingGlassIcon,
 	ScanIcon,
 	WarningCircleIcon,
@@ -21,12 +21,10 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
-import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { QueueStatusTabs } from "@/features/orders/components/queue-status-tabs";
 import { StoreAutocomplete } from "@/features/orders/components/store-autocomplete";
 import { useBarcodeScanner } from "@/features/orders/hooks/useBarcodeScanner";
-import { formatOrderDateTime } from "@/features/orders/lib/format";
 import {
 	type FetchOrderServiceQueueQuery,
 	fetchOrderDetail,
@@ -37,13 +35,13 @@ import {
 	queryKeys,
 } from "@/lib/api";
 import { formatOrderServiceItemDetails } from "@/lib/order-service-item-details";
-import { meQueryOptions, storesQueryOptions } from "@/lib/query-options";
-import { readServerErrorMessage } from "@/lib/server-error";
 import {
-	ACTIVE_ORDER_SERVICE_STATUSES,
-	formatOrderServiceStatus,
-	getOrderServiceStatusBadgeVariant,
-} from "@/lib/status";
+	meQueryOptions,
+	orderServiceQueueCountsQueryOptions,
+	storesQueryOptions,
+} from "@/lib/query-options";
+import { readServerErrorMessage } from "@/lib/server-error";
+import { ACTIVE_ORDER_SERVICE_STATUSES } from "@/lib/status";
 import { cn } from "@/lib/utils";
 import { getCurrentUser } from "@/stores/auth-store";
 
@@ -58,7 +56,7 @@ const TERMINAL_QUEUE_STATUSES = new Set<QueueOrderServiceItem["status"]>([
 const HOUR_MS = 3_600_000;
 const DAY_MS = 24 * HOUR_MS;
 
-type AgeTone = "muted" | "info" | "warning" | "destructive";
+type AgeTone = "clean" | "aging" | "late" | "overdue";
 
 function formatElapsedDuration(ms: number): string {
 	const totalMinutes = Math.floor(ms / 60_000);
@@ -66,36 +64,40 @@ function formatElapsedDuration(ms: number): string {
 		return `${Math.max(totalMinutes, 0)}m`;
 	}
 	const totalHours = Math.floor(totalMinutes / 60);
-	const minutes = totalMinutes % 60;
-	if (totalHours < 24) {
-		return `${totalHours}h ${minutes}m`;
+	if (totalHours < 48) {
+		return `${totalHours}h`;
 	}
-	const days = Math.floor(totalHours / 24);
-	const hours = totalHours % 24;
-	return `${days}d ${hours}h`;
+	return `${Math.floor(totalHours / 24)}d`;
 }
 
 function getElapsedTone(ms: number): AgeTone {
 	if (ms < 2 * HOUR_MS) {
-		return "muted";
+		return "clean";
 	}
 	if (ms < DAY_MS) {
-		return "info";
+		return "aging";
 	}
 	if (ms < 3 * DAY_MS) {
-		return "warning";
+		return "late";
 	}
-	return "destructive";
+	return "overdue";
 }
 
-const AGE_TONE_CLASS: Record<AgeTone, string> = {
-	muted: "border-border/70 bg-muted/40 text-muted-foreground",
-	info: "border-info/40 bg-info/10 text-info",
-	warning: "border-warning/50 bg-warning/10 text-warning",
-	destructive: "border-destructive/50 bg-destructive/10 text-destructive",
+const AGE_STRIPE_CLASS: Record<AgeTone, string> = {
+	clean: "bg-border",
+	aging: "bg-info",
+	late: "bg-warning",
+	overdue: "bg-destructive",
 };
 
-const workerSearchSchema = z.object({
+const AGE_TEXT_CLASS: Record<AgeTone, string> = {
+	clean: "text-muted-foreground",
+	aging: "text-info",
+	late: "text-warning",
+	overdue: "text-destructive",
+};
+
+const queueSearchSchema = z.object({
 	storeId: z.coerce.number().int().positive().optional(),
 	status: z.enum(ACTIVE_ORDER_SERVICE_STATUSES).optional(),
 	dateFrom: z
@@ -110,8 +112,8 @@ const workerSearchSchema = z.object({
 
 const numericLookupRegex = /^\d+$/;
 
-export const Route = createFileRoute("/_admin/worker/")({
-	validateSearch: (search) => workerSearchSchema.parse(search),
+export const Route = createFileRoute("/_admin/queue/")({
+	validateSearch: (search) => queueSearchSchema.parse(search),
 	loader: async ({ context }) => {
 		const currentUser = getCurrentUser();
 
@@ -122,17 +124,17 @@ export const Route = createFileRoute("/_admin/worker/")({
 				: undefined,
 		]);
 	},
-	component: WorkerQueuePage,
+	component: QueuePage,
 });
 
-function WorkerQueuePage() {
+function QueuePage() {
 	const currentUser = getCurrentUser();
 	const navigate = useNavigate({ from: Route.fullPath });
 	const search = Route.useSearch();
 	const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
 	const [itemCode, setItemCode] = useState("");
-	const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
+	const [isFilterOpen, setIsFilterOpen] = useState(false);
 
 	const meQuery = useQuery({
 		...meQueryOptions(),
@@ -157,10 +159,7 @@ function WorkerQueuePage() {
 
 		if (userStoreIds.length > 0) {
 			void navigate({
-				search: (prev: { storeId?: number }) => ({
-					...prev,
-					storeId: userStoreIds[0],
-				}),
+				search: (prev) => ({ ...prev, storeId: userStoreIds[0] }),
 				replace: true,
 			});
 		}
@@ -213,6 +212,11 @@ function WorkerQueuePage() {
 			const nextOffset = lastPage.meta.offset + lastPage.meta.limit;
 			return nextOffset < lastPage.meta.total ? nextOffset : undefined;
 		},
+		enabled: parsedStoreId !== undefined,
+	});
+
+	const countsQuery = useQuery({
+		...orderServiceQueueCountsQueryOptions(parsedStoreId),
 		enabled: parsedStoreId !== undefined,
 	});
 
@@ -278,7 +282,7 @@ function WorkerQueuePage() {
 						return {
 							orderId: orderService.order.id,
 							storeId: orderService.order.store_id,
-							workerServiceId: orderService.id,
+							queueServiceId: orderService.id,
 						};
 					}
 				} catch {
@@ -298,16 +302,16 @@ function WorkerQueuePage() {
 			return {
 				orderId: orderService.order.id,
 				storeId: orderService.order.store_id,
-				workerServiceId: orderService.id,
+				queueServiceId: orderService.id,
 			};
 		},
 		onSuccess: (result) => {
-			if (result.workerServiceId !== undefined) {
+			if (result.queueServiceId !== undefined) {
 				void navigate({
-					to: "/worker/$orderId/$serviceId",
+					to: "/queue/$orderId/$serviceId",
 					params: {
 						orderId: String(result.orderId),
-						serviceId: String(result.workerServiceId),
+						serviceId: String(result.queueServiceId),
 					},
 				});
 				return;
@@ -340,7 +344,7 @@ function WorkerQueuePage() {
 	const navigateToQueueDetail = useCallback(
 		(item: QueueOrderServiceItem) => {
 			void navigate({
-				to: "/worker/$orderId/$serviceId",
+				to: "/queue/$orderId/$serviceId",
 				params: {
 					orderId: String(item.order_id),
 					serviceId: String(item.id),
@@ -352,10 +356,7 @@ function WorkerQueuePage() {
 
 	const updateStoreFilter = (value: string) => {
 		void navigate({
-			search: (prev: {
-				storeId?: number;
-				status?: (typeof ACTIVE_ORDER_SERVICE_STATUSES)[number];
-			}) => ({
+			search: (prev) => ({
 				...prev,
 				storeId: value ? Number(value) : undefined,
 			}),
@@ -364,12 +365,7 @@ function WorkerQueuePage() {
 
 	const updateStatusFilter = (value: string) => {
 		void navigate({
-			search: (prev: {
-				storeId?: number;
-				status?: (typeof ACTIVE_ORDER_SERVICE_STATUSES)[number];
-				dateFrom?: string;
-				dateTo?: string;
-			}) => ({
+			search: (prev) => ({
 				...prev,
 				status:
 					value && value !== "all"
@@ -381,12 +377,7 @@ function WorkerQueuePage() {
 
 	const updateDateRangeFilter = (next: { from?: string; to?: string } = {}) => {
 		void navigate({
-			search: (prev: {
-				storeId?: number;
-				status?: (typeof ACTIVE_ORDER_SERVICE_STATUSES)[number];
-				dateFrom?: string;
-				dateTo?: string;
-			}) => ({
+			search: (prev) => ({
 				...prev,
 				dateFrom: next.from,
 				dateTo: next.to,
@@ -394,67 +385,56 @@ function WorkerQueuePage() {
 		});
 	};
 
+	const activeFilterCount =
+		(selectedDateFrom || selectedDateTo ? 1 : 0) +
+		(role === "admin" && parsedStoreId !== undefined ? 1 : 0);
+
 	return (
 		<>
 			<PageHeader
-				title="Queue"
 				actions={
-					<Badge variant={queueQuery.isLoading ? "secondary" : "outline"}>
-						{`${totalItems} items`}
-					</Badge>
-				}
-			/>
-
-			<div className="grid gap-5">
-				<section className="grid gap-4 border border-border bg-background/70 p-4">
-					<div className="flex justify-end lg:hidden">
-						<Dialog
-							open={isMobileFilterOpen}
-							onOpenChange={setIsMobileFilterOpen}
-						>
+					<div className="flex items-center gap-2">
+						<Badge variant={queueQuery.isLoading ? "secondary" : "outline"}>
+							{`${totalItems} items`}
+						</Badge>
+						<Dialog onOpenChange={setIsFilterOpen} open={isFilterOpen}>
 							<DialogTrigger
 								render={
 									<Button
+										aria-label="Filters"
+										icon={<FunnelIcon className="size-4" />}
 										type="button"
 										variant="outline"
-										className="h-11 px-4"
 									/>
 								}
 							>
-								Filters
+								{activeFilterCount > 0 ? String(activeFilterCount) : null}
 							</DialogTrigger>
-							<DialogContent className="max-w-[calc(100%-1.5rem)] gap-5 p-4">
+							<DialogContent className="max-w-[calc(100%-1.5rem)] gap-5 p-4 sm:max-w-md">
 								<DialogHeader>
 									<DialogTitle>Filters</DialogTitle>
 								</DialogHeader>
 								<div className="grid gap-4">
 									<StoreAutocomplete
-										id="queue-store-mobile"
-										value={parsedStoreId?.toString() ?? ""}
-										onValueChange={updateStoreFilter}
 										allowedStoreIds={
 											role === "admin" ? undefined : userStoreIds
 										}
+										id="queue-store"
+										onValueChange={updateStoreFilter}
 										placeholder="Select store"
+										value={parsedStoreId?.toString() ?? ""}
 									/>
-
-									<QueueStatusTabs
-										value={selectedStatus ?? "all"}
-										onValueChange={updateStatusFilter}
-									/>
-
 									<DateRangePicker
 										commitOnComplete
 										from={selectedDateFrom}
-										to={selectedDateTo}
 										onChange={updateDateRangeFilter}
 										onClear={() => updateDateRangeFilter()}
+										to={selectedDateTo}
 									/>
-
 									<Button
-										type="button"
 										className="h-10 pointer-coarse:h-11"
-										onClick={() => setIsMobileFilterOpen(false)}
+										onClick={() => setIsFilterOpen(false)}
+										type="button"
 									>
 										Done
 									</Button>
@@ -462,110 +442,93 @@ function WorkerQueuePage() {
 							</DialogContent>
 						</Dialog>
 					</div>
+				}
+				title="Queue"
+			/>
 
-					<div className="grid gap-3 lg:grid-cols-[minmax(0,220px)_1fr]">
-						<div className="hidden lg:block">
-							<StoreAutocomplete
-								id="queue-store"
-								value={parsedStoreId?.toString() ?? ""}
-								onValueChange={updateStoreFilter}
-								allowedStoreIds={role === "admin" ? undefined : userStoreIds}
-								placeholder="Select store"
-							/>
-						</div>
-						<div className="grid gap-2">
-							<Field>
-								<FieldLabel htmlFor="queue-item-code">
-									Find order item
-								</FieldLabel>
-								<div className="grid gap-2 lg:flex lg:flex-row">
-									<Input
-										id="queue-item-code"
-										placeholder="Type item code, order ID, or line ID"
-										value={itemCode}
-										onChange={(event) => setItemCode(event.target.value)}
-									/>
-									<Button
-										type="button"
-										variant="outline"
-										className="h-10 pointer-coarse:h-11 w-full lg:w-auto lg:min-w-28"
-										icon={<MagnifyingGlassIcon className="size-4" />}
-										disabled={!itemCode.trim() || lookupMutation.isPending}
-										onClick={() => {
-											lookupMutation.mutate({
-												mode: "manual",
-												value: itemCode.trim(),
-											});
-										}}
-									>
-										Find
-									</Button>
-									<Button
-										type="button"
-										variant="outline"
-										className="h-10 pointer-coarse:h-11 w-full lg:w-auto lg:min-w-28"
-										icon={<ScanIcon className="size-4" />}
-										onClick={() => {
-											if (scanner.isScanning) {
-												scanner.stop();
-												return;
-											}
-
-											void scanner.start();
-										}}
-									>
-										{scanner.isScanning ? "Stop Scan" : "Scan Tag"}
-									</Button>
-								</div>
-							</Field>
-							{scanner.error ? (
-								<div className="flex items-center gap-2 text-sm text-destructive">
-									<WarningCircleIcon className="size-4" weight="fill" />
-									<span>{scanner.error}</span>
-								</div>
-							) : null}
-						</div>
-					</div>
-
-					<QueueStatusTabs
-						className="hidden lg:grid"
-						value={selectedStatus ?? "all"}
-						onValueChange={updateStatusFilter}
+			<div className="grid gap-3">
+				{/* One line, so the first queue row is above the fold on a phone. The
+				    old panel stacked a label, an input and two full-width buttons and
+				    pushed every item off screen. */}
+				<div className="flex items-center gap-2">
+					<Input
+						aria-label="Find by item code, order ID, or line ID"
+						className="min-w-0 flex-1"
+						onChange={(event) => setItemCode(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" && itemCode.trim()) {
+								lookupMutation.mutate({
+									mode: "manual",
+									value: itemCode.trim(),
+								});
+							}
+						}}
+						placeholder="Item code / order ID"
+						value={itemCode}
 					/>
+					<Button
+						aria-label="Find"
+						disabled={!itemCode.trim() || lookupMutation.isPending}
+						icon={<MagnifyingGlassIcon className="size-4" />}
+						onClick={() => {
+							lookupMutation.mutate({ mode: "manual", value: itemCode.trim() });
+						}}
+						size="icon-lg"
+						type="button"
+						variant="outline"
+					/>
+					<Button
+						aria-label={scanner.isScanning ? "Stop scan" : "Scan tag"}
+						icon={<ScanIcon className="size-4" />}
+						onClick={() => {
+							if (scanner.isScanning) {
+								scanner.stop();
+								return;
+							}
 
-					<div className="hidden lg:block">
-						<DateRangePicker
-							commitOnComplete
-							from={selectedDateFrom}
-							to={selectedDateTo}
-							onChange={updateDateRangeFilter}
-							onClear={() => updateDateRangeFilter()}
-						/>
+							void scanner.start();
+						}}
+						size="icon-lg"
+						type="button"
+						variant={scanner.isScanning ? "default" : "outline"}
+					/>
+				</div>
+
+				{scanner.error ? (
+					<div className="flex items-center gap-2 text-destructive text-sm">
+						<WarningCircleIcon className="size-4" weight="fill" />
+						<span>{scanner.error}</span>
 					</div>
+				) : null}
 
-					{scanner.isScanning ? (
-						<video
-							ref={scanner.videoRef}
-							className="aspect-video w-full border border-border object-cover"
-							autoPlay
-							playsInline
-							muted
-						/>
-					) : null}
-				</section>
+				{scanner.isScanning ? (
+					<video
+						autoPlay
+						className="aspect-video w-full border border-border object-cover"
+						muted
+						playsInline
+						ref={scanner.videoRef}
+					/>
+				) : null}
+
+				<QueueStatusTabs
+					counts={countsQuery.data}
+					onValueChange={updateStatusFilter}
+					value={selectedStatus ?? "all"}
+				/>
 
 				<section className="grid gap-2">
 					{role === "admin" && parsedStoreId === undefined ? (
-						<div className="border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+						<div className="border border-dashed border-border px-4 py-8 text-center text-muted-foreground text-sm">
 							Select a store.
 						</div>
 					) : null}
 
 					{queueItems.map((item) => (
 						<QueueRow
-							key={item.id}
-							item={item}
 							currentUserId={currentUser?.id}
+							item={item}
+							key={item.id}
 							onOpen={navigateToQueueDetail}
 						/>
 					))}
@@ -576,17 +539,17 @@ function WorkerQueuePage() {
 					    resolve. */}
 					{queueQuery.isLoading ? (
 						<div className="grid gap-2">
-							{Array.from({ length: 4 }, (_, index) => (
+							{Array.from({ length: 6 }, (_, index) => (
 								<div
+									className="h-20 animate-pulse border border-border bg-muted/40"
 									key={index}
-									className="h-28 animate-pulse border border-border bg-muted/40"
 								/>
 							))}
 						</div>
 					) : null}
 
 					{queueQuery.isError ? (
-						<div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+						<div className="border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive text-sm">
 							{queueQuery.error instanceof Error
 								? queueQuery.error.message
 								: "Failed to load the queue."}
@@ -597,16 +560,16 @@ function WorkerQueuePage() {
 					!queueQuery.isError &&
 					queueItems.length === 0 &&
 					parsedStoreId !== undefined ? (
-						<div className="border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+						<div className="border border-dashed border-border px-4 py-8 text-center text-muted-foreground text-sm">
 							No items.
 						</div>
 					) : null}
 
-					<div ref={loadMoreRef} className="h-6" />
+					<div className="h-6" ref={loadMoreRef} />
 
 					{queueQuery.isFetchingNextPage ? (
-						<p className="text-center text-sm text-muted-foreground">
-							Loading...
+						<p className="text-center text-muted-foreground text-sm">
+							Loading…
 						</p>
 					) : null}
 				</section>
@@ -615,35 +578,6 @@ function WorkerQueuePage() {
 	);
 }
 
-interface WaitingBadgeProps {
-	orderCreatedAt: string;
-}
-
-const WaitingBadge = ({ orderCreatedAt }: WaitingBadgeProps) => {
-	const [now, setNow] = useState(() => Date.now());
-
-	useEffect(() => {
-		const interval = setInterval(() => setNow(Date.now()), 60_000);
-		return () => clearInterval(interval);
-	}, []);
-
-	const elapsedMs = Math.max(0, now - new Date(orderCreatedAt).getTime());
-	const ageTone = getElapsedTone(elapsedMs);
-	const ageLabel = formatElapsedDuration(elapsedMs);
-
-	return (
-		<span
-			className={cn(
-				"inline-flex items-center gap-1 border px-2 py-0.5 font-mono text-[11px] tabular-nums",
-				AGE_TONE_CLASS[ageTone],
-			)}
-		>
-			<HourglassIcon className="size-3" />
-			{`Waiting ${ageLabel}`}
-		</span>
-	);
-};
-
 interface QueueRowProps {
 	item: QueueOrderServiceItem;
 	currentUserId?: number;
@@ -651,65 +585,73 @@ interface QueueRowProps {
 }
 
 const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
+	// One clock for the row, ticking a minute at a time: age is the whole point
+	// of the row, so a stale number is worse than the re-render.
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const interval = setInterval(() => setNow(Date.now()), 60_000);
+		return () => clearInterval(interval);
+	}, []);
+
+	const isTerminal = TERMINAL_QUEUE_STATUSES.has(item.status);
+	const elapsedMs = Math.max(
+		0,
+		now - new Date(item.order_created_at).getTime(),
+	);
+	const tone = getElapsedTone(elapsedMs);
+
 	const isHandledByCurrentUser =
 		currentUserId !== undefined && item.handler_id === currentUserId;
 	const isHandledByAnotherWorker =
 		item.handler_id !== null &&
 		item.handler_id !== undefined &&
 		!isHandledByCurrentUser;
-
-	const isTerminal = TERMINAL_QUEUE_STATUSES.has(item.status);
+	const assignment = isHandledByCurrentUser
+		? "Assigned to me"
+		: isHandledByAnotherWorker
+			? `Assigned to ${item.handler_name ?? "worker"}`
+			: "Open";
 
 	return (
 		<button
-			type="button"
-			className={cn(
-				"group grid gap-3 border border-border bg-background px-4 py-4 text-left transition-colors hover:bg-muted/40",
-				item.is_priority && "border-warning/40 bg-warning/5",
-			)}
+			className="group flex items-stretch gap-0 border border-border bg-background text-left transition-colors hover:bg-muted/40"
 			onClick={() => onOpen(item)}
+			type="button"
 		>
-			<div className="flex items-start justify-between gap-3">
-				<div className="grid gap-2">
-					<div className="flex flex-wrap items-center gap-2">
-						{item.is_priority ? (
-							<Badge variant="warning">Priority</Badge>
-						) : (
-							<Badge variant="outline">Standard</Badge>
+			{/* The stripe is the triage signal — colour at the edge of every row
+			    reads down a list without stopping to parse a badge. */}
+			<span
+				aria-hidden="true"
+				className={cn("w-1 shrink-0", AGE_STRIPE_CLASS[tone])}
+			/>
+			<span className="grid min-w-0 flex-1 gap-0.5 px-3 py-2.5">
+				<span className="flex items-baseline gap-2">
+					<span
+						className={cn(
+							"w-10 shrink-0 font-mono font-semibold text-sm tabular-nums",
+							AGE_TEXT_CLASS[tone],
 						)}
-						<Badge variant={getOrderServiceStatusBadgeVariant(item.status)}>
-							{formatOrderServiceStatus(item.status)}
-						</Badge>
-						<Badge variant={isHandledByCurrentUser ? "info" : "secondary"}>
-							{isHandledByCurrentUser
-								? "Assigned to me"
-								: isHandledByAnotherWorker
-									? `Assigned to ${item.handler_name ?? "worker"}`
-									: "Open"}
-						</Badge>
-						{isTerminal ? null : (
-							<WaitingBadge orderCreatedAt={item.order_created_at} />
-						)}
-					</div>
-					<div className="grid gap-1">
-						<p className="text-lg font-semibold tracking-tight">
-							{item.item_code ?? `Service #${item.id}`}
-						</p>
-						<p className="text-sm text-muted-foreground">{item.service_name}</p>
-					</div>
-				</div>
-				<CaretRightIcon
-					className="mt-1 size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-					weight="bold"
-				/>
-			</div>
-
-			<div className="grid gap-1 text-sm text-muted-foreground sm:grid-cols-2">
-				<p>{`Order ${item.order_code}`}</p>
-				<p>{formatOrderDateTime(item.order_created_at)}</p>
-				<p>{`Store ${item.store_code} - ${item.store_name}`}</p>
-				<p>{`Item ${formatOrderServiceItemDetails(item)}`}</p>
-			</div>
+					>
+						{isTerminal ? "—" : formatElapsedDuration(elapsedMs)}
+					</span>
+					<span className="min-w-0 flex-1 truncate font-mono font-semibold text-sm">
+						{item.item_code ?? `Service #${item.id}`}
+					</span>
+					<CaretRightIcon
+						className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+						weight="bold"
+					/>
+				</span>
+				<span className="truncate pl-12 text-muted-foreground text-xs">
+					{`${item.service_name} · ${formatOrderServiceItemDetails(item)}`}
+				</span>
+				<span className="truncate pl-12 text-muted-foreground text-xs">
+					{item.is_priority ? (
+						<span className="font-medium text-warning">Priority · </span>
+					) : null}
+					{assignment}
+				</span>
+			</span>
 		</button>
 	);
 });

--- a/apps/web/src/routes/_admin/queue.index.tsx
+++ b/apps/web/src/routes/_admin/queue.index.tsx
@@ -1,3 +1,4 @@
+import { PICKUP_OVERDUE_HOURS } from "@fresclean/api/schema";
 import {
 	CaretRightIcon,
 	FlagIcon,
@@ -42,7 +43,10 @@ import {
 	storesQueryOptions,
 } from "@/lib/query-options";
 import { readServerErrorMessage } from "@/lib/server-error";
-import { ACTIVE_ORDER_SERVICE_STATUSES } from "@/lib/status";
+import {
+	ACTIVE_ORDER_SERVICE_STATUSES,
+	formatOrderServiceStatus,
+} from "@/lib/status";
 import { cn } from "@/lib/utils";
 import { getCurrentUser } from "@/stores/auth-store";
 
@@ -56,10 +60,9 @@ const TERMINAL_QUEUE_STATUSES = new Set<QueueOrderServiceItem["status"]>([
 
 const HOUR_MS = 3_600_000;
 
-// The turnaround the shop promises. One threshold, not a four-step ramp: an
-// amber-at-24h/red-at-72h scale paints a whole backlog the same colour, and a
-// list where every row is red says nothing. Matches PICKUP_OVERDUE_HOURS.
-const TURNAROUND_MS = 72 * HOUR_MS;
+// One threshold, not a four-step ramp: an amber-at-24h/red-at-72h scale paints a
+// whole backlog the same colour, and a list where every row is red says nothing.
+const TURNAROUND_MS = PICKUP_OVERDUE_HOURS * HOUR_MS;
 
 // One timer for the whole list, not one per row: the queue scrolls to hundreds
 // of rows and each row used to own its own interval, so the clock cost grew
@@ -642,6 +645,16 @@ const QueueRow = memo(({ item, currentUserId, now, onOpen }: QueueRowProps) => {
 					/>
 				</span>
 				<span className="flex min-w-0 items-baseline gap-2 text-muted-foreground text-xs">
+					{/* On the All chip a queued Item and one back from a failed quality
+					    check are otherwise the same row, and triaging the rack means
+					    opening each one. Kept on the filtered chips too: a barcode scan
+					    and a search both land here spanning statuses. */}
+					<Badge
+						className="shrink-0 px-1.5 py-0 font-mono text-[10px] uppercase tracking-wide"
+						variant="outline"
+					>
+						{formatOrderServiceStatus(item.status)}
+					</Badge>
 					<span className="min-w-0 flex-1 truncate">{secondary}</span>
 					<span className="shrink-0 font-mono text-[10px]">
 						{item.item_code ?? `#${item.id}`}

--- a/apps/web/src/routes/_admin/queue.index.tsx
+++ b/apps/web/src/routes/_admin/queue.index.tsx
@@ -1,5 +1,6 @@
 import {
 	CaretRightIcon,
+	FlagIcon,
 	FunnelIcon,
 	MagnifyingGlassIcon,
 	ScanIcon,
@@ -34,7 +35,7 @@ import {
 	type QueueOrderServiceItem,
 	queryKeys,
 } from "@/lib/api";
-import { formatOrderServiceItemDetails } from "@/lib/order-service-item-details";
+import { getOrderServiceItemDetails } from "@/lib/order-service-item-details";
 import {
 	meQueryOptions,
 	orderServiceQueueCountsQueryOptions,
@@ -54,9 +55,11 @@ const TERMINAL_QUEUE_STATUSES = new Set<QueueOrderServiceItem["status"]>([
 ]);
 
 const HOUR_MS = 3_600_000;
-const DAY_MS = 24 * HOUR_MS;
 
-type AgeTone = "clean" | "aging" | "late" | "overdue";
+// The turnaround the shop promises. One threshold, not a four-step ramp: an
+// amber-at-24h/red-at-72h scale paints a whole backlog the same colour, and a
+// list where every row is red says nothing. Matches PICKUP_OVERDUE_HOURS.
+const TURNAROUND_MS = 72 * HOUR_MS;
 
 function formatElapsedDuration(ms: number): string {
 	const totalMinutes = Math.floor(ms / 60_000);
@@ -69,33 +72,6 @@ function formatElapsedDuration(ms: number): string {
 	}
 	return `${Math.floor(totalHours / 24)}d`;
 }
-
-function getElapsedTone(ms: number): AgeTone {
-	if (ms < 2 * HOUR_MS) {
-		return "clean";
-	}
-	if (ms < DAY_MS) {
-		return "aging";
-	}
-	if (ms < 3 * DAY_MS) {
-		return "late";
-	}
-	return "overdue";
-}
-
-const AGE_STRIPE_CLASS: Record<AgeTone, string> = {
-	clean: "bg-border",
-	aging: "bg-info",
-	late: "bg-warning",
-	overdue: "bg-destructive",
-};
-
-const AGE_TEXT_CLASS: Record<AgeTone, string> = {
-	clean: "text-muted-foreground",
-	aging: "text-info",
-	late: "text-warning",
-	overdue: "text-destructive",
-};
 
 const queueSearchSchema = z.object({
 	storeId: z.coerce.number().int().positive().optional(),
@@ -514,7 +490,7 @@ function QueuePage() {
 					value={selectedStatus ?? "all"}
 				/>
 
-				<section className="grid gap-2">
+				<section className="grid min-w-0 gap-2">
 					{role === "admin" && parsedStoreId === undefined ? (
 						<div className="border border-dashed border-border px-4 py-8 text-center text-muted-foreground text-sm">
 							Select a store.
@@ -591,56 +567,68 @@ const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
 		0,
 		now - new Date(item.order_created_at).getTime(),
 	);
-	const tone = getElapsedTone(elapsedMs);
+	const isBreached = !isTerminal && elapsedMs >= TURNAROUND_MS;
 
 	const isHandledByCurrentUser =
 		currentUserId !== undefined && item.handler_id === currentUserId;
-	const isHandledByAnotherWorker =
-		item.handler_id !== null &&
-		item.handler_id !== undefined &&
-		!isHandledByCurrentUser;
-	const assignment = isHandledByCurrentUser
-		? "Assigned to me"
-		: isHandledByAnotherWorker
-			? `Assigned to ${item.handler_name ?? "worker"}`
-			: "Open";
+	const handler = isHandledByCurrentUser
+		? "Me"
+		: (item.handler_name ?? (item.handler_id === null ? null : "Worker"));
+
+	// Lead with whatever actually identifies the Item. Descriptors are optional at
+	// intake, so a fixed "descriptors on top" row shouts "No item details" at full
+	// weight and demotes the service — the only thing left that says anything.
+	const descriptors = getOrderServiceItemDetails(item);
+	const secondary = [descriptors ? item.service_name : null, handler]
+		.filter(Boolean)
+		.join(" · ");
 
 	return (
+		// min-w-0 at every level down to the truncating text: without it the row's
+		// min-content sizes the auto grid column, and the search field and status
+		// chips above — siblings in that same column — get pushed off screen.
 		<button
-			className="group flex items-stretch gap-0 border border-border bg-background text-left transition-colors hover:bg-muted/40"
+			className="group flex min-w-0 items-stretch gap-0 border border-border bg-background text-left transition-colors hover:bg-muted/40"
 			onClick={() => onOpen(item)}
 			type="button"
 		>
 			<span
 				aria-hidden="true"
-				className={cn("w-1 shrink-0", AGE_STRIPE_CLASS[tone])}
+				className={cn(
+					"w-1 shrink-0",
+					isBreached ? "bg-destructive" : "bg-border",
+				)}
 			/>
 			<span className="grid min-w-0 flex-1 gap-0.5 px-3 py-2.5">
-				<span className="flex items-baseline gap-2">
+				<span className="flex min-w-0 items-baseline gap-2">
+					{item.is_priority ? (
+						<FlagIcon
+							aria-label="Priority"
+							className="size-3.5 shrink-0 self-center text-warning"
+							weight="fill"
+						/>
+					) : null}
+					<span className="min-w-0 flex-1 truncate font-medium text-sm">
+						{descriptors ?? item.service_name}
+					</span>
 					<span
 						className={cn(
-							"w-10 shrink-0 font-mono font-semibold text-sm tabular-nums",
-							AGE_TEXT_CLASS[tone],
+							"shrink-0 font-mono font-semibold text-sm tabular-nums",
+							isBreached ? "text-destructive" : "text-muted-foreground",
 						)}
 					>
 						{isTerminal ? "—" : formatElapsedDuration(elapsedMs)}
-					</span>
-					<span className="min-w-0 flex-1 truncate font-mono font-semibold text-sm">
-						{item.item_code ?? `Service #${item.id}`}
 					</span>
 					<CaretRightIcon
 						className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
 						weight="bold"
 					/>
 				</span>
-				<span className="truncate pl-12 text-muted-foreground text-xs">
-					{`${item.service_name} · ${formatOrderServiceItemDetails(item)}`}
-				</span>
-				<span className="truncate pl-12 text-muted-foreground text-xs">
-					{item.is_priority ? (
-						<span className="font-medium text-warning">Priority · </span>
-					) : null}
-					{assignment}
+				<span className="flex min-w-0 items-baseline gap-2 text-muted-foreground text-xs">
+					<span className="min-w-0 flex-1 truncate">{secondary}</span>
+					<span className="shrink-0 font-mono text-[10px]">
+						{item.item_code ?? `#${item.id}`}
+					</span>
 				</span>
 			</span>
 		</button>

--- a/apps/web/src/routes/_admin/queue.index.tsx
+++ b/apps/web/src/routes/_admin/queue.index.tsx
@@ -61,6 +61,20 @@ const HOUR_MS = 3_600_000;
 // list where every row is red says nothing. Matches PICKUP_OVERDUE_HOURS.
 const TURNAROUND_MS = 72 * HOUR_MS;
 
+// One timer for the whole list, not one per row: the queue scrolls to hundreds
+// of rows and each row used to own its own interval, so the clock cost grew
+// with the backlog and every row ticked on its own drifting phase.
+function useMinuteClock(): number {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		const interval = setInterval(() => setNow(Date.now()), 60_000);
+		return () => clearInterval(interval);
+	}, []);
+
+	return now;
+}
+
 function formatElapsedDuration(ms: number): string {
 	const totalMinutes = Math.floor(ms / 60_000);
 	if (totalMinutes < 60) {
@@ -111,6 +125,7 @@ function QueuePage() {
 
 	const [itemCode, setItemCode] = useState("");
 	const [isFilterOpen, setIsFilterOpen] = useState(false);
+	const now = useMinuteClock();
 
 	const meQuery = useQuery({
 		...meQueryOptions(),
@@ -428,8 +443,14 @@ function QueuePage() {
 						aria-label="Find by item code, order ID, or line ID"
 						className="min-w-0 flex-1"
 						onChange={(event) => setItemCode(event.target.value)}
+						// Same guard the Find button carries: without it a held Enter
+						// fires a second lookup over the first and navigates twice.
 						onKeyDown={(event) => {
-							if (event.key === "Enter" && itemCode.trim()) {
+							if (
+								event.key === "Enter" &&
+								itemCode.trim() &&
+								!lookupMutation.isPending
+							) {
 								lookupMutation.mutate({
 									mode: "manual",
 									value: itemCode.trim(),
@@ -502,6 +523,7 @@ function QueuePage() {
 							currentUserId={currentUser?.id}
 							item={item}
 							key={item.id}
+							now={now}
 							onOpen={navigateToQueueDetail}
 						/>
 					))}
@@ -552,16 +574,11 @@ function QueuePage() {
 interface QueueRowProps {
 	item: QueueOrderServiceItem;
 	currentUserId?: number;
+	now: number;
 	onOpen: (item: QueueOrderServiceItem) => void;
 }
 
-const QueueRow = memo(({ item, currentUserId, onOpen }: QueueRowProps) => {
-	const [now, setNow] = useState(() => Date.now());
-	useEffect(() => {
-		const interval = setInterval(() => setNow(Date.now()), 60_000);
-		return () => clearInterval(interval);
-	}, []);
-
+const QueueRow = memo(({ item, currentUserId, now, onOpen }: QueueRowProps) => {
 	const isTerminal = TERMINAL_QUEUE_STATUSES.has(item.status);
 	const elapsedMs = Math.max(
 		0,

--- a/apps/web/src/routes/_admin/route.tsx
+++ b/apps/web/src/routes/_admin/route.tsx
@@ -84,7 +84,7 @@ const pageMeta: Record<string, { title: string; description?: string }> = {
 		title: "Users",
 		description: "Insert and edit users with role management.",
 	},
-	"/worker": {
+	"/queue": {
 		title: "Queue",
 		description:
 			"Priority-first worker queue with item detail and photo upload.",
@@ -95,7 +95,7 @@ function AdminLayout() {
 	const { pathname } = useLocation();
 	const meta =
 		pageMeta[pathname] ??
-		(pathname.startsWith("/worker/")
+		(pathname.startsWith("/queue/")
 			? {
 					title: "Queue Detail",
 					description: "Update one queue item and upload progress photos.",

--- a/apps/web/src/routes/_admin/worker.index.tsx
+++ b/apps/web/src/routes/_admin/worker.index.tsx
@@ -399,7 +399,7 @@ function WorkerQueuePage() {
 			<PageHeader
 				title="Queue"
 				actions={
-					<Badge variant={queueQuery.isPending ? "secondary" : "outline"}>
+					<Badge variant={queueQuery.isLoading ? "secondary" : "outline"}>
 						{`${totalItems} items`}
 					</Badge>
 				}
@@ -570,7 +570,11 @@ function WorkerQueuePage() {
 						/>
 					))}
 
-					{queueQuery.isPending ? (
+					{/* isLoading, not isPending: with no store picked the query is
+					    disabled, and a disabled query stays pending forever — gating on
+					    isPending stacks four skeletons under "Select a store." that never
+					    resolve. */}
+					{queueQuery.isLoading ? (
 						<div className="grid gap-2">
 							{Array.from({ length: 4 }, (_, index) => (
 								<div
@@ -589,7 +593,7 @@ function WorkerQueuePage() {
 						</div>
 					) : null}
 
-					{!queueQuery.isPending &&
+					{!queueQuery.isLoading &&
 					!queueQuery.isError &&
 					queueItems.length === 0 &&
 					parsedStoreId !== undefined ? (

--- a/apps/web/src/routes/auth/login.tsx
+++ b/apps/web/src/routes/auth/login.tsx
@@ -18,7 +18,7 @@ const loginSchema = z.object({
 
 const landingRouteForRole = (role?: string) => {
 	if (role === "worker") {
-		return "/worker" as const;
+		return "/queue" as const;
 	}
 	if (role === "cashier") {
 		return "/transactions" as const;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -476,6 +476,14 @@ export const ordersTable = pgTable(
       .notNull()
       .default(sql`lpad(floor(random() * 1000000)::text, 6, '0')`),
 
+    // When the Item actually reached the shelf and the customer could first come
+    // for it. The overdue shelf is measured from here, never from created_at: a
+    // repair booked Monday and finished Thursday has been collectable for an
+    // hour, not for three days. Null unless the order is standing ready now —
+    // recomputeOrderRollup clears it when work reopens, so the clock restarts
+    // from the day the customer was next told to come.
+    ready_at: timestamp("ready_at"),
+
     refunded_amount: decimal("refunded_amount", { precision: 12, scale: 0 })
       .default("0")
       .notNull(),

--- a/packages/server/src/modules/orders/order-admin.schema.ts
+++ b/packages/server/src/modules/orders/order-admin.schema.ts
@@ -222,8 +222,17 @@ export const GETOrderServiceQueueQuerySchema = z
     }
   );
 
+export const GETOrderServiceQueueCountsQuerySchema = z
+  .object({
+    store_id: z.coerce.number().int().positive().optional(),
+  })
+  .optional();
+
 export type GetMyOrderServicesQuery = z.infer<
   typeof GETMyOrderServicesQuerySchema
+>;
+export type GetOrderServiceQueueCountsQuery = z.infer<
+  typeof GETOrderServiceQueueCountsQuerySchema
 >;
 export type GetOrderServiceQueueQuery = z.infer<
   typeof GETOrderServiceQueueQuerySchema

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -152,7 +152,7 @@ export async function getMyOrderServices(
     .orderBy(asc(ordersServicesTable.id));
 }
 
-// Null means this account has no branch yet: an empty queue, not the company's.
+// Null means "no branch assigned" — an empty queue, not an unscoped one.
 async function resolveQueueStoreCondition(user: JWTPayload, storeId?: number) {
   const scope = await resolveStoreScope(user, storeId);
 
@@ -163,8 +163,6 @@ async function resolveQueueStoreCondition(user: JWTPayload, storeId?: number) {
       return inArray(ordersTable.store_id, scope.storeIds);
     case "none":
       return null;
-    // Unlike the other lists, an unscoped floor is useless here: every branch's
-    // work in one queue is a list nobody can work from, so the admin must pick.
     case "all":
       throw new BadRequestException("Store is required for admin queue access");
     default:
@@ -293,9 +291,8 @@ const EMPTY_QUEUE_COUNTS = {
   ready_for_pickup: 0,
 };
 
-// How much work is sitting in each status right now, for the strip a worker
-// taps to filter by. Branch-scoped only: a count that also honoured the date
-// range would describe the page already on screen.
+// Branch-scoped only, deliberately: honouring the date range too would just
+// count what is already on screen.
 export async function getOrderServiceQueueCounts(
   user: JWTPayload,
   query?: GetOrderServiceQueueCountsQuery
@@ -332,9 +329,8 @@ export async function getOrderServiceQueueCounts(
   const countOf = (status: OrderService["status"]) =>
     totalByStatus.get(status) ?? 0;
 
-  // Spelled out rather than derived from the enum: a status added to the
-  // workshop has to be given a chip here on purpose, not silently counted
-  // into nothing.
+  // Listed by hand, not mapped over the enum: a new workshop status must be
+  // given a chip on purpose rather than counted into nothing.
   return {
     all: rows.reduce((sum, row) => sum + Number(row.total), 0),
     queued: countOf("queued"),

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -22,6 +22,7 @@ import { BadRequestException, ForbiddenException } from "@/http-exceptions";
 import type { OrderTx } from "@/modules/orders/order.repository";
 import type {
   GetMyOrderServicesQuery,
+  GetOrderServiceQueueCountsQuery,
   GetOrderServiceQueueQuery,
   PatchOrderServiceHandlerInput,
   PatchOrderServiceStatusInput,
@@ -151,32 +152,17 @@ export async function getMyOrderServices(
     .orderBy(asc(ordersServicesTable.id));
 }
 
-export async function getOrderServiceQueue(
-  user: JWTPayload,
-  query?: GetOrderServiceQueueQuery
-) {
-  const normalized = normalizeOrderServiceQueueQuery(query);
-  const conditions = [
-    notInArray(ordersServicesTable.status, [
-      ...ORDER_TERMINAL_SERVICE_STATUSES,
-    ]),
-  ];
-
-  const scope = await resolveStoreScope(user, normalized.store_id);
+// Null means this account has no branch yet: an empty queue, not the company's.
+async function resolveQueueStoreCondition(user: JWTPayload, storeId?: number) {
+  const scope = await resolveStoreScope(user, storeId);
 
   switch (scope.kind) {
     case "one":
-      conditions.push(eq(ordersTable.store_id, scope.storeId));
-      break;
+      return eq(ordersTable.store_id, scope.storeId);
     case "some":
-      conditions.push(inArray(ordersTable.store_id, scope.storeIds));
-      break;
-    // A worker with no branch yet gets an empty page, not the company queue.
+      return inArray(ordersTable.store_id, scope.storeIds);
     case "none":
-      return {
-        items: [],
-        meta: buildPaginationMeta(0, normalized),
-      };
+      return null;
     // Unlike the other lists, an unscoped floor is useless here: every branch's
     // work in one queue is a list nobody can work from, so the admin must pick.
     case "all":
@@ -184,6 +170,31 @@ export async function getOrderServiceQueue(
     default:
       return unhandledStoreScope(scope);
   }
+}
+
+export async function getOrderServiceQueue(
+  user: JWTPayload,
+  query?: GetOrderServiceQueueQuery
+) {
+  const normalized = normalizeOrderServiceQueueQuery(query);
+  const storeCondition = await resolveQueueStoreCondition(
+    user,
+    normalized.store_id
+  );
+
+  if (storeCondition === null) {
+    return {
+      items: [],
+      meta: buildPaginationMeta(0, normalized),
+    };
+  }
+
+  const conditions = [
+    notInArray(ordersServicesTable.status, [
+      ...ORDER_TERMINAL_SERVICE_STATUSES,
+    ]),
+    storeCondition,
+  ];
 
   if (normalized.status !== undefined) {
     conditions.push(eq(ordersServicesTable.status, normalized.status));
@@ -270,6 +281,67 @@ export async function getOrderServiceQueue(
   return {
     items,
     meta: buildPaginationMeta(Number(countRows[0]?.total ?? 0), normalized),
+  };
+}
+
+const EMPTY_QUEUE_COUNTS = {
+  all: 0,
+  queued: 0,
+  processing: 0,
+  quality_check: 0,
+  qc_reject: 0,
+  ready_for_pickup: 0,
+};
+
+// How much work is sitting in each status right now, for the strip a worker
+// taps to filter by. Branch-scoped only: a count that also honoured the date
+// range would describe the page already on screen.
+export async function getOrderServiceQueueCounts(
+  user: JWTPayload,
+  query?: GetOrderServiceQueueCountsQuery
+) {
+  const storeCondition = await resolveQueueStoreCondition(
+    user,
+    query?.store_id
+  );
+
+  if (storeCondition === null) {
+    return EMPTY_QUEUE_COUNTS;
+  }
+
+  const rows = await db
+    .select({
+      status: ordersServicesTable.status,
+      total: sql<number>`count(*)`,
+    })
+    .from(ordersServicesTable)
+    .innerJoin(ordersTable, eq(ordersServicesTable.order_id, ordersTable.id))
+    .where(
+      and(
+        notInArray(ordersServicesTable.status, [
+          ...ORDER_TERMINAL_SERVICE_STATUSES,
+        ]),
+        storeCondition
+      )
+    )
+    .groupBy(ordersServicesTable.status);
+
+  const totalByStatus = new Map(
+    rows.map((row) => [row.status, Number(row.total)])
+  );
+  const countOf = (status: OrderService["status"]) =>
+    totalByStatus.get(status) ?? 0;
+
+  // Spelled out rather than derived from the enum: a status added to the
+  // workshop has to be given a chip here on purpose, not silently counted
+  // into nothing.
+  return {
+    all: rows.reduce((sum, row) => sum + Number(row.total), 0),
+    queued: countOf("queued"),
+    processing: countOf("processing"),
+    quality_check: countOf("quality_check"),
+    qc_reject: countOf("qc_reject"),
+    ready_for_pickup: countOf("ready_for_pickup"),
   };
 }
 

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -282,17 +282,6 @@ export async function getOrderServiceQueue(
   };
 }
 
-// A factory, not a shared constant: handing every unassigned worker the same
-// object means one caller mutating it changes what the next request is told.
-const emptyQueueCounts = () => ({
-  all: 0,
-  queued: 0,
-  processing: 0,
-  quality_check: 0,
-  qc_reject: 0,
-  ready_for_pickup: 0,
-});
-
 // Branch-scoped only, deliberately: honouring the date range too would just
 // count what is already on screen.
 export async function getOrderServiceQueueCounts(
@@ -304,8 +293,16 @@ export async function getOrderServiceQueueCounts(
     query?.store_id
   );
 
+  // A worker with no branch yet: an empty rack, not the company's.
   if (storeCondition === null) {
-    return emptyQueueCounts();
+    return {
+      all: 0,
+      queued: 0,
+      processing: 0,
+      quality_check: 0,
+      qc_reject: 0,
+      ready_for_pickup: 0,
+    };
   }
 
   const rows = await db

--- a/packages/server/src/modules/orders/order-queue.service.ts
+++ b/packages/server/src/modules/orders/order-queue.service.ts
@@ -282,14 +282,16 @@ export async function getOrderServiceQueue(
   };
 }
 
-const EMPTY_QUEUE_COUNTS = {
+// A factory, not a shared constant: handing every unassigned worker the same
+// object means one caller mutating it changes what the next request is told.
+const emptyQueueCounts = () => ({
   all: 0,
   queued: 0,
   processing: 0,
   quality_check: 0,
   qc_reject: 0,
   ready_for_pickup: 0,
-};
+});
 
 // Branch-scoped only, deliberately: honouring the date range too would just
 // count what is already on screen.
@@ -303,7 +305,7 @@ export async function getOrderServiceQueueCounts(
   );
 
   if (storeCondition === null) {
-    return EMPTY_QUEUE_COUNTS;
+    return emptyQueueCounts();
   }
 
   const rows = await db

--- a/packages/server/src/modules/orders/order-status-machine.test.ts
+++ b/packages/server/src/modules/orders/order-status-machine.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { is, SQL } from "drizzle-orm";
 import { orderServiceStatusEnum } from "@/db/schema";
 import { BadRequestException } from "@/http-exceptions";
 import {
@@ -6,6 +7,7 @@ import {
   type DbExecutor,
   deriveOrderStatus,
   isTerminalOrderServiceStatus,
+  nextReadyAt,
   ORDER_SERVICE_TRANSITIONS,
   ORDER_TERMINAL_SERVICE_STATUSES,
   type OrderServiceStatus,
@@ -304,5 +306,30 @@ describe("summarizeOrderFulfillment", () => {
     ]);
     expect(summary.is_ready_for_pickup).toBe(true);
     expect(summary.is_partially_picked_up).toBe(false);
+  });
+});
+
+describe("nextReadyAt shelf clock", () => {
+  it("does not restart the wait when a rollup finds the order still on the shelf", () => {
+    // Editing a repair price or taking payment recomputes the order. Stamping
+    // the current time here would push the shelf clock forward every time, and
+    // a pair nobody has collected in a week would never reach the Overdue pill.
+    // A plain Date is exactly that regression, so reject one.
+    const readyAt = nextReadyAt("ready_for_pickup");
+
+    expect(readyAt).not.toBeInstanceOf(Date);
+    expect(is(readyAt, SQL)).toBe(true);
+  });
+
+  it("clears the shelf clock when work reopens", () => {
+    // A failed quality check sends the Item back to the workshop. The customer
+    // cannot collect it, so the wait starts over when it returns to the shelf.
+    expect(nextReadyAt("processing")).toBeNull();
+    expect(nextReadyAt("created")).toBeNull();
+  });
+
+  it("clears the shelf clock once the order is off the books", () => {
+    expect(nextReadyAt("completed")).toBeNull();
+    expect(nextReadyAt("cancelled")).toBeNull();
   });
 });

--- a/packages/server/src/modules/orders/order-status-machine.ts
+++ b/packages/server/src/modules/orders/order-status-machine.ts
@@ -146,6 +146,18 @@ export function billableOrderTotal(
   return serviceTotal + productTotal;
 }
 
+// When the shelf clock should read from, given where the order just landed.
+// coalesce rather than a fresh now(): a rollup fired by a price edit or a
+// payment must not push the clock forward, or an order sitting uncollected for a
+// week would never surface as overdue. Null on any other status, so a qc_reject
+// sending the Item back to the workshop restarts the wait from the day the
+// customer is next told to come.
+export function nextReadyAt(status: DerivedOrderStatus) {
+  return status === "ready_for_pickup"
+    ? sql`coalesce(${ordersTable.ready_at}, now())`
+    : null;
+}
+
 export async function recomputeOrderRollup(
   executor: DbExecutor,
   orderId: number,
@@ -171,6 +183,7 @@ export async function recomputeOrderRollup(
       status: nextStatus,
       completed_at: nextStatus === "completed" ? new Date() : null,
       cancelled_at: nextStatus === "cancelled" ? new Date() : null,
+      ready_at: nextReadyAt(nextStatus),
       total: nextTotal.toString(),
       // A promo the customer already earned stays (ADR-0015), but it can
       // never be worth more than what is left to pay, so on a mostly

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -275,7 +275,10 @@ export async function findOrders(
       continue;
     }
 
-    const descriptors = [row.brand, row.color, row.model, row.size]
+    // brand · model · color · size — the same order the web's
+    // getOrderServiceItemDescriptors uses, so /orders and /queue name one Item
+    // the same way round.
+    const descriptors = [row.brand, row.model, row.color, row.size]
       .map((value) => value?.trim())
       .filter((value): value is string => Boolean(value));
 

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -8,14 +8,17 @@ import {
   ordersTable,
 } from "@/db/schema";
 import { BadRequestException } from "@/http-exceptions";
-import type { NormalizedOrderListQuery } from "@/modules/orders/order.schema";
+import type {
+  NormalizedOrderListQuery,
+  OrderListFilters,
+} from "@/modules/orders/order.schema";
 import {
   deriveOrderRefundStatus,
   type OrderRefundStatus,
 } from "@/modules/orders/order-refund-status";
 import { isNumericSearch } from "@/modules/orders/order-search";
 import { summarizeOrderFulfillment } from "@/modules/orders/order-status-machine";
-import { jakartaDayEnd, jakartaDayStart } from "@/utils/date";
+import { jakartaDayEnd, jakartaDayStart, jakartaNow } from "@/utils/date";
 
 export type OrderTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -54,6 +57,10 @@ export interface OrderListItem {
   discount: string;
   fulfillment: ReturnType<typeof summarizeOrderFulfillment>;
   id: number;
+  // What the customer will say at the counter — "the black Nikes, size 42" —
+  // taken from the first live Item on the Order. An Order named only by its
+  // Service reads "Repair · Repair" and identifies nothing.
+  item_descriptors: string[];
   notes: string | null;
   payment_method_id: number | null;
   payment_method_name: string | null;
@@ -78,10 +85,12 @@ interface FindOrdersResult {
   total: number;
 }
 
-function buildOrderWhere(
-  filters: NormalizedOrderListQuery,
-  scopedStoreIds?: number[]
-) {
+// How long finished work may sit on the shelf before the counter should be
+// chasing the customer. Same 72h the workshop board paints red, so an aged Item
+// and an uncollected Order mean the same thing to whoever is looking.
+const PICKUP_OVERDUE_HOURS = 72;
+
+function buildOrderWhere(filters: OrderListFilters, scopedStoreIds?: number[]) {
   const conditions: Record<string, unknown>[] = [];
 
   if (scopedStoreIds !== undefined) {
@@ -98,6 +107,15 @@ function buildOrderWhere(
 
   if (filters.payment_status) {
     conditions.push({ payment_status: filters.payment_status });
+  }
+
+  if (filters.overdue) {
+    conditions.push({ status: "ready_for_pickup" });
+    conditions.push({
+      created_at: {
+        lt: jakartaNow().subtract(PICKUP_OVERDUE_HOURS, "hour").toDate(),
+      },
+    });
   }
 
   if (filters.store_id) {
@@ -219,12 +237,7 @@ export async function findOrders(
       limit: filters.limit,
       offset: filters.offset,
     }),
-    db.query.ordersTable
-      .findMany({
-        where: buildOrderWhere(filters, scopedStoreIds),
-        columns: { id: true },
-      })
-      .then((rows) => rows.length),
+    countOrders(filters, scopedStoreIds),
   ]);
 
   const orderIds = rows.map((row) => row.id);
@@ -236,13 +249,21 @@ export async function findOrders(
           columns: {
             order_id: true,
             status: true,
+            brand: true,
+            color: true,
+            model: true,
+            size: true,
           },
+          // Intake order, so the Item the counter keyed first is the one that
+          // names the Order.
+          orderBy: { id: "asc" },
         });
 
   const groupedStatuses = new Map<
     number,
     (typeof serviceRows)[number]["status"][]
   >();
+  const descriptorsByOrderId = new Map<number, string[]>();
 
   for (const row of serviceRows) {
     if (row.order_id === null) {
@@ -252,6 +273,20 @@ export async function findOrders(
     const current = groupedStatuses.get(row.order_id) ?? [];
     current.push(row.status);
     groupedStatuses.set(row.order_id, current);
+
+    // First *described* live line wins, not simply the first: an Item keyed
+    // with nothing but its Service would otherwise blank the whole row.
+    if (row.status === "cancelled" || descriptorsByOrderId.has(row.order_id)) {
+      continue;
+    }
+
+    const descriptors = [row.brand, row.color, row.model, row.size]
+      .map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value));
+
+    if (descriptors.length > 0) {
+      descriptorsByOrderId.set(row.order_id, descriptors);
+    }
   }
 
   const items: OrderListItem[] = rows.map((row) => ({
@@ -279,12 +314,27 @@ export async function findOrders(
     created_by: row.created_by,
     updated_by: row.updated_by,
     fulfillment: summarizeOrderFulfillment(groupedStatuses.get(row.id) ?? []),
+    item_descriptors: descriptorsByOrderId.get(row.id) ?? [],
   }));
 
   return {
     items,
     total,
   };
+}
+
+// Same predicate the list runs, without paging it — so a filter pill's count
+// and the total on the page it opens can never disagree.
+export function countOrders(
+  filters: OrderListFilters,
+  scopedStoreIds?: number[]
+): Promise<number> {
+  return db.query.ordersTable
+    .findMany({
+      where: buildOrderWhere(filters, scopedStoreIds),
+      columns: { id: true },
+    })
+    .then((rows) => rows.length);
 }
 
 export async function reserveNextOrderNumber(

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -57,9 +57,6 @@ export interface OrderListItem {
   discount: string;
   fulfillment: ReturnType<typeof summarizeOrderFulfillment>;
   id: number;
-  // What the customer will say at the counter — "the black Nikes, size 42" —
-  // taken from the first live Item on the Order. An Order named only by its
-  // Service reads "Repair · Repair" and identifies nothing.
   item_descriptors: string[];
   notes: string | null;
   payment_method_id: number | null;
@@ -85,9 +82,8 @@ interface FindOrdersResult {
   total: number;
 }
 
-// How long finished work may sit on the shelf before the counter should be
-// chasing the customer. Same 72h the workshop board paints red, so an aged Item
-// and an uncollected Order mean the same thing to whoever is looking.
+// Same 72h the queue paints red for an aged Item, so both screens agree on what
+// "late" means.
 const PICKUP_OVERDUE_HOURS = 72;
 
 function buildOrderWhere(filters: OrderListFilters, scopedStoreIds?: number[]) {
@@ -254,8 +250,7 @@ export async function findOrders(
             model: true,
             size: true,
           },
-          // Intake order, so the Item the counter keyed first is the one that
-          // names the Order.
+          // Intake order — item_descriptors below reads the first row.
           orderBy: { id: "asc" },
         });
 
@@ -274,8 +269,8 @@ export async function findOrders(
     current.push(row.status);
     groupedStatuses.set(row.order_id, current);
 
-    // First *described* live line wins, not simply the first: an Item keyed
-    // with nothing but its Service would otherwise blank the whole row.
+    // First *described* live line, not simply the first: an Item keyed with
+    // nothing but its Service would otherwise blank the whole row.
     if (row.status === "cancelled" || descriptorsByOrderId.has(row.order_id)) {
       continue;
     }
@@ -323,18 +318,18 @@ export async function findOrders(
   };
 }
 
-// Same predicate the list runs, without paging it — so a filter pill's count
-// and the total on the page it opens can never disagree.
-export function countOrders(
+// Counts by fetching ids rather than db.$count(), because $count() cannot take
+// the relational builder's object `where` — and reusing buildOrderWhere is what
+// keeps a pill's number equal to the total of the page it opens.
+export async function countOrders(
   filters: OrderListFilters,
   scopedStoreIds?: number[]
 ): Promise<number> {
-  return db.query.ordersTable
-    .findMany({
-      where: buildOrderWhere(filters, scopedStoreIds),
-      columns: { id: true },
-    })
-    .then((rows) => rows.length);
+  const rows = await db.query.ordersTable.findMany({
+    where: buildOrderWhere(filters, scopedStoreIds),
+    columns: { id: true },
+  });
+  return rows.length;
 }
 
 export async function reserveNextOrderNumber(

--- a/packages/server/src/modules/orders/order.repository.ts
+++ b/packages/server/src/modules/orders/order.repository.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/orders/order-refund-status";
 import { isNumericSearch } from "@/modules/orders/order-search";
 import { summarizeOrderFulfillment } from "@/modules/orders/order-status-machine";
+import { PICKUP_OVERDUE_HOURS } from "@/schema/turnaround";
 import { jakartaDayEnd, jakartaDayStart, jakartaNow } from "@/utils/date";
 
 export type OrderTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -82,10 +83,6 @@ interface FindOrdersResult {
   total: number;
 }
 
-// Same 72h the queue paints red for an aged Item, so both screens agree on what
-// "late" means.
-const PICKUP_OVERDUE_HOURS = 72;
-
 function buildOrderWhere(filters: OrderListFilters, scopedStoreIds?: number[]) {
   const conditions: Record<string, unknown>[] = [];
 
@@ -107,8 +104,11 @@ function buildOrderWhere(filters: OrderListFilters, scopedStoreIds?: number[]) {
 
   if (filters.overdue) {
     conditions.push({ status: "ready_for_pickup" });
+    // Aged from the shelf, not from intake. A null ready_at drops out of `lt`
+    // on its own, which is the wanted answer: an order nobody has finished has
+    // not kept the customer waiting for a collection it could not make.
     conditions.push({
-      created_at: {
+      ready_at: {
         lt: jakartaNow().subtract(PICKUP_OVERDUE_HOURS, "hour").toDate(),
       },
     });
@@ -321,18 +321,23 @@ export async function findOrders(
   };
 }
 
-// Counts by fetching ids rather than db.$count(), because $count() cannot take
-// the relational builder's object `where` — and reusing buildOrderWhere is what
-// keeps a pill's number equal to the total of the page it opens.
+// Postgres does the counting and hands back one row. db.$count() cannot take the
+// relational builder's object `where`, and a second SQL-level where-builder is
+// how a pill's number stops matching the total of the page it opens — so the
+// count rides along on buildOrderWhere itself. The window runs before LIMIT, so
+// the single row carries the count of every match, not of the row returned.
 export async function countOrders(
   filters: OrderListFilters,
   scopedStoreIds?: number[]
 ): Promise<number> {
-  const rows = await db.query.ordersTable.findMany({
+  const [row] = await db.query.ordersTable.findMany({
     where: buildOrderWhere(filters, scopedStoreIds),
     columns: { id: true },
+    extras: { total: sql<number>`(count(*) over ())::int`.as("total") },
+    limit: 1,
   });
-  return rows.length;
+  // No row means nothing matched — the window had nothing to report it on.
+  return row?.total ?? 0;
 }
 
 export async function reserveNextOrderNumber(

--- a/packages/server/src/modules/orders/order.schema.test.ts
+++ b/packages/server/src/modules/orders/order.schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { GETOrdersQuerySchema } from "@/modules/orders/order.schema";
+
+describe("GETOrdersQuerySchema overdue/status pairing", () => {
+  it("rejects a status that contradicts overdue", () => {
+    // An overdue Item is by definition still on the ready-for-pickup shelf, so
+    // asking for overdue collected orders describes nothing the shop can hold.
+    // Answered as an empty list it reads as "no late orders" — the reassurance
+    // the counter must never get from a question it did not ask.
+    expect(
+      GETOrdersQuerySchema.safeParse({ overdue: "true", status: "completed" })
+        .success
+    ).toBe(false);
+  });
+
+  it("accepts overdue paired with the shelf it already implies", () => {
+    expect(
+      GETOrdersQuerySchema.safeParse({
+        overdue: "true",
+        status: "ready_for_pickup",
+      }).success
+    ).toBe(true);
+  });
+
+  it("leaves each filter alone on its own", () => {
+    expect(GETOrdersQuerySchema.safeParse({ overdue: "true" }).success).toBe(
+      true
+    );
+    expect(
+      GETOrdersQuerySchema.safeParse({ status: "cancelled" }).success
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/modules/orders/order.schema.ts
+++ b/packages/server/src/modules/orders/order.schema.ts
@@ -37,6 +37,18 @@ export const GETOrdersQuerySchema = z
       path: ["date_from"],
     }
   )
+  // overdue already pins status to ready_for_pickup, so pairing it with any
+  // other status asks for orders that cannot exist. Answering that with an empty
+  // list would read as "nothing on the shelf is late" — the one thing the caller
+  // must not conclude from a query the shelf never got asked.
+  .refine(
+    (query) =>
+      !(query.overdue && query.status) || query.status === "ready_for_pickup",
+    {
+      error: "overdue only applies to status=ready_for_pickup",
+      path: ["overdue"],
+    }
+  )
   .optional();
 
 export type GetOrdersQuery = z.infer<typeof GETOrdersQuerySchema>;

--- a/packages/server/src/modules/orders/order.schema.ts
+++ b/packages/server/src/modules/orders/order.schema.ts
@@ -15,9 +15,7 @@ export const GETOrdersQuerySchema = z
     status: z.enum(orderStatusEnum.enumValues).optional(),
     payment_status: z.enum(orderPaymentStatusEnum.enumValues).optional(),
 
-    // Finished work nobody has collected. Not a status of its own — it is
-    // ready_for_pickup that has aged past the shelf window, and the counter
-    // needs it as one click because chasing those customers is the job.
+    // Not a status of its own: ready_for_pickup aged past the shelf window.
     overdue: z.stringbool().optional(),
 
     customer_id: z.coerce.number().int().positive().optional(),
@@ -44,9 +42,8 @@ export const GETOrdersQuerySchema = z
 export type GetOrdersQuery = z.infer<typeof GETOrdersQuerySchema>;
 type ParsedOrdersQuery = NonNullable<GetOrdersQuery>;
 
-// The counts behind the list's filter pills. Only the branch narrows them: a
-// pill set that also honoured the active status or date would count what is
-// already on screen, and the point of the row is what you are not looking at.
+// Branch-scoped only, deliberately: a pill set that honoured the active status
+// or date would count what is already on screen.
 export const GETOrderCountsQuerySchema = z
   .object({
     store_id: z.coerce.number().int().positive().optional(),
@@ -72,8 +69,6 @@ export interface NormalizedOrderListQuery {
   store_id?: number;
 }
 
-// Everything that narrows which orders match, with nothing about which page of
-// them to return — what a count needs and a list needs the rest of.
 export type OrderListFilters = Omit<
   NormalizedOrderListQuery,
   "limit" | "offset" | "sort_by" | "sort_order"

--- a/packages/server/src/modules/orders/order.schema.ts
+++ b/packages/server/src/modules/orders/order.schema.ts
@@ -15,6 +15,11 @@ export const GETOrdersQuerySchema = z
     status: z.enum(orderStatusEnum.enumValues).optional(),
     payment_status: z.enum(orderPaymentStatusEnum.enumValues).optional(),
 
+    // Finished work nobody has collected. Not a status of its own — it is
+    // ready_for_pickup that has aged past the shelf window, and the counter
+    // needs it as one click because chasing those customers is the job.
+    overdue: z.stringbool().optional(),
+
     customer_id: z.coerce.number().int().positive().optional(),
     store_id: z.coerce.number().int().positive().optional(),
     created_by: z.coerce.number().int().positive().optional(),
@@ -39,6 +44,17 @@ export const GETOrdersQuerySchema = z
 export type GetOrdersQuery = z.infer<typeof GETOrdersQuerySchema>;
 type ParsedOrdersQuery = NonNullable<GetOrdersQuery>;
 
+// The counts behind the list's filter pills. Only the branch narrows them: a
+// pill set that also honoured the active status or date would count what is
+// already on screen, and the point of the row is what you are not looking at.
+export const GETOrderCountsQuerySchema = z
+  .object({
+    store_id: z.coerce.number().int().positive().optional(),
+  })
+  .optional();
+
+export type GetOrderCountsQuery = z.infer<typeof GETOrderCountsQuerySchema>;
+
 export interface NormalizedOrderListQuery {
   created_by?: number;
   customer_id?: number;
@@ -46,6 +62,7 @@ export interface NormalizedOrderListQuery {
   date_to?: string;
   limit: number;
   offset: number;
+  overdue?: boolean;
   payment_method_id?: number;
   payment_status?: ParsedOrdersQuery["payment_status"];
   search?: string;
@@ -54,6 +71,13 @@ export interface NormalizedOrderListQuery {
   status?: ParsedOrdersQuery["status"];
   store_id?: number;
 }
+
+// Everything that narrows which orders match, with nothing about which page of
+// them to return — what a count needs and a list needs the rest of.
+export type OrderListFilters = Omit<
+  NormalizedOrderListQuery,
+  "limit" | "offset" | "sort_by" | "sort_order"
+>;
 
 export function normalizeOrderListQuery(
   query?: GetOrdersQuery
@@ -69,6 +93,7 @@ export function normalizeOrderListQuery(
     search: query?.search,
     status: query?.status,
     payment_status: query?.payment_status,
+    overdue: query?.overdue,
     customer_id: query?.customer_id,
     store_id: query?.store_id,
     created_by: query?.created_by,

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -6,6 +6,7 @@ import { BadRequestException, NotFoundException } from "@/http-exceptions";
 import { claimRedemptions } from "@/modules/campaigns/campaign-redemption.service";
 import { resolveOrCreateCustomer } from "@/modules/customers/customer.service";
 import {
+  countOrders,
   findOrders,
   insertOrder,
   insertOrderProducts,
@@ -14,6 +15,7 @@ import {
   reserveNextOrderNumber,
 } from "@/modules/orders/order.repository";
 import {
+  type GetOrderCountsQuery,
   type GetOrdersQuery,
   normalizeOrderListQuery,
 } from "@/modules/orders/order.schema";
@@ -172,38 +174,69 @@ function buildOrderServiceRows({
   }));
 }
 
+// Which branches this account may be shown, as the repository wants it:
+// undefined means "do not narrow further", [] means nothing at all.
+async function resolveOrderScopedStoreIds(user: JWTPayload, storeId?: number) {
+  const scope = await resolveStoreScope(user, storeId);
+
+  switch (scope.kind) {
+    // A cashier browsing "all orders" still only sees the branches they work
+    // at — an open list would leak every branch's takings to any staff.
+    case "some":
+      return scope.storeIds;
+    // A staff account not yet assigned to a branch: nothing, not everything.
+    case "none":
+      return [];
+    // An admin browses every branch, and a named branch is already the
+    // store_id filter the query carries.
+    case "all":
+    case "one":
+      return;
+    default:
+      return unhandledStoreScope(scope);
+  }
+}
+
 export async function listOrders(query?: GetOrdersQuery, user?: JWTPayload) {
   const normalized = normalizeOrderListQuery(query);
-  let scopedStoreIds: number[] | undefined;
-
-  if (user) {
-    const scope = await resolveStoreScope(user, normalized.store_id);
-
-    switch (scope.kind) {
-      // A cashier browsing "all orders" still only sees the branches they work
-      // at — an open list would leak every branch's takings to any staff.
-      case "some":
-        scopedStoreIds = scope.storeIds;
-        break;
-      // A staff account not yet assigned to a branch: nothing, not everything.
-      case "none":
-        scopedStoreIds = [];
-        break;
-      // An admin browses every branch, and a named branch is already the
-      // store_id filter the query carries.
-      case "all":
-      case "one":
-        break;
-      default:
-        return unhandledStoreScope(scope);
-    }
-  }
+  const scopedStoreIds = user
+    ? await resolveOrderScopedStoreIds(user, normalized.store_id)
+    : undefined;
 
   const { items, total } = await findOrders(normalized, scopedStoreIds);
 
   return {
     items,
     meta: buildPaginationMeta(total, normalized),
+  };
+}
+
+// The list's triage row: how many orders sit behind each pill, before anyone
+// touches a control. Every count runs the list's own predicate, so a pill
+// reading 3 opens a page whose total is 3.
+export async function getOrderListCounts(
+  query: GetOrderCountsQuery,
+  user: JWTPayload
+) {
+  const storeId = query?.store_id;
+  const scopedStoreIds = await resolveOrderScopedStoreIds(user, storeId);
+  const base = { store_id: storeId };
+  const today = jakartaNow().format("YYYY-MM-DD");
+
+  const [all, todayTotal, unpaid, readyForPickup, overdue] = await Promise.all([
+    countOrders(base, scopedStoreIds),
+    countOrders({ ...base, date_from: today, date_to: today }, scopedStoreIds),
+    countOrders({ ...base, payment_status: "unpaid" }, scopedStoreIds),
+    countOrders({ ...base, status: "ready_for_pickup" }, scopedStoreIds),
+    countOrders({ ...base, overdue: true }, scopedStoreIds),
+  ]);
+
+  return {
+    all,
+    today: todayTotal,
+    unpaid,
+    ready_for_pickup: readyForPickup,
+    overdue,
   };
 }
 

--- a/packages/server/src/modules/orders/order.service.ts
+++ b/packages/server/src/modules/orders/order.service.ts
@@ -174,21 +174,16 @@ function buildOrderServiceRows({
   }));
 }
 
-// Which branches this account may be shown, as the repository wants it:
-// undefined means "do not narrow further", [] means nothing at all.
+// As the repository wants it: undefined means "do not narrow further", [] means
+// nothing at all. Confusing the two shows one account every branch's orders.
 async function resolveOrderScopedStoreIds(user: JWTPayload, storeId?: number) {
   const scope = await resolveStoreScope(user, storeId);
 
   switch (scope.kind) {
-    // A cashier browsing "all orders" still only sees the branches they work
-    // at — an open list would leak every branch's takings to any staff.
     case "some":
       return scope.storeIds;
-    // A staff account not yet assigned to a branch: nothing, not everything.
     case "none":
       return [];
-    // An admin browses every branch, and a named branch is already the
-    // store_id filter the query carries.
     case "all":
     case "one":
       return;
@@ -211,9 +206,6 @@ export async function listOrders(query?: GetOrdersQuery, user?: JWTPayload) {
   };
 }
 
-// The list's triage row: how many orders sit behind each pill, before anyone
-// touches a control. Every count runs the list's own predicate, so a pill
-// reading 3 opens a page whose total is 3.
 export async function getOrderListCounts(
   query: GetOrderCountsQuery,
   user: JWTPayload

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -116,8 +116,7 @@ const app = new Hono<OrderAccessEnv>()
 
     return c.json(success(items, undefined, meta));
   })
-  // Ahead of /:id, like /services/queue: "counts" is not an order number, and
-  // the router matches on registration order.
+  // Must stay ahead of /:id — the router matches on registration order.
   .get(
     "/counts",
     zodValidator("query", GETOrderCountsQuerySchema),

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -17,6 +17,7 @@ import {
   GETMyOrderServicesQuerySchema,
   GETOrderByItemCodeQuerySchema,
   GETOrderServiceByIdQuerySchema,
+  GETOrderServiceQueueCountsQuerySchema,
   GETOrderServiceQueueQuerySchema,
   orderServiceParamSchema,
   orderServicePhotoParamSchema,
@@ -53,6 +54,7 @@ import {
   getOrderServiceById,
   getOrderServiceByItemCode,
   getOrderServiceQueue,
+  getOrderServiceQueueCounts,
   startOrderServiceWork,
   updateOrderServiceHandler,
   updateOrderServiceStatus,
@@ -136,6 +138,16 @@ const app = new Hono<OrderAccessEnv>()
       const { items, meta } = await getOrderServiceQueue(user, query);
 
       return c.json(success(items, "Queue retrieved successfully", meta));
+    }
+  )
+  .get(
+    "/services/queue/counts",
+    zodValidator("query", GETOrderServiceQueueCountsQuerySchema),
+    async (c) => {
+      const user = c.get("jwtPayload");
+      const query = c.req.valid("query");
+
+      return c.json(success(await getOrderServiceQueueCounts(user, query)));
     }
   )
   .get(

--- a/packages/server/src/routes/admin/orders.ts
+++ b/packages/server/src/routes/admin/orders.ts
@@ -3,10 +3,14 @@ import { createMiddleware } from "hono/factory";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
 import { NotFoundException } from "@/http-exceptions";
-import { GETOrdersQuerySchema } from "@/modules/orders/order.schema";
+import {
+  GETOrderCountsQuerySchema,
+  GETOrdersQuerySchema,
+} from "@/modules/orders/order.schema";
 import {
   createOrder,
   getOrderDetailById,
+  getOrderListCounts,
   listOrders,
 } from "@/modules/orders/order.service";
 import {
@@ -110,6 +114,18 @@ const app = new Hono<OrderAccessEnv>()
 
     return c.json(success(items, undefined, meta));
   })
+  // Ahead of /:id, like /services/queue: "counts" is not an order number, and
+  // the router matches on registration order.
+  .get(
+    "/counts",
+    zodValidator("query", GETOrderCountsQuerySchema),
+    async (c) => {
+      const query = c.req.valid("query");
+      const user = c.get("jwtPayload");
+
+      return c.json(success(await getOrderListCounts(query, user)));
+    }
+  )
   .get(
     "/services/queue",
     zodValidator("query", GETOrderServiceQueueQuerySchema),

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -67,6 +67,10 @@ export type CampaignEligibilityContext = _CampaignEligibilityContext;
 export type CampaignEligibilityInput = _CampaignEligibilityInput;
 export const campaignIneligibilityReason = _campaignIneligibilityReason;
 
+import { PICKUP_OVERDUE_HOURS as _PICKUP_OVERDUE_HOURS } from "@/schema/turnaround";
+
+export const PICKUP_OVERDUE_HOURS = _PICKUP_OVERDUE_HOURS;
+
 import {
   hasUnpricedLine as _hasUnpricedLine,
   isUnpricedLine as _isUnpricedLine,

--- a/packages/server/src/schema/turnaround.ts
+++ b/packages/server/src/schema/turnaround.ts
@@ -1,0 +1,6 @@
+// The turnaround the shop promises the customer at drop-off. Two screens judge
+// an Item late against it — /orders counts it into the Overdue pill, /queue
+// paints the row red — and they are describing the same shelf, so they read the
+// same number. Held here rather than in either one: a second copy is how the
+// counter and the workshop end up disagreeing about which Items are late.
+export const PICKUP_OVERDUE_HOURS = 72;


### PR DESCRIPTION
Closes the twelve items in the 2026-08-10 UI audit — six bugs (B1–B6) and six layout/usability items (LU1–LU6). Every screen below was checked in a real browser at **390 / 1024 / 1440** as the seeded admin.

**Do not automerge** — this is here to be looked at.

---

## What to look at, screen by screen

### `/queue` — was `/worker`
The route is renamed, because "worker" named the person and the page is a list of work.

| Before | After |
| --- | --- |
| Item code in the heading slot, service + descriptors in two dim lines under it | Descriptors lead (`Puma · Urban · cyan · 41`), service + handler on line two, code demoted to a mono tail |
| Four age tones — neutral / info at 2h / warning at 24h / red at 72h | One threshold at 72h, matching `PICKUP_OVERDUE_HOURS` |
| Six status chips sliced at the viewport edge | Chips scroll, last one fades out |

The four-tone ramp was the main thing worth killing: a real backlog is days old, so the whole list came out red and the colour stopped carrying information. A `2d` row now reads neutral and only a genuine breach is red.

**Also fixed here:** a horizontal overflow at 390 that was invisible. The row's `min-content` propagated up two nested grids, sized the shared `auto` column at 447px inside a 366px parent, and pushed the search field and the status chips off screen — while `overflow-x-clip` on the section kept `document.scrollWidth` at 390 and hid the symptom. `min-w-0` at every level down to the truncating text.

### POS `/transactions`
**The catalog is reverted to `main`.** The densified version — category pill strip, two columns from the smallest breakpoint, `min-h-16` cards, in-cart count badge — made the tile the cashier taps smaller and noisier than what it replaced. One change kept on top: the `Search` label goes `sr-only` (the placeholder already says it), which lifts the first service card from ~455px down to ~305px on a phone.

The **cart rail** from that same commit stays: at ≥1280 the cart stands in its own column instead of hiding behind a bottom bar. Below 1280 the mini bar remains, now on its own opaque surface so it stops bleeding into the catalog behind it (B4).

**Category pills** (not in the audit — asked for separately). 43 services in one flat list is a scroll, not a choice; `Repair` alone is 16 of them. A scrolling pill strip under the search field narrows it in one tap. Counts are taken off the whole catalog, never the search-narrowed list, so typing cannot drop the pill you are filtering by. Hidden for a mode with only one category — every add-on is a `Retail Product`, and a strip that only ever says `All 12` is noise.

The store already held `activeServiceCategory` and the catalog already filtered on it. Nothing drove it, so it sat on `all` forever. This adds the missing control, not new state.

**Removing a cart line** (also asked for separately). It previously required opening the checkout, keying a customer name and phone, and reaching step two — the only place lines were listed. The list now lives on the page: always visible in the rail at `xl`, and behind a closed `CART` disclosure on a phone so it costs one row until it is needed. `CartLines` is shared by both surfaces and reads the cart itself rather than taking rows as props, so they cannot show different lines or remove them differently.

### Checkout
The sheet stays a **full-width bottom sheet at every width**, unchanged from `main`. An earlier pass made it a right-side drawer above 1280; that capped it at `max-w-sm`, folded each item row's descriptor fields back to one column, and cramped the three-step header. The Items step is the widest thing in the app and it needs the window.

- Locked steps now say what unlocks them — *"Items and Payment unlock once you enter the customer name and phone."* They use `aria-disabled`, not `disabled`, so a keyboard user can still land on the step and hear the reason (B5).
- Each intake item collapses to one row with the descriptor fields behind a `<details>`; the **drop-off photo gate moved above** the items, since it blocks the step (B6/LU6).
- Item names **wrap** instead of truncating. Collapsing the row left the name ~130px next to the mono price column, so every line read `Deep Clea…` — the one string that says which Item this is. The category came off the row too: the cashier just tapped a card labelled with it.

### Orders `/orders`
- The counts **are** the filters now. Five pills — All / Today / Unpaid / Ready / Overdue — each showing a live count, backed by a new `/api/admin/orders/counts` endpoint. Overdue turns red when it is non-zero and not selected.
- **The status and payment dropdowns are gone.** Deliberate, and the trade-off is real: you can no longer filter by `processing`, `completed`, `cancelled`, or by `paid`. The pills cover the questions the counter actually asks at the counter.
- Item descriptors appear under the customer name (`Red`, `Navy`, `Grey`), so a row says which Item it is without opening it.
- At 1024–1279 the sidebar collapses to icons so the table gets the width (B3), and the table no longer sits inside its own scroll container — the page scrolls as one document, so the last rows are reachable (B2).

### Order detail
**Layout is unchanged from `main` — one column.** An earlier pass split it into Services plus a 24rem Payment/Attachments rail at `xl`; that is reverted.

What LU5 keeps: `Print` is surfaced as its own button in the header instead of hiding in the overflow menu, and `Refund order` moved into the Payment card beside the money it acts on.

### `/queue` with no store selected
A disabled TanStack Query stays `pending` forever, so four skeletons pulsed under the "Select a store." empty state indefinitely. Gated on `isLoading` instead (B1).

---

## Server changes

- `GET /api/admin/orders/counts` — five counts for the pill row, reusing `buildOrderWhere` so a pill's number always equals the total of the page it opens.
- `countOrders` counts id-only rows rather than using `db.$count()`, which cannot take the relational builder's object `where`.
- The queue endpoint is branch-scoped and takes a status filter; `/counts` is registered ahead of `/:id` because Hono matches in registration order.

---

## Two things to decide

1. **72h turnaround.** The new single threshold assumes the shop promises 72 hours, taken from `PICKUP_OVERDUE_HOURS`. If the real promise is different, it is one constant.
2. **Age is order age, not time-in-status.** `orders_services` carries no timestamps at all — no `created_at`, no status-change time — so the only age a queue row can show is the *order's*. Making this "3 days in Quality Check" needs a schema change.

Also worth knowing: a non-admin user with no store assigned sees an empty `/queue`. Pre-existing, not touched here.

---

## Checks

- `bun x ultracite check` — clean, 391 files
- `bun run type-check` — 3 successful, 3 total
- Browser-verified at 390 / 1024 / 1440: Orders list, order detail, POS catalog, cart rail, checkout steps 1–2, `/queue` with and without a store

## Three things reverted to `main` after review

Layout changes that landed in earlier commits on this branch and were then rolled back, so the diff is smaller than the commit count suggests:

1. **POS catalog** — the densified grid. Reverted; only the `sr-only` search label is kept.
2. **Checkout sheet** — the right-side drawer above 1280. Reverted to bottom at every width.
3. **Order detail** — the two-column `xl` split. Reverted to one column.
